### PR TITLE
collection, mutable (9): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -51,6 +51,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     with Serializable {
 
   import AnyRefMap._
+  /** Creates a new empty `AnyRefMap` whose `apply` throws `NoSuchElementException` for missing keys. */
   def this() = this(AnyRefMap.exceptionDefault, 16, initBlank = true)
 
   /** Creates a new `AnyRefMap` that returns default values according to a supplied key-value mapping.
@@ -99,6 +100,13 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
   }
 
+  /** Builds a new `AnyRefMap` containing the key/value pairs of the given collection.
+   *
+   *  If several pairs share a key, the last one wins.
+   *
+   *  @param coll the key/value pairs to build the map from
+   *  @return a new `AnyRefMap` containing the pairs of `coll`
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(K, V)]^): AnyRefMap[K,V] = {
     var sz = coll.knownSize
     if(sz < 0) sz = 4
@@ -107,11 +115,16 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
+  /** Returns a new empty builder producing an `AnyRefMap` of the same key and value types. */
   override protected def newSpecificBuilder: Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
 
+  /** Returns the number of key/value pairs in this map. */
   override def size: Int = _size
+  /** Returns `size`; the number of key/value pairs is always known. */
   override def knownSize: Int = size
+  /** Returns `true` if this map contains no key/value pairs. */
   override def isEmpty: Boolean = _size == 0
+  /** Returns a new empty `AnyRefMap` with the same default-value function as this map. */
   override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)
 
   private def imbalanced: Boolean =
@@ -157,18 +170,45 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     if (o >= 0) o | MissVacant else e | MissingBit
   }
 
+  /** Tests whether a key is present in this map.
+   *
+   *  @param key the key to look up; may be `null`
+   *  @return `true` if `key` has an associated value, `false` otherwise
+   */
   override def contains(key: K): Boolean = seekEntry(hashOf(key), key) >= 0
 
+  /** Optionally returns the value associated with a key.
+   *
+   *  @param key the key to look up
+   *  @return `Some` of the value associated with `key`, or `None` if `key` is not present
+   */
   override def get(key: K): Option[V] = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) None else Some(_values(i).asInstanceOf[V])
   }
 
+  /** Returns the value associated with a key, or a computed alternative if the key is not present.
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the alternative result; evaluated only if `key` is not present
+   *  @return the value associated with `key`, or `default` if `key` is not present
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) default else _values(i).asInstanceOf[V]
   }
 
+  /** Returns the value associated with a key, computing and storing a value if the key is not present.
+   *
+   *  If `key` is not present, evaluates `defaultValue`, adds the resulting entry to
+   *  this map, and returns the result. `defaultValue` may itself query or modify this
+   *  map; the entry for `key` is added after it completes.
+   *
+   *  @param key the key to look up
+   *  @param defaultValue the value to store and return if `key` is not present; evaluated at most once
+   *  @return the value associated with `key`, either pre-existing or newly stored
+   */
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     val h = hashOf(key)
     var i = seekEntryOrOpen(h, key)
@@ -276,6 +316,12 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     repack(m)
   }
 
+  /** Adds a key/value pair to this map, returning any value previously associated with the key.
+   *
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   *  @return `Some` of the value previously associated with `key`, or `None` if `key` was not present
+   */
   override def put(key: K, value: V): Option[V] = {
     val h = hashOf(key)
     val i = seekEntryOrOpen(h, key)
@@ -334,8 +380,22 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    */
   @inline final def addOne(key: K, value: V): this.type = { update(key, value); this }
 
+  /** Adds a key/value pair to this map and returns the map.
+   *
+   *  @param kv the key/value pair to add; any existing value for the same key is overwritten
+   *  @return this map after the entry has been added
+   */
   @inline override final def addOne(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
 
+  /** Removes a key from this map, and returns the map.
+   *
+   *  If `key` is present, its entry is removed and its slot is marked vacant;
+   *  vacant slots are reclaimed on a later `repack`. Does nothing if `key` is
+   *  not present.
+   *
+   *  @param key the key to remove
+   *  @return this map after the removal
+   */
   def subtractOne(key: K): this.type = {
     val i = seekEntry(hashOf(key), key)
     if (i >= 0) {
@@ -348,12 +408,15 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     this
   }
 
+  /** Returns an iterator over the key/value pairs of this map. */
   def iterator: Iterator[(K, V)] = new AnyRefMapIterator[(K, V)] {
     protected def nextResult(k: K, v: V) = (k, v)
   }
+  /** Returns an iterator over the keys of this map. */
   override def keysIterator: Iterator[K] = new AnyRefMapIterator[K] {
     protected def nextResult(k: K, v: V) = k
   }
+  /** Returns an iterator over the values of this map. */
   override def valuesIterator: Iterator[V] = new AnyRefMapIterator[V] {
     protected def nextResult(k: K, v: V) = v
   }
@@ -388,6 +451,11 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
   }
 
 
+  /** Applies a function to each key/value pair of this map.
+   *
+   *  @tparam U the result type of the function; the results are discarded
+   *  @param f the function to apply to each key/value pair
+   */
   override def foreach[U](f: ((K,V)) => U): Unit = {
     var i = 0
     var e = _size
@@ -402,6 +470,13 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     }
   }
 
+  /** Applies a function to each key/value pair of this map, passing key and value as separate arguments.
+   *
+   *  Unlike `foreach`, does not allocate a tuple per entry.
+   *
+   *  @tparam U the result type of the function; the results are discarded
+   *  @param f the function to apply to each key and value
+   */
   override def foreachEntry[U](f: (K,V) => U): Unit = {
     var i = 0
     var e = _size
@@ -416,6 +491,10 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     }
   }
 
+  /** Returns a copy of this map with the same entries, default-value function, and internal layout.
+   *
+   *  Later changes to the copy do not affect this map, and vice versa.
+   */
   override def clone(): AnyRefMap[K, V] = {
     val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)
@@ -425,9 +504,28 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     arm
   }
 
+  /** Returns a new `AnyRefMap` containing the entries of this map and one additional key/value pair.
+   *
+   *  This map is not modified.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param kv the key/value pair to add; it overrides any entry of this map with the same key
+   *  @return a new `AnyRefMap` with the entries of this map plus `kv`
+   */
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def + [V1 >: V](kv: (K, V1)): AnyRefMap[K, V1] = AnyRefMap.from(new View.Appended(this, kv))
 
+  /** Returns a new `AnyRefMap` containing the entries of this map and two or more additional key/value pairs.
+   *
+   *  This map is not modified. When keys coincide, later pairs override earlier
+   *  ones and entries of this map.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param elem1 the first key/value pair to add
+   *  @param elem2 the second key/value pair to add
+   *  @param elems the remaining key/value pairs to add, if any
+   *  @return a new `AnyRefMap` with the entries of this map plus all the given pairs
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): AnyRefMap[K, V1]^{} = {
     // An empty capture annotation is needed in the result type to satisfy the overriding checker.
@@ -435,14 +533,40 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     if(elems.isEmpty) m else m.concat(elems)
   }
 
+  /** Returns a new `AnyRefMap` containing the entries of this map together with those of another collection.
+   *
+   *  This map is not modified. When keys coincide, pairs of `xs` override
+   *  entries of this map, and later pairs of `xs` override earlier ones.
+   *
+   *  @tparam V2 the value type of the resulting map, a supertype of this map's value type
+   *  @param xs the key/value pairs to add
+   *  @return a new `AnyRefMap` with the entries of this map and of `xs`
+   */
   override def concat[V2 >: V](xs: scala.collection.IterableOnce[(K, V2)]^): AnyRefMap[K, V2] = {
     val arm = clone().asInstanceOf[AnyRefMap[K, V2]]
     xs.iterator.foreach(kv => arm += kv)
     arm
   }
 
+  /** Returns a new `AnyRefMap` containing the entries of this map together with those of another collection.
+   *
+   *  Alias for `concat`; this map is not modified.
+   *
+   *  @tparam V2 the value type of the resulting map, a supertype of this map's value type
+   *  @param xs the key/value pairs to add
+   *  @return a new `AnyRefMap` with the entries of this map and of `xs`
+   */
   override def ++[V2 >: V](xs: scala.collection.IterableOnce[(K, V2)]^): AnyRefMap[K, V2] = concat(xs)
 
+  /** Returns a copy of this map with one key/value pair added or replaced.
+   *
+   *  This map is not modified.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   *  @return a clone of this map with `key` mapped to `value`
+   */
   @deprecated("Use m.clone().addOne(k,v) instead of m.updated(k, v)", "2.13.0")
   override def updated[V1 >: V](key: K, value: V1): AnyRefMap[K, V1] =
     clone().asInstanceOf[AnyRefMap[K, V1]].addOne(key, value)
@@ -557,6 +681,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     strictOptimizedCollect(AnyRefMap.newBuilder[K2, V2], pf)
 
+  /** Removes all entries from this map, keeping the internal buffer at its current size. */
   override def clear(): Unit = {
     import java.util.Arrays.fill
     fill(_keys, null)
@@ -566,8 +691,10 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
     _vacant = 0
   }
 
+  /** Returns a serialization proxy that rebuilds this map on deserialization; called by Java serialization. */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(AnyRefMap.toFactory[K, V](AnyRefMap), this)
 
+  /** Returns `"AnyRefMap"`, the prefix used in this map's string representation. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "AnyRefMap"
 }
@@ -593,12 +720,20 @@ object AnyRefMap {
    */
   final class AnyRefMapBuilder[K <: AnyRef, V] extends ReusableBuilder[(K, V), AnyRefMap[K, V]] {
     private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
+    /** Adds a key/value pair to the map under construction.
+     *
+     *  @param entry the key/value pair to add; any existing value for the same key is overwritten
+     *  @return this builder
+     */
     def addOne(entry: (K, V)): this.type = {
       elems += entry
       this
     }
+    /** Resets this builder by starting a fresh, empty map; previously returned maps are unaffected. */
     def clear(): Unit = elems = new AnyRefMap[K, V]
+    /** Returns the map under construction. The map is returned directly, not copied, so additions made before the next `clear` also appear in the returned map. */
     def result(): AnyRefMap[K, V] = elems
+    /** Returns the number of entries added since the last `clear`. */
     override def knownSize: Int = elems.knownSize
   }
 
@@ -611,6 +746,12 @@ object AnyRefMap {
    */
   def apply[K <: AnyRef, V](elems: (K, V)*): AnyRefMap[K, V] = buildFromIterableOnce(elems)
 
+  /** Creates a new empty builder for an `AnyRefMap`.
+   *
+   *  @tparam K the type of keys, must be a subtype of `AnyRef`
+   *  @tparam V the type of values
+   *  @return a new reusable builder producing an `AnyRefMap`
+   */
   def newBuilder[K <: AnyRef, V]: ReusableBuilder[(K, V), AnyRefMap[K, V]] = new AnyRefMapBuilder[K, V]
 
   private def buildFromIterableOnce[K <: AnyRef, V](elems: IterableOnce[(K, V)]^): AnyRefMap[K, V] = {
@@ -689,6 +830,14 @@ object AnyRefMap {
     arm
   }
 
+  /** Implicitly converts this companion object to a `Factory`, so it can be passed
+   *  where a factory of `AnyRefMap`s is expected, for example to `to(AnyRefMap)`.
+   *
+   *  @tparam K the type of keys, must be a subtype of `AnyRef`
+   *  @tparam V the type of values
+   *  @param dummy this companion object; its value is never used
+   *  @return a `Factory` that builds an `AnyRefMap` from key/value pairs
+   */
   implicit def toFactory[K <: AnyRef, V](dummy: AnyRefMap.type): Factory[(K, V), AnyRefMap[K, V]] = ToFactory.asInstanceOf[Factory[(K, V), AnyRefMap[K, V]]]
 
   @SerialVersionUID(3L)
@@ -697,13 +846,33 @@ object AnyRefMap {
     def newBuilder: Builder[(AnyRef, AnyRef), AnyRefMap[AnyRef, AnyRef]] = AnyRefMap.newBuilder[AnyRef, AnyRef]
   }
 
+  /** Implicitly converts this companion object to a `BuildFrom`, so it can be passed
+   *  where a `BuildFrom` producing `AnyRefMap`s is expected.
+   *
+   *  @tparam K the type of keys, must be a subtype of `AnyRef`
+   *  @tparam V the type of values
+   *  @param factory this companion object; its value is never used
+   *  @return a `BuildFrom` that builds an `AnyRefMap` from key/value pairs, ignoring the source collection
+   */
   implicit def toBuildFrom[K <: AnyRef, V](factory: AnyRefMap.type): BuildFrom[Any, (K, V), AnyRefMap[K, V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (K, V), AnyRefMap[K, V]]]
   private object ToBuildFrom extends BuildFrom[Any, (AnyRef, AnyRef), AnyRefMap[AnyRef, AnyRef]] {
     def fromSpecific(from: Any)(it: IterableOnce[(AnyRef, AnyRef)]^): AnyRefMap[AnyRef, AnyRef] = AnyRefMap.from(it)
     def newBuilder(from: Any): ReusableBuilder[(AnyRef, AnyRef), AnyRefMap[AnyRef, AnyRef]] = AnyRefMap.newBuilder[AnyRef, AnyRef]
   }
 
+  /** An implicit `Factory` for `AnyRefMap`s, for APIs that look one up implicitly.
+   *
+   *  @tparam K the type of keys, must be a subtype of `AnyRef`
+   *  @tparam V the type of values
+   *  @return a `Factory` that builds an `AnyRefMap` from key/value pairs
+   */
   implicit def iterableFactory[K <: AnyRef, V]: Factory[(K, V), AnyRefMap[K, V]] = toFactory[K, V](this)
+  /** An implicit `BuildFrom` that builds an `AnyRefMap` when the source collection is an `AnyRefMap`.
+   *
+   *  @tparam K the type of keys of the resulting map, must be a subtype of `AnyRef`
+   *  @tparam V the type of values of the resulting map
+   *  @return a `BuildFrom` that builds an `AnyRefMap` from key/value pairs
+   */
   implicit def buildFromAnyRefMap[K <: AnyRef, V]: BuildFrom[AnyRefMap[?, ?], (K, V), AnyRefMap[K, V]] = toBuildFrom(this)
 }
 

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -48,21 +48,49 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     with IterableFactoryDefaults[A, ArrayBuffer]
     with DefaultSerializable {
 
+  /** Creates an empty array buffer whose backing array has the default initial
+   *  capacity of `ArrayBuffer.DefaultInitialSize` (16) elements.
+   */
   def this() = this(new Array[AnyRef](ArrayBuffer.DefaultInitialSize), 0)
 
+  /** Creates an empty array buffer with the given initial capacity.
+   *
+   *  @param initialSize the initial capacity of the backing array, not the size
+   *                     of the buffer, which starts empty; values less than 1
+   *                     are treated as 1
+   */
   def this(initialSize: Int) = this(new Array[AnyRef](initialSize max 1), 0)
 
   @transient private var mutationCount: Int = 0
 
   // needs to be `private[collection]` or `protected[collection]` for parallel-collections
+  /** The backing array, holding the buffer's elements at indices `0` until
+   *  `size0`, erased to `AnyRef`. The remaining slots are unused and `null`.
+   */
   protected[collection] var array: Array[AnyRef] = initialElements
+  /** The number of elements in this buffer. */
   protected var size0 = initialSize
 
+  /** Returns a stepper for the elements of this buffer, which enables creating
+   *  a Java stream over them (see [[scala.jdk.StreamConverters]]).
+   *
+   *  The stepper reads the backing array directly and performs no mutation
+   *  checking.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape the stepper shape corresponding to the element type
+   *  @return a stepper, additionally marked `EfficientSplit` as it splits
+   *          efficiently for parallel processing
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     shape.parUnbox(new ObjectArrayStepper(array, 0, length).asInstanceOf[AnyStepper[A] & EfficientSplit])
   }
 
+  /** The number of elements in this $coll. Never `-1`, as the size is always known.
+   *
+   *  Overridden to select `IndexedSeqOps`' implementation, which returns `length`.
+   */
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
   /** Ensures that the internal array has at least `n` cells.
@@ -112,22 +140,42 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     if (hi > size0) throw CommonErrors.indexOutOfBounds(index = hi - 1, max = size0 - 1)
   }
 
+  /** Returns the element of this buffer at index `n`, in constant time.
+   *
+   *  @param n the index of the element to return
+   *  @return the element at index `n`
+   *  @throws IndexOutOfBoundsException if `n < 0` or `n >= length`
+   */
   def apply(n: Int): A = {
     checkWithinBounds(n, n + 1)
     array(n).asInstanceOf[A]
   }
 
+  /** Replaces the element at index `index` with `elem`, in constant time.
+   *
+   *  @param index the index of the element to replace
+   *  @param elem the new element
+   *  @throws IndexOutOfBoundsException if `index < 0` or `index >= length`
+   */
   def update(@deprecatedName("n", "2.13.0") index: Int, elem: A): Unit = {
     checkWithinBounds(index, index + 1)
     mutationCount += 1
     array(index) = elem.asInstanceOf[AnyRef]
   }
 
+  /** Returns the number of elements in this buffer. */
   def length = size0
 
   // TODO: return `IndexedSeqView` rather than `ArrayBufferView`
+  /** Returns a view over the elements of this buffer.
+   *
+   *  Iterators obtained from the view, directly or through further view
+   *  transformations, throw a [[java.util.ConcurrentModificationException]]
+   *  when this buffer is mutated after their creation.
+   */
   override def view: ArrayBufferView[A] = new ArrayBufferView(this, () => mutationCount)
 
+  /** The companion object `ArrayBuffer`, used by transformation methods to build new array buffers. */
   override def iterableFactory: SeqFactory[ArrayBuffer] = ArrayBuffer
 
   /** Note: This does not actually resize the internal representation.
@@ -146,6 +194,15 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this
   }
 
+  /** Appends `elem` to this buffer.
+   *
+   *  Takes amortized constant time: when the backing array is full, it is
+   *  replaced by one at least twice as large (until the VM's maximum array
+   *  size is reached).
+   *
+   *  @param elem the element to append
+   *  @return this $coll
+   */
   def addOne(elem: A): this.type = {
     mutationCount += 1
     val newSize = size0 + 1
@@ -156,6 +213,14 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   }
 
   // Overridden to use array copying for efficiency where possible.
+  /** Appends all elements of `elems` to this buffer.
+   *
+   *  When `elems` is itself an `ArrayBuffer`, its elements are copied in bulk
+   *  with a single array copy. `elems` may be this buffer itself.
+   *
+   *  @param elems the collection containing the elements to append
+   *  @return this $coll
+   */
   override def addAll(elems: IterableOnce[A]^): this.type = {
     elems match {
       case elems: ArrayBuffer[?] =>
@@ -171,6 +236,17 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this
   }
 
+  /** Inserts `elem` at index `index` into this buffer.
+   *
+   *  The elements at indices `index` and above are shifted one position towards
+   *  the end, taking time linear in `length - index`. If `index == length`, the
+   *  element is appended.
+   *
+   *  @param index the index where the element is inserted
+   *  @param elem the element to insert
+   *  @throws IndexOutOfBoundsException if the index `index` is not in the valid range
+   *          `0 <= index <= length`
+   */
   def insert(@deprecatedName("n", "2.13.0") index: Int, elem: A): Unit = {
     checkWithinBounds(index, index)
     mutationCount += 1
@@ -180,11 +256,31 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this(index) = elem
   }
 
+  /** Prepends `elem` to this buffer.
+   *
+   *  Takes time linear in the buffer size, as all existing elements are shifted
+   *  one position towards the end.
+   *
+   *  @param elem the element to prepend
+   *  @return this $coll
+   */
   def prepend(elem: A): this.type = {
     insert(0, elem)
     this
   }
 
+  /** Inserts all elements of `elems` at index `index` into this buffer.
+   *
+   *  The elements at indices `index` and above are shifted towards the end to
+   *  make room. If `elems` is a `collection.Iterable`, its elements are copied
+   *  in directly, which is safe even when `elems` is this buffer itself; any
+   *  other `IterableOnce` is first copied into a temporary array buffer.
+   *
+   *  @param index the index where the elements are inserted
+   *  @param elems the collection containing the elements to insert
+   *  @throws IndexOutOfBoundsException if the index `index` is not in the valid range
+   *          `0 <= index <= length`
+   */
   def insertAll(@deprecatedName("n", "2.13.0") index: Int, elems: IterableOnce[A]^): Unit = {
     checkWithinBounds(index, index)
     elems match {
@@ -241,17 +337,38 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
       throw new IllegalArgumentException("removing negative number of elements: " + count)
     }
 
+  /** Returns this buffer itself, not a copy of it. */
   @deprecated("Use 'this' instance instead", "2.13.0")
   @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
   @inline def result(): this.type = this
 
+  /** Returns a new builder that appends its elements to this buffer and applies
+   *  `f` to this buffer when its `result()` method is called.
+   *
+   *  @tparam NewTo the result type of `f`
+   *  @param f the function applied to this buffer to obtain the builder's result
+   *  @return a builder backed by this buffer, with result `f` applied to the buffer
+   */
   @deprecated("Use 'new GrowableBuilder(this).mapResult(f)' instead", "2.13.0")
   @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
   @inline def mapResult[NewTo](f: (ArrayBuffer[A]) => NewTo): Builder[A, NewTo]^{f} = new GrowableBuilder[A, ArrayBuffer[A]](this).mapResult(f)
 
+  /** The prefix of this $coll's `toString` representation, `"ArrayBuffer"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "ArrayBuffer"
 
+  /** Copies elements of this buffer to an array, as a single bulk array copy.
+   *
+   *  Copying starts at index `start` of the destination and stops when the end
+   *  of this buffer, the end of `xs`, or the limit `len` is reached, whichever
+   *  comes first.
+   *
+   *  @tparam B the element type of the destination array
+   *  @param xs the destination array
+   *  @param start the index of `xs` at which to start copying
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements copied
+   */
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {
@@ -283,18 +400,75 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     if (start == end) z
     else foldr(start, end - 1, op(array(end - 1).asInstanceOf[A], z), op)
 
+  /** Applies the binary operator `op` to the start value `z` and all elements
+   *  of this buffer, going left to right.
+   *
+   *  Overridden to read the backing array directly.
+   *
+   *  @tparam B the result type of the operator
+   *  @param z the start value
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements, going
+   *          left to right with start value `z` on the left, or `z` if this
+   *          buffer is empty
+   */
   override def foldLeft[B](z: B)(op: (B, A) => B): B = foldl(0, length, z, op)
 
+  /** Applies the binary operator `op` to all elements of this buffer and the
+   *  start value `z`, going right to left.
+   *
+   *  Overridden to read the backing array directly.
+   *
+   *  @tparam B the result type of the operator
+   *  @param z the start value
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements, going
+   *          right to left with start value `z` on the right, or `z` if this
+   *          buffer is empty
+   */
   override def foldRight[B](z: B)(op: (A, B) => B): B = foldr(0, length, z, op)
 
+  /** Applies the binary operator `op` to all elements of this buffer, going
+   *  left to right.
+   *
+   *  Overridden to read the backing array directly.
+   *
+   *  @tparam B the result type of the operator, a supertype of the element type
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements, going left to right
+   *  @throws UnsupportedOperationException if this buffer is empty
+   */
   override def reduceLeft[B >: A](op: (B, A) => B): B =
     if (length > 0) foldl(1, length, array(0).asInstanceOf[B], op)
     else super.reduceLeft(op)
 
+  /** Applies the binary operator `op` to all elements of this buffer, going
+   *  right to left.
+   *
+   *  Overridden to read the backing array directly.
+   *
+   *  @tparam B the result type of the operator, a supertype of the element type
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements, going right to left
+   *  @throws UnsupportedOperationException if this buffer is empty
+   */
   override def reduceRight[B >: A](op: (A, B) => B): B =
     if (length > 0) foldr(0, length - 1, array(length - 1).asInstanceOf[B], op)
     else super.reduceRight(op)
 
+  /** Groups elements into fixed-size blocks by passing a "sliding window" over
+   *  them, returning an iterator of array buffers.
+   *
+   *  The iterator is fail-fast: it throws a
+   *  [[java.util.ConcurrentModificationException]] if this buffer is mutated
+   *  during iteration.
+   *
+   *  @param size the number of elements per group
+   *  @param step the distance between the first elements of successive groups
+   *  @return an iterator over the groups, each an `ArrayBuffer` of `size`
+   *          elements, except possibly a smaller final group
+   *  @throws IllegalArgumentException if `size` or `step` is not positive
+   */
   override def sliding(size: Int, step: Int): Iterator[ArrayBuffer[A]] =
     new MutationTracker.CheckedIterator(super.sliding(size = size, step = step), mutationCount)
 }
@@ -308,9 +482,24 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
  */
 @SerialVersionUID(3L)
 object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
+  /** The capacity, 16, of the backing array of an `ArrayBuffer` created without
+   *  an initial size, and the default size `clearAndShrink` resizes to; since that
+   *  only ever shrinks, a buffer whose array is already smaller keeps it. It
+   *  is also the minimum capacity allocated when a buffer's backing array first
+   *  grows.
+   */
   final val DefaultInitialSize = 16
   private val emptyArray = new Array[AnyRef](0)
 
+  /** Creates an array buffer containing the elements of `coll`.
+   *
+   *  If the size of `coll` is known, the backing array is allocated only once,
+   *  large enough for all elements.
+   *
+   *  @tparam B the element type
+   *  @param coll the collection providing the elements
+   *  @return a new `ArrayBuffer` with the elements of `coll` in order
+   */
   def from[B](coll: collection.IterableOnce[B]^): ArrayBuffer[B] = {
     val k = coll.knownSize
     if (k >= 0) {
@@ -323,10 +512,23 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
     else new ArrayBuffer[B] ++= coll
   }
 
+  /** Returns a new builder that produces an `ArrayBuffer`.
+   *
+   *  The returned builder forwards `sizeHint` to the underlying buffer, so the
+   *  backing array can be pre-allocated.
+   *
+   *  @tparam A the element type
+   *  @return a builder producing an `ArrayBuffer`
+   */
   def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new GrowableBuilder[A, ArrayBuffer[A]](empty[A]) {
     override def sizeHint(size: Int): Unit = elems.sizeHint(size)
   }
 
+  /** Creates a new, empty array buffer with the default initial capacity.
+   *
+   *  @tparam A the element type
+   *  @return a new empty `ArrayBuffer`
+   */
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 
   /** The increased size for an array-backed collection.
@@ -378,8 +580,28 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
 }
 
 // TODO: use `CheckedIndexedSeqView.Id` once we can change the return type of `ArrayBuffer#view`
+/** An `IndexedSeqView` over an [[ArrayBuffer]], obtained from `ArrayBuffer#view`.
+ *
+ *  Iterators obtained from this view, directly or through the overridden
+ *  transformation methods, check the buffer's mutation count and throw a
+ *  [[java.util.ConcurrentModificationException]] if the buffer is mutated
+ *  after the iterator's creation. A view built through the deprecated
+ *  `(array, length)` constructor has a constant mutation count instead, so its
+ *  iterators never detect mutation.
+ *
+ *  @tparam A the element type of the underlying buffer
+ */
 final class ArrayBufferView[A] private[mutable](underlying: ArrayBuffer[A], mutationCount: () => Int)
   extends AbstractIndexedSeqView[A] {
+  /** Creates a view over the first `length` elements of `array`.
+   *
+   *  The array is wrapped in a fresh `ArrayBuffer`, and the view performs no
+   *  mutation tracking: its mutation count is a constant 0, so its iterators
+   *  never detect a concurrent mutation.
+   *
+   *  @param array the array holding the elements, erased to `AnyRef`
+   *  @param length the number of elements to expose
+   */
   @deprecated("never intended to be public; call ArrayBuffer#view instead", since = "2.13.7")
   def this(array: Array[AnyRef], length: Int) = {
     // this won't actually track mutation, but it would be a pain to have the implementation
@@ -396,30 +618,117 @@ final class ArrayBufferView[A] private[mutable](underlying: ArrayBuffer[A], muta
     }, () => 0)
   }
 
+  /** Returns a fresh array containing the elements of the underlying buffer,
+   *  not the buffer's internal storage.
+   */
   @deprecated("never intended to be public", since = "2.13.7")
   def array: Array[AnyRef] = underlying.toArray[Any].asInstanceOf[Array[AnyRef]]
 
+  /** Returns the element of the underlying buffer at index `n`.
+   *
+   *  @param n the index of the element to return
+   *  @throws IndexOutOfBoundsException if `n < 0` or `n >= length`
+   */
   @throws[IndexOutOfBoundsException]
   def apply(n: Int): A = underlying(n)
+  /** Returns the current number of elements in the underlying buffer. */
   def length: Int = underlying.length
+  /** The prefix of this view's `toString` representation, `"ArrayBufferView"`. */
   override protected def className = "ArrayBufferView"
 
   // we could inherit all these from `CheckedIndexedSeqView`, except this class is public
+  /** Returns a fail-fast iterator over the elements of this view. */
   override def iterator: Iterator[A]^{this} = new CheckedIndexedSeqView.CheckedIterator(this, mutationCount())
+  /** Returns a fail-fast iterator over the elements of this view, in reverse order. */
   override def reverseIterator: Iterator[A]^{this} = new CheckedIndexedSeqView.CheckedReverseIterator(this, mutationCount())
 
+  /** Returns a mutation-checked view of this view with `elem` appended.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param elem the element to append
+   *  @return a view of the elements of this view followed by `elem`
+   */
   override def appended[B >: A](elem: B): IndexedSeqView[B]^{this} = new CheckedIndexedSeqView.Appended(this, elem)(mutationCount)
+  /** Returns a mutation-checked view of this view with `elem` prepended.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param elem the element to prepend
+   *  @return a view of `elem` followed by the elements of this view
+   */
   override def prepended[B >: A](elem: B): IndexedSeqView[B]^{this} = new CheckedIndexedSeqView.Prepended(elem, this)(mutationCount)
+  /** Returns a mutation-checked view of the first `n` elements of this view.
+   *
+   *  @param n the number of elements to take
+   *  @return a view of the first `n` elements, of all elements if `n` exceeds
+   *          the length, or of no elements if `n` is negative
+   */
   override def take(n: Int): IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.Take(this, n)(mutationCount)
+  /** Returns a mutation-checked view of the last `n` elements of this view.
+   *
+   *  @param n the number of elements to take
+   *  @return a view of the last `n` elements, of all elements if `n` exceeds
+   *          the length, or of no elements if `n` is negative
+   */
   override def takeRight(n: Int): IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.TakeRight(this, n)(mutationCount)
+  /** Returns a mutation-checked view of all but the first `n` elements of this view.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of all elements except the first `n`
+   */
   override def drop(n: Int): IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.Drop(this, n)(mutationCount)
+  /** Returns a mutation-checked view of all but the last `n` elements of this view.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of all elements except the last `n`
+   */
   override def dropRight(n: Int): IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.DropRight(this, n)(mutationCount)
+  /** Returns a mutation-checked view with `f` lazily applied to each element of this view.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param f the function to apply to each element
+   *  @return a view of the results of applying `f` to the elements of this view
+   */
   override def map[B](f: A => B): IndexedSeqView[B]^{this, f} = new CheckedIndexedSeqView.Map(this, f)(mutationCount)
+  /** Returns a mutation-checked view of the elements of this view in reverse order. */
   override def reverse: IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.Reverse(this)(mutationCount)
+  /** Returns a mutation-checked view of the elements at indices `from` until `until` of this view.
+   *
+   *  @param from the index of the first element in the slice
+   *  @param until the index one past the last element in the slice
+   *  @return a view of the elements in the given index range
+   */
   override def slice(from: Int, until: Int): IndexedSeqView[A]^{this} = new CheckedIndexedSeqView.Slice(this, from, until)(mutationCount)
+  /** Returns a mutation-checked view that applies `f` to each element as it is
+   *  traversed, for its side effect, and produces the element unchanged.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each traversed element
+   *  @return a view of the same elements as this view
+   */
   override def tapEach[U](f: A => U): IndexedSeqView[A]^{this, f} = new CheckedIndexedSeqView.Map(this, { (a: A) => f(a); a})(mutationCount)
 
+  /** Returns a mutation-checked view of the elements of this view followed by
+   *  the elements of `suffix`.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param suffix the indexed sequence or view whose elements follow this view's
+   *  @return a view of the concatenation
+   */
   override def concat[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{suffix, this} = new CheckedIndexedSeqView.Concat(this, suffix)(mutationCount)
+  /** Returns a mutation-checked view of the elements of this view followed by
+   *  the elements of `suffix`, like `concat`.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param suffix the indexed sequence or view whose elements follow this view's
+   *  @return a view of the concatenation
+   */
   override def appendedAll[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{suffix, this} = new CheckedIndexedSeqView.Concat(this, suffix)(mutationCount)
+  /** Returns a mutation-checked view of the elements of `prefix` followed by
+   *  the elements of this view.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param prefix the indexed sequence or view whose elements precede this view's
+   *  @return a view of the concatenation
+   */
   override def prependedAll[B >: A](prefix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{prefix, this} = new CheckedIndexedSeqView.Concat(prefix, this)(mutationCount)
 }

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -26,8 +26,16 @@ import scala.reflect.ClassTag
 sealed abstract class ArrayBuilder[T]
   extends ReusableBuilder[T, Array[T]]
     with Serializable {
+  /** The number of elements this builder can hold without resizing, typically
+   *  the length of `elems`; 0 while no backing array is allocated. The `ofUnit`
+   *  builder keeps no array at all and simply records a capacity here.
+   */
   protected var capacity: Int = 0
+  /** The backing array, holding the first `size` elements added to this
+   *  builder, or `null` while no array is allocated.
+   */
   protected def elems: Array[T] | Null // may not be allocated at size = capacity = 0
+  /** The number of elements added to this builder so far. */
   protected var size: Int = 0
 
   /** Current number of elements. */
@@ -36,15 +44,45 @@ sealed abstract class ArrayBuilder[T]
   /** Current number of elements. */
   override def knownSize: Int = size
 
+  /** Grows the backing array, if necessary, so that it can hold at least
+   *  `size` elements. The `ofUnit` builder, which keeps no array, only records
+   *  the new capacity.
+   *
+   *  When growing is needed, the new capacity is the largest of the requested
+   *  size, twice the current capacity, and the default initial size (16),
+   *  capped at the maximum array size the VM supports.
+   *
+   *  @param size the required minimum capacity
+   *  @throws RuntimeException if `size` is negative (an overflow) or exceeds
+   *          the maximum array size the VM supports
+   */
   protected final def ensureSize(size: Int): Unit = {
     val newLen = resizeUp(capacity, size)
     if (newLen > 0) resize(newLen)
   }
 
+  /** Grows the backing array to hold at least `size` elements; for the `ofUnit`
+   *  builder, which keeps no array, records the capacity instead.
+   *
+   *  Does nothing if the current capacity suffices; otherwise resizes to
+   *  exactly `size`, avoiding the over-allocation of the doubling strategy
+   *  when the final number of elements is known in advance.
+   *
+   *  @param size the expected number of elements
+   */
   override final def sizeHint(size: Int): Unit = if (capacity < size) resize(size)
 
+  /** Discards all elements added so far, leaving this builder empty.
+   *
+   *  Any backing array is kept at its current capacity and reused.
+   */
   def clear(): Unit = size = 0
 
+  /** Resizes this builder to the new capacity `size`; builders backed by an
+   *  array reallocate it to that length, preserving the elements added so far.
+   *
+   *  @param size the new capacity
+   */
   protected def resize(size: Int): Unit
 
   /** Adds all elements of an array.
@@ -77,6 +115,18 @@ sealed abstract class ArrayBuilder[T]
     this
   }
 
+  /** Adds all elements of an iterable collection.
+   *
+   *  If `xs` has a known size, the backing array is grown once up front and
+   *  the elements are copied in bulk; otherwise the elements are added one by
+   *  one.
+   *
+   *  @param xs the collection whose elements are added
+   *  @return this builder with the elements of `xs` appended
+   *  @throws IllegalStateException if `xs` reports a positive known size but yields a
+   *          different number of elements; a reported size of zero is taken on trust and
+   *          `xs` is not iterated at all
+   */
   override def addAll(xs: IterableOnce[T]^): this.type = {
     val k = xs.knownSize
     if (k > 0) {
@@ -122,6 +172,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef | Null](implicit ct: ClassTag[T]) extends ArrayBuilder[T] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[T] | Null = null
 
     private def mkArray(size: Int): Array[T] = {
@@ -130,11 +183,21 @@ object ArrayBuilder {
       else java.util.Arrays.copyOf[T](elems, size)
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: T): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -142,6 +205,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[T] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -152,11 +223,17 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Discards all elements added so far, leaving this builder empty.
+     *
+     *  The backing array is kept at its current capacity, but its cells are
+     *  nulled out so that the discarded elements can be garbage collected.
+     */
     override def clear(): Unit = {
       super.clear()
       if(elems ne null) java.util.Arrays.fill(elems.asInstanceOf[Array[AnyRef]], null)
     }
 
+    /** Returns the string `"ArrayBuilder.ofRef"`. */
     override def toString() = "ArrayBuilder.ofRef"
   }
 
@@ -164,6 +241,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofByte extends ArrayBuilder[Byte] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Byte] | Null = null
 
     private def mkArray(size: Int): Array[Byte] = {
@@ -172,11 +252,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Byte): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -184,6 +274,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Byte] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -194,6 +292,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofByte"`. */
     override def toString() = "ArrayBuilder.ofByte"
   }
 
@@ -201,6 +300,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofShort extends ArrayBuilder[Short] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Short] | Null = null
 
     private def mkArray(size: Int): Array[Short] = {
@@ -209,11 +311,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Short): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -221,6 +333,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Short] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -231,6 +351,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofShort"`. */
     override def toString() = "ArrayBuilder.ofShort"
   }
 
@@ -238,6 +359,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofChar extends ArrayBuilder[Char] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Char] | Null = null
 
     private def mkArray(size: Int): Array[Char] = {
@@ -246,11 +370,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Char): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -258,6 +392,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Char] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -268,6 +410,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofChar"`. */
     override def toString() = "ArrayBuilder.ofChar"
   }
 
@@ -275,6 +418,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofInt extends ArrayBuilder[Int] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Int] | Null = null
 
     private def mkArray(size: Int): Array[Int] = {
@@ -283,11 +429,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Int): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -295,6 +451,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Int] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -305,6 +469,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofInt"`. */
     override def toString() = "ArrayBuilder.ofInt"
   }
 
@@ -312,6 +477,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofLong extends ArrayBuilder[Long] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Long] | Null = null
 
     private def mkArray(size: Int): Array[Long] = {
@@ -320,11 +488,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Long): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -332,6 +510,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Long] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -342,6 +528,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofLong"`. */
     override def toString() = "ArrayBuilder.ofLong"
   }
 
@@ -349,6 +536,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofFloat extends ArrayBuilder[Float] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Float] | Null = null
 
     private def mkArray(size: Int): Array[Float] = {
@@ -357,11 +547,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Float): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -369,6 +569,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Float] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -379,6 +587,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofFloat"`. */
     override def toString() = "ArrayBuilder.ofFloat"
   }
 
@@ -386,6 +595,9 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofDouble extends ArrayBuilder[Double] {
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Double] | Null = null
 
     private def mkArray(size: Int): Array[Double] = {
@@ -394,11 +606,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Double): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -406,6 +628,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Double] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -416,6 +646,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofDouble"`. */
     override def toString() = "ArrayBuilder.ofDouble"
   }
 
@@ -424,6 +655,9 @@ object ArrayBuilder {
   class ofBoolean extends ArrayBuilder[Boolean] {
     this: ofBoolean^{} =>
 
+    /** The backing array; `null` until storage is first allocated, and reset
+     *  to `null` when `result()` hands the array off without copying.
+     */
     protected var elems: Array[Boolean] | Null = null
 
     private def mkArray(size: Int): Array[Boolean] = {
@@ -432,11 +666,21 @@ object ArrayBuilder {
       newelems
     }
 
+    /** Reallocates the backing array to length `size`, copying the elements
+     *  added so far, and updates `capacity`.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = {
       elems = mkArray(size)
       capacity = size
     }
 
+    /** Adds a single element to this builder.
+     *
+     *  @param elem the element to add
+     *  @return this builder with `elem` appended
+     */
     def addOne(elem: Boolean): this.type = {
       ensureSize(size + 1)
       elems.nn(size) = elem
@@ -444,6 +688,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns an array containing all elements added to this builder.
+     *
+     *  If the elements added exactly fill the backing array, that array is
+     *  returned directly, without copying, and this builder gives it up;
+     *  otherwise the elements are copied into a new array of exactly the
+     *  right length. After this call, `clear()` must be called before this
+     *  builder is used again.
+     */
     def result(): Array[Boolean] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
@@ -454,6 +706,7 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
+    /** Returns the string `"ArrayBuilder.ofBoolean"`. */
     override def toString() = "ArrayBuilder.ofBoolean"
   }
 
@@ -461,8 +714,17 @@ object ArrayBuilder {
   @SerialVersionUID(3L)
   final class ofUnit extends ArrayBuilder[Unit] {
 
+    /** Not supported: this builder stores no elements, only their count.
+     *
+     *  @throws UnsupportedOperationException always
+     */
     protected def elems: Array[Unit] | Null = throw new UnsupportedOperationException()
 
+    /** Adds a single unit value by incrementing the element count.
+     *
+     *  @param elem never used, as all unit values are identical
+     *  @return this builder with its size increased by 1
+     */
     def addOne(elem: Unit): this.type = {
       val newSize = size + 1
       ensureSize(newSize)
@@ -470,6 +732,13 @@ object ArrayBuilder {
       this
     }
 
+    /** Adds all elements of a collection by increasing the element count by
+     *  its size.
+     *
+     *  @param xs the collection whose elements are counted; it is iterated
+     *            fully to compute its size, but its elements are not stored
+     *  @return this builder with its size increased by the size of `xs`
+     */
     override def addAll(xs: IterableOnce[Unit]^): this.type = {
       val newSize = size + xs.iterator.size
       ensureSize(newSize)
@@ -477,6 +746,14 @@ object ArrayBuilder {
       this
     }
 
+    /** Adds `length` unit values by increasing the element count, without
+     *  inspecting the array.
+     *
+     *  @param xs the array whose elements are counted; never used
+     *  @param offset the start index of the slice; never used
+     *  @param length the number of elements to add, applied as is
+     *  @return this builder with its size increased by `length`
+     */
     override def addAll(xs: Array[? <: Unit], offset: Int, length: Int): this.type = {
       val newSize = size + length
       ensureSize(newSize)
@@ -484,6 +761,11 @@ object ArrayBuilder {
       this
     }
 
+    /** Returns a new array of `size` unit values.
+     *
+     *  A fresh array is allocated and filled on each call; this builder's
+     *  count is left unchanged.
+     */
     def result() = {
       val ans = new Array[Unit](size)
       var i = 0
@@ -491,8 +773,14 @@ object ArrayBuilder {
       ans
     }
 
+    /** Records the new capacity; no storage is allocated, as this builder
+     *  stores no elements.
+     *
+     *  @param size the new capacity
+     */
     protected def resize(size: Int): Unit = capacity = size
 
+    /** Returns the string `"ArrayBuilder.ofUnit"`. */
     override def toString() = "ArrayBuilder.ofUnit"
   }
 }

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -39,6 +39,10 @@ import scala.reflect.ClassTag
   *  @define willNotTerminateInf
   */
 class ArrayDeque[A] protected (
+    /** The underlying circular buffer. Its length is always a power of two; the
+     *  elements occupy the slots from `start` (inclusive) to `end` (exclusive),
+     *  wrapping around the end of the buffer, and all unused slots are `null`.
+     */
     protected var array: Array[AnyRef | Null],
     private[ArrayDeque] var start: Int,
     private[ArrayDeque] var end: Int
@@ -62,28 +66,70 @@ class ArrayDeque[A] protected (
     this.end = end
   }
 
+  /** Creates an empty array deque that can hold at least `initialSize` elements
+   *  before its internal buffer needs to grow.
+   *
+   *  @param initialSize the initial capacity hint; the buffer allocated is the
+   *                     next power of two above this value, at least 16
+   *  @throws IllegalArgumentException if `initialSize` is negative or too large to
+   *          allocate, since `ArrayDeque.alloc` rejects it
+   */
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) = this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
+  /** Returns the number of elements in this array deque; the size is always known. */
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
   // No-Op override to allow for more efficient stepper in a minor release.
+  /** Returns a stepper for the elements of this array deque.
+   *
+   *  Steppers enable creating a Java stream to operate on the elements.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape implicit evidence selecting the stepper type for the element type `A`
+   *  @return a stepper over the elements, supporting efficient splitting for
+   *          parallel processing
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = super.stepper(using shape)
 
+  /** Returns the element at the given index, in constant time.
+   *
+   *  @param idx the zero-based index of the element
+   *  @return the element at index `idx`
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   */
   def apply(idx: Int): A = {
     requireBounds(idx)
     _get(idx)
   }
 
+  /** Replaces the element at the given index, in constant time.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the new value
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   */
   def update(idx: Int, elem: A): Unit = {
     requireBounds(idx)
     _set(idx, elem)
   }
 
+  /** Appends an element to the end of this array deque, growing the internal
+   *  buffer if it is full. Takes amortized constant time.
+   *
+   *  @param elem the element to append
+   *  @return this array deque
+   */
   def addOne(elem: A): this.type = {
     ensureSize(length + 1)
     appendAssumingCapacity(elem)
   }
 
+  /** Prepends an element to the front of this array deque, growing the internal
+   *  buffer if it is full. Takes amortized constant time.
+   *
+   *  @param elem the element to prepend
+   *  @return this array deque
+   */
   def prepend(elem: A): this.type = {
     ensureSize(length + 1)
     prependAssumingCapacity(elem)
@@ -101,6 +147,15 @@ class ArrayDeque[A] protected (
     this
   }
 
+  /** Prepends all elements of a collection to the front of this array deque.
+   *
+   *  The prepended elements keep their order: after the call, the first element
+   *  of `elems` is the first element of this array deque. The internal buffer is
+   *  resized at most once and `elems` is traversed at most twice.
+   *
+   *  @param elems the elements to prepend
+   *  @return this array deque
+   */
   override def prependAll(elems: IterableOnce[A]^): this.type = {
     val it = elems.iterator
     if (it.nonEmpty) {
@@ -133,6 +188,14 @@ class ArrayDeque[A] protected (
     this
   }
 
+  /** Appends all elements of a collection to the end of this array deque.
+   *
+   *  If the size of `elems` is known, the internal buffer is resized at most
+   *  once before the elements are appended.
+   *
+   *  @param elems the elements to append
+   *  @return this array deque
+   */
   override def addAll(elems: IterableOnce[A]^): this.type = {
     elems.knownSize match {
       case srcLength if srcLength > 0 =>
@@ -143,6 +206,15 @@ class ArrayDeque[A] protected (
     this
   }
 
+  /** Inserts an element at a given index, shifting the shorter of the prefix
+   *  before `idx` and the suffix from `idx` onwards; the elements previously at
+   *  `idx` and beyond follow the inserted element. Takes O(min(idx, length - idx))
+   *  time, or O(length) when the buffer is full and has to grow first.
+   *
+   *  @param idx the index at which to insert, from `0` to `length` inclusive
+   *  @param elem the element to insert
+   *  @throws IndexOutOfBoundsException if `idx` is negative or greater than `length`
+   */
   def insert(idx: Int, elem: A): Unit = {
     requireBounds(idx, length+1)
     val n = length
@@ -179,6 +251,17 @@ class ArrayDeque[A] protected (
     }
   }
 
+  /** Inserts all elements of a collection at a given index, keeping their
+   *  order; the elements previously at `idx` and beyond follow the inserted
+   *  elements. Shifts the shorter of the prefix before `idx` and the suffix
+   *  from `idx` onwards. The buffer is resized at most once, except when inserting at
+   *  the end from a collection of unknown size, which appends one element at a time
+   *  and may resize repeatedly.
+   *
+   *  @param idx the index at which to insert, from `0` to `length` inclusive
+   *  @param elems the elements to insert
+   *  @throws IndexOutOfBoundsException if `idx` is negative or greater than `length`
+   */
   def insertAll(idx: Int, elems: IterableOnce[A]^): Unit = {
     requireBounds(idx, length+1)
     val n = length
@@ -233,6 +316,19 @@ class ArrayDeque[A] protected (
     }
   }
 
+  /** Removes `count` elements starting at index `idx`.
+   *
+   *  If fewer than `count` elements exist from `idx` to the end, all elements
+   *  from `idx` onwards are removed. If `count` is zero, does nothing; `idx` is
+   *  not validated in that case. The internal buffer may shrink when a large
+   *  buffer becomes mostly empty.
+   *
+   *  @param idx the index of the first element to remove
+   *  @param count the number of elements to remove
+   *  @throws IndexOutOfBoundsException if `count` is positive and `idx` is
+   *          negative or not less than `length`
+   *  @throws IllegalArgumentException if `count` is negative
+   */
   def remove(idx: Int, count: Int): Unit = {
     if (count > 0) {
       requireBounds(idx)
@@ -275,12 +371,24 @@ class ArrayDeque[A] protected (
     }
   }
 
+  /** Removes the element at a given index and returns it.
+   *
+   *  @param idx the index of the element to remove
+   *  @return the removed element
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   */
   def remove(idx: Int): A = {
     val elem = this(idx)
     remove(idx, 1)
     elem
   }
 
+  /** Removes the first occurrence of the given element from this array deque,
+   *  if present; otherwise does nothing.
+   *
+   *  @param elem the element to remove
+   *  @return this array deque
+   */
   override def subtractOne(elem: A): this.type = {
     val idx = indexOf(elem)
     if (idx >= 0) remove(idx, 1) //TODO: SeqOps should be fluent API
@@ -432,14 +540,28 @@ class ArrayDeque[A] protected (
     res.result()
   }
 
+  /** Grows the internal buffer, if necessary, so that this array deque can hold
+   *  at least `hint` elements without further resizing. Does nothing if `hint`
+   *  is not greater than the current length or the buffer is already large enough.
+   *
+   *  @param hint the number of elements to reserve capacity for
+   */
   @inline def ensureSize(hint: Int) = if (hint > length && mustGrow(hint)) resize(hint)
 
+  /** Returns the number of elements in this array deque. */
   def length = end_-(start)
 
+  /** Returns `true` if this array deque contains no elements, in constant time. */
   override def isEmpty = start == end
 
+  /** Returns a copy of this array deque, backed by a clone of the internal
+   *  buffer. The elements themselves are not copied.
+   */
   override protected def klone(): ArrayDeque[A] = new ArrayDeque(array.clone(), start = start, end = end)
 
+  /** Returns the companion object [[ArrayDeque]], the factory used to build new
+   *  collections of this type.
+   */
   override def iterableFactory: SeqFactory[ArrayDeque] = ArrayDeque
 
   /**
@@ -470,9 +592,35 @@ class ArrayDeque[A] protected (
     this
   }
 
+  /** Returns a new `ArrayDeque` backed directly by the given array (not a
+   *  copy), containing its first `end` elements.
+   *
+   *  @param array the array to use as the internal buffer; its length must be a
+   *               power of two
+   *  @param end the number of elements, from the start of `array`, that the result
+   *             contains; it must be less than the array's length, since the circular
+   *             buffer always leaves one slot free
+   *  @return a new `ArrayDeque` over the first `end` elements of `array`
+   */
   protected def ofArray(array: Array[AnyRef | Null], end: Int): ArrayDeque[A] =
     new ArrayDeque[A](array, start = 0, end)
 
+  /** Copies elements of this array deque to another array, beginning at index
+   *  `destStart` of `dest`.
+   *
+   *  The number of elements copied is the minimum of `len`, the length of this
+   *  array deque, and the remaining capacity of `dest` from `destStart`; if
+   *  that minimum is not positive, nothing is copied.
+   *
+   *  @tparam B the element type of the destination array, a supertype of `A`
+   *  @param dest the destination array
+   *  @param destStart the index of `dest` at which to write the first element; it must
+   *                   be within `dest` whenever there is anything to copy
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements actually copied
+   *  @throws IndexOutOfBoundsException if there are elements to copy and `destStart` is
+   *          not a valid index of `dest`
+   */
   override def copyToArray[B >: A](dest: Array[B], destStart: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, dest.length, destStart, len)
     if (copied > 0) {
@@ -481,6 +629,13 @@ class ArrayDeque[A] protected (
     copied
   }
 
+  /** Returns a new array containing all elements of this array deque in order.
+   *
+   *  The result does not share storage with this array deque.
+   *
+   *  @tparam B the element type of the result array, a supertype of `A`
+   *  @return a new array with the elements of this array deque
+   */
   override def toArray[B >: A: ClassTag]: Array[B] =
     copySliceToArray(srcStart = 0, dest = new Array[B](length), destStart = 0, maxItems = length)
 
@@ -490,6 +645,9 @@ class ArrayDeque[A] protected (
   def trimToSize(): Unit = resize(length)
 
   // Utils for common modular arithmetic:
+  /** Returns the physical index into the internal buffer of the slot `idx`
+   *  places after `start`, wrapping around the power-of-two buffer length.
+   */
   @inline protected def start_+(idx: Int) = (start + idx) & (array.length - 1)
   @inline private def start_-(idx: Int) = (start - idx) & (array.length - 1)
   @inline private def end_+(idx: Int) = (end + idx) & (array.length - 1)
@@ -524,6 +682,7 @@ class ArrayDeque[A] protected (
     reset(array = array2, start = 0, end = n)
   }
 
+  /** Returns `"ArrayDeque"`, the name of this collection type used in `toString` output. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "ArrayDeque"
 }
@@ -536,6 +695,17 @@ class ArrayDeque[A] protected (
 @SerialVersionUID(3L)
 object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
 
+  /** Builds a new `ArrayDeque` containing the elements of the given collection.
+   *
+   *  If the size of `coll` is known, the elements are copied directly into a
+   *  buffer of sufficient capacity; otherwise they are appended one by one.
+   *
+   *  @tparam B the element type
+   *  @param coll the collection whose elements are copied
+   *  @return a new `ArrayDeque` with the elements of `coll`
+   *  @throws IllegalStateException if `coll` reports a known size that differs
+   *          from the number of elements its iterator yields
+   */
   def from[B](coll: collection.IterableOnce[B]^): ArrayDeque[B] = {
     val s = coll.knownSize
     if (s >= 0) {
@@ -546,6 +716,14 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
     } else new ArrayDeque[B]() ++= coll
   }
 
+  /** Returns a new builder for an `ArrayDeque`.
+   *
+   *  The builder appends elements to a deque that becomes the result; a size
+   *  hint pre-allocates buffer capacity.
+   *
+   *  @tparam A the element type
+   *  @return a builder producing an `ArrayDeque`
+   */
   def newBuilder[A]: Builder[A, ArrayDeque[A]] =
     new GrowableBuilder[A, ArrayDeque[A]](empty) {
       override def sizeHint(size: Int): Unit = {
@@ -553,8 +731,17 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
       }
     }
 
+  /** Returns a new, empty `ArrayDeque` with the default initial capacity.
+   *
+   *  @tparam A the element type
+   *  @return a new, empty `ArrayDeque`
+   */
   def empty[A]: ArrayDeque[A] = new ArrayDeque[A]()
 
+  /** The default initial size hint, 16: an `ArrayDeque` created without an
+   *  explicit initial size can hold at least this many elements before its
+   *  internal buffer grows.
+   */
   final val DefaultInitialSize = 16
 
   /**
@@ -578,16 +765,42 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
 }
 
 transparent trait ArrayDequeOps[A, +CC[_] <: caps.Pure, +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC, C] {
+  /** The underlying circular buffer. Its length is always a power of two. */
   protected def array: Array[AnyRef | Null]
 
+  /** Returns a copy of this collection, as produced by `klone()`. */
   final override def clone(): C = klone()
 
+  /** Returns a copy of this collection; called by `clone()`. Implementations
+   *  copy the internal buffer so that the copy does not share storage with the
+   *  original; the elements themselves are not copied.
+   */
   protected def klone(): C
 
+  /** Returns a new collection backed directly by the given array (not a copy),
+   *  containing its first `end` elements. Subclasses must override this method
+   *  to return the most specific collection type.
+   *
+   *  @param array the array to use as the internal buffer; its length must be a
+   *               power of two
+   *  @param end the number of elements, from the start of `array`, that the
+   *             result contains
+   *  @return a new collection over the first `end` elements of `array`
+   */
   protected def ofArray(array: Array[AnyRef | Null], end: Int): C
 
+  /** Returns the physical index into the internal buffer of the slot `idx`
+   *  places after the first element, wrapping around the power-of-two buffer
+   *  length.
+   */
   protected def start_+(idx: Int): Int
 
+  /** Checks that `idx` is a valid index, throwing if it is not.
+   *
+   *  @param idx the index to validate
+   *  @param until the exclusive upper bound for `idx`; defaults to `length`
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `until`
+   */
   @inline protected final def requireBounds(idx: Int, until: Int = length): Unit =
     if (idx < 0 || idx >= until)
       throw CommonErrors.indexOutOfBounds(index = idx, max = until - 1)
@@ -616,6 +829,9 @@ transparent trait ArrayDequeOps[A, +CC[_] <: caps.Pure, +C <: AnyRef] extends St
     dest
   }
 
+  /** Returns a new collection with the elements of this collection in reverse
+   *  order. This collection is not modified.
+   */
   override def reverse: C = {
     val n = length
     val arr = ArrayDeque.alloc(n)
@@ -627,6 +843,17 @@ transparent trait ArrayDequeOps[A, +CC[_] <: caps.Pure, +C <: AnyRef] extends St
     ofArray(arr, n)
   }
 
+  /** Returns a new collection containing the elements from index `from`
+   *  (inclusive) to index `until` (exclusive). This collection is not modified.
+   *
+   *  Both indices are clamped to the range `0` to `length`: if the clamped
+   *  range is empty, returns an empty collection; if it covers every element,
+   *  returns a copy of this collection.
+   *
+   *  @param from the index of the first element to include
+   *  @param until the index one past the last element to include
+   *  @return a new collection with the selected elements
+   */
   override def slice(from: Int, until: Int): C = {
     val n = length
     val left = Math.max(0, Math.min(n, from))
@@ -642,8 +869,28 @@ transparent trait ArrayDequeOps[A, +CC[_] <: caps.Pure, +C <: AnyRef] extends St
     }
   }
 
+  /** Groups elements in fixed size blocks by passing a "sliding window" over
+   *  them, moving the window `step` elements at a time.
+   *
+   *  @param size the number of elements per group
+   *  @param step the distance between the first elements of successive groups
+   *  @return an iterator producing collections of `size` elements each, except
+   *          the last group, which may be smaller
+   *  @throws IllegalArgumentException if `size` or `step` is not positive
+   *  @throws java.util.ConcurrentModificationException from the returned iterator if the
+   *          length of this collection changes while it is being consumed
+   */
   override def sliding(@deprecatedName("window") size: Int, step: Int): Iterator[C] =
     super.sliding(size = size, step = step)
 
+  /** Partitions the elements into fixed size groups.
+   *
+   *  @param n the number of elements per group
+   *  @return an iterator producing collections of `n` elements each, except the
+   *          last group, which may be smaller
+   *  @throws IllegalArgumentException if `n` is not positive
+   *  @throws java.util.ConcurrentModificationException from the returned iterator if the
+   *          length of this collection changes while it is being consumed
+   */
   override def grouped(n: Int): Iterator[C] = sliding(n, n)
 }

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -41,15 +41,29 @@ sealed abstract class ArraySeq[T]
     with StrictOptimizedSeqOps[T, ArraySeq, ArraySeq[T]]
     with Serializable {
 
+  /** Returns the companion factory in its untagged form, which requires no `ClassTag`
+   *  and therefore builds collections backed by an `Array[AnyRef]`, storing primitive
+   *  values boxed.
+   */
   override def iterableFactory: scala.collection.SeqFactory[ArraySeq] = ArraySeq.untagged
 
+  /** Builds a new `ArraySeq` containing the elements of `coll`, using this wrapped array's
+   *  `elemTag` so that the result has the same underlying array representation.
+   *
+   *  @param coll the collection whose elements are copied into the result
+   *  @return a new `ArraySeq` with the elements of `coll`
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[T]^): ArraySeq[T] = {
     val b = ArrayBuilder.make(using elemTag).asInstanceOf[ArrayBuilder[T]]
     b.sizeHint(coll, delta = 0)
     b ++= coll
     ArraySeq.make(b.result())
   }
+  /** Returns a builder for an `ArraySeq`, using this wrapped array's `elemTag` so that the
+   *  result has the same underlying array representation.
+   */
   override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(using elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
+  /** Returns the empty `ArraySeq`, the single instance shared for all element types. */
   override def empty: ArraySeq[T] = ArraySeq.empty(using elemTag.asInstanceOf[ClassTag[T]])
 
   /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
@@ -71,13 +85,39 @@ sealed abstract class ArraySeq[T]
    */
   def array: Array[?]
 
+  /** Returns a stepper for the elements of this wrapped array.
+   *
+   *  Steppers enable creating a Java stream to operate on the elements. For a primitive
+   *  element type, the stepper steps over unboxed values unless a reference-shaped stepper
+   *  is explicitly requested.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape implicit evidence selecting the stepper type for the element type `T`
+   *  @return a stepper over the elements, supporting efficient splitting for parallel
+   *          processing
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[T, S]): S & EfficientSplit
 
+  /** Returns `"ArraySeq"`, the name of this collection type used in `toString` output. */
   override protected def className = "ArraySeq"
 
   /** Clones this object, including the underlying Array. */
   override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]
 
+  /** Copies elements of this wrapped array to another array, beginning at index `start`
+   *  of `xs`.
+   *
+   *  The number of elements copied is the minimum of `len`, the length of this wrapped
+   *  array, and the remaining capacity of `xs` from `start`; if that minimum is not
+   *  positive, nothing is copied. Copying is performed by a single `Array.copy` of the
+   *  underlying array.
+   *
+   *  @tparam B the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array
+   *  @param start the index of `xs` at which to write the first element
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements actually copied
+   */
   override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {
@@ -86,6 +126,15 @@ sealed abstract class ArraySeq[T]
     copied
   }
 
+  /** Compares this wrapped array with another object for equality.
+   *
+   *  Two `ArraySeq`s whose underlying arrays differ in length are never equal. Otherwise,
+   *  general sequence equality applies, so a wrapped array can be equal to any other
+   *  sequence containing the same elements in the same order.
+   *
+   *  @param other the object to compare with
+   *  @return `true` if `other` is a sequence with equal elements in the same order
+   */
   override def equals(other: Any): Boolean = other match {
     case that: ArraySeq[?] if this.array.length != that.array.length =>
       false
@@ -93,9 +142,27 @@ sealed abstract class ArraySeq[T]
       super.equals(other)
   }
 
+  /** Returns a new `ArraySeq` with the elements of this wrapped array sorted according to
+   *  the given ordering.
+   *
+   *  This wrapped array is not modified; the result wraps a sorted copy of the underlying
+   *  array.
+   *
+   *  @tparam B the type on which `ord` is defined, a supertype of `T`
+   *  @param ord the ordering used to compare elements
+   */
   override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq[T] =
     ArraySeq.make(array.sorted(using ord.asInstanceOf[Ordering[Any]])).asInstanceOf[ArraySeq[T]]
 
+  /** Sorts this wrapped array in place according to the given ordering, using a stable
+   *  sort.
+   *
+   *  A wrapped array with fewer than two elements is left untouched.
+   *
+   *  @tparam B the type on which `ord` is defined, a supertype of `T`
+   *  @param ord the ordering used to compare elements
+   *  @return this wrapped array, sorted
+   */
   override def sortInPlace[B >: T]()(implicit ord: Ordering[B]): this.type = {
     if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
     this
@@ -105,14 +172,42 @@ sealed abstract class ArraySeq[T]
 /** A companion object used to create instances of `ArraySeq`. */
 @SerialVersionUID(3L)
 object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
+  /** A factory for `ArraySeq`s that requires no `ClassTag`.
+   *
+   *  Collections built through this factory are backed by an `Array[AnyRef]` and store
+   *  primitive values boxed.
+   */
   val untagged: SeqFactory[ArraySeq] = new ClassTagSeqFactory.AnySeqDelegate(self)
 
   // This is reused for all calls to empty.
   private val EmptyArraySeq  = new ofRef[AnyRef](new Array[AnyRef](0))
+  /** Returns the empty `ArraySeq`.
+   *
+   *  The same instance, backed by an empty `Array[AnyRef]`, is shared for all element
+   *  types; the `ClassTag` is never consulted.
+   *
+   *  @tparam T the element type
+   */
   def empty[T : ClassTag]: ArraySeq[T] = EmptyArraySeq.asInstanceOf[ArraySeq[T]]
 
+  /** Builds a new `ArraySeq` containing the elements of the given collection.
+   *
+   *  The elements are copied into a new array whose element type is determined by the
+   *  `ClassTag`, and the result wraps that array.
+   *
+   *  @tparam A the element type
+   *  @param it the collection whose elements are copied
+   *  @return a new `ArraySeq` with the elements of `it`
+   */
   def from[A : ClassTag](it: scala.collection.IterableOnce[A]^): ArraySeq[A] = make(Array.from[A](it))
 
+  /** Returns a new builder for an `ArraySeq`.
+   *
+   *  The builder collects elements into an array whose element type is determined by the
+   *  `ClassTag`, then wraps the result without copying.
+   *
+   *  @tparam A the element type
+   */
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] = ArrayBuilder.make[A].mapResult(make)
 
   /** Wraps an existing `Array` into a `ArraySeq` of the proper primitive specialization type
@@ -144,13 +239,51 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     case x: Array[Unit]    => new ofUnit(x)
   }).asInstanceOf[ArraySeq[T]]
 
+  /** An `ArraySeq` backed by an array of reference values.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @tparam T the element type, a reference type
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef | Null](val array: Array[T]) extends ArraySeq[T] {
+    /** Returns a class tag for the runtime component type of the underlying array,
+     *  which may be a subtype or supertype of `T`.
+     */
     def elemTag: ClassTag[T] = ClassTag[T](array.getClass.getComponentType)
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): T = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     *  @throws ArrayStoreException if the wrapped array's runtime component type is
+     *          narrower than `T` and `elem` is not an instance of it
+     */
     def update(index: Int, elem: T): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofRef` instances are equal if their underlying arrays contain equal
+     *  elements (compared with `equals`) in the same order. Comparison with
+     *  anything else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofRef[?] =>
         Array.equals(
@@ -158,7 +291,19 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
           that.array.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[T] = new ArrayOps.ArrayIterator[T](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  If a value-shaped stepper is requested for an element type that boxes a
+     *  primitive, the stepper unboxes the values; otherwise it steps over the
+     *  reference values directly.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `T`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[T, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         new ObjectArrayStepper(array, 0, array.length)
@@ -166,19 +311,64 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Byte]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofByte(val array: Array[Byte]) extends ArraySeq[Byte] {
     // Type erases to `ManifestFactory.ByteManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Byte`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Byte.type = ClassTag.Byte
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Byte = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Byte): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofByte` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Byte] = new ArrayOps.ArrayIterator[Byte](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Byte` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Byte`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Byte, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedByteArrayStepper(array, 0, array.length))
@@ -186,19 +376,64 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Short]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofShort(val array: Array[Short]) extends ArraySeq[Short] {
     // Type erases to `ManifestFactory.ShortManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Short`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Short.type = ClassTag.Short
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Short = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Short): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofShort` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofShort => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Short] = new ArrayOps.ArrayIterator[Short](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Short` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Short`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Short, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedShortArrayStepper(array, 0, array.length))
@@ -206,25 +441,84 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Char]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofChar(val array: Array[Char]) extends ArraySeq[Char] {
     // Type erases to `ManifestFactory.CharManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Char`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Char.type = ClassTag.Char
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Char = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Char): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofChar` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Char] = new ArrayOps.ArrayIterator[Char](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Char` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Char`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Char, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedCharArrayStepper(array, 0, array.length))
       else new WidenedCharArrayStepper(array, 0, array.length)
       ).asInstanceOf[S & EfficientSplit]
 
+    /** Appends the characters of this wrapped array to a string builder,
+     *  preceded by the string `start`, separated by the string `sep`, and
+     *  followed by the string `end`.
+     *
+     *  Optimized for the underlying `Array[Char]`: with an empty separator the
+     *  whole array is appended in a single call, and otherwise the required
+     *  capacity is reserved up front.
+     *
+     *  @param sb the string builder to append to
+     *  @param start the starting string
+     *  @param sep the separator string
+     *  @param end the ending string
+     *  @return the string builder `sb` to which elements were appended
+     */
     override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type = {
       val jsb = sb.underlying
       if (start.length != 0) jsb.append(start)
@@ -247,19 +541,63 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     }
   }
 
+  /** An `ArraySeq` backed by an `Array[Int]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofInt(val array: Array[Int]) extends ArraySeq[Int] {
     // Type erases to `ManifestFactory.IntManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Int`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Int.type = ClassTag.Int
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Int = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Int): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofInt` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofInt => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Int] = new ArrayOps.ArrayIterator[Int](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Int` values unless a reference-shaped
+     *  stepper is explicitly requested, in which case the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Int`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Int, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new IntArrayStepper(array, 0, array.length))
@@ -267,19 +605,63 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Long]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofLong(val array: Array[Long]) extends ArraySeq[Long] {
     // Type erases to `ManifestFactory.LongManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Long`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Long.type = ClassTag.Long
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Long = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Long): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofLong` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Long] = new ArrayOps.ArrayIterator[Long](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Long` values unless a reference-shaped
+     *  stepper is explicitly requested, in which case the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Long`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Long, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParLongStepper(new LongArrayStepper(array, 0, array.length))
@@ -287,14 +669,49 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Float]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofFloat(val array: Array[Float]) extends ArraySeq[Float] {
     // Type erases to `ManifestFactory.FloatManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Float`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Float.type = ClassTag.Float
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Float = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofFloat` instances are equal if they share the same underlying array,
+     *  or if their underlying arrays contain the same elements in the same order,
+     *  compared with `==`. A `NaN` element is not `==` to anything, so two
+     *  distinct arrays containing `NaN` are never equal. Comparison with anything
+     *  else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofFloat =>
         val thatArray = that.array
@@ -305,7 +722,19 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         }
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Float` values, widened to `Double`,
+     *  unless a reference-shaped stepper is explicitly requested, in which case
+     *  the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Float`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Float, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParDoubleStepper(new WidenedFloatArrayStepper(array, 0, array.length))
@@ -313,14 +742,49 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Double]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofDouble(val array: Array[Double]) extends ArraySeq[Double] {
     // Type erases to `ManifestFactory.DoubleManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Double`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Double.type = ClassTag.Double
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Double = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofDouble` instances are equal if they share the same underlying array,
+     *  or if their underlying arrays contain the same elements in the same order,
+     *  compared with `==`. A `NaN` element is not `==` to anything, so two
+     *  distinct arrays containing `NaN` are never equal. Comparison with anything
+     *  else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofDouble =>
         val thatArray = that.array
@@ -331,7 +795,19 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         }
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper steps over the unboxed `Double` values unless a
+     *  reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Double`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Double, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParDoubleStepper(new DoubleArrayStepper(array, 0, array.length))
@@ -339,36 +815,123 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Boolean]`, storing its elements unboxed.
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofBoolean(val array: Array[Boolean]) extends ArraySeq[Boolean] {
     // Type erases to `ManifestFactory.BooleanManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Boolean`, the tag of the unboxed element type. */
     def elemTag: ClassTag.Boolean.type = ClassTag.Boolean
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Boolean = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Boolean): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofBoolean` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back
+     *  to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofBoolean => Arrays.equals(array, that.array)
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Boolean] = new ArrayOps.ArrayIterator[Boolean](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  There is no primitive stepper shape for `Boolean`, so the stepper always
+     *  steps over boxed values.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Boolean`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Boolean, S]): S & EfficientSplit =
       new BoxedBooleanArrayStepper(array, 0, array.length).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An `ArraySeq` backed by an `Array[Unit]` (at runtime, an array of boxed unit values).
+   *
+   *  The given array is used directly, not copied: mutations of the array are visible
+   *  through this wrapped array and vice versa.
+   *
+   *  @param array the underlying array
+   */
   @SerialVersionUID(3L)
   final class ofUnit(val array: Array[Unit]) extends ArraySeq[Unit] {
     // Type erases to `ManifestFactory.UnitManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Unit`, the tag of the element type. */
     def elemTag: ClassTag.Unit.type = ClassTag.Unit
+    /** Returns the number of elements in this wrapped array. */
     def length: Int = array.length
+    /** Returns the unit value at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def apply(index: Int): Unit = array(index)
+    /** Replaces the element at the given index of the underlying array.
+     *
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the new value
+     *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     def update(index: Int, elem: Unit): Unit = { array(index) = elem }
+    /** Returns a hash code computed from the array elements, consistent with the hashing
+     *  of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(array)
+    /** Compares this wrapped array with another object for equality.
+     *
+     *  Two `ofUnit` instances are equal if their underlying arrays have the same
+     *  length, since all unit values are equal. Comparison with anything else
+     *  falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     */
     override def equals(that: Any) = that match {
       case that: ofUnit => array.length == that.array.length
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Unit] = new ArrayOps.ArrayIterator[Unit](array)
+    /** Returns a stepper for the elements of this wrapped array.
+     *
+     *  The stepper always steps over the boxed unit values.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Unit`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Unit, S]): S & EfficientSplit =
       new ObjectArrayStepper[AnyRef](array.asInstanceOf[Array[AnyRef]], 0, array.length).asInstanceOf[S & EfficientSplit]
   }

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -47,27 +47,70 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with collection.BitSetOps[BitSet]
     with Serializable {
 
+  /** Creates a new empty bitset with an initial capacity for elements up to `initSize - 1`.
+   *
+   *  The bitset grows automatically when larger elements are added.
+   *
+   *  @param initSize the number of elements the initial word array can represent;
+   *                  at least one 64-bit word is always allocated, and a value within
+   *                  63 of `Int.MaxValue` overflows the rounding and allocates just one
+   */
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
 
+  /** Creates a new empty bitset with the minimal initial capacity of one 64-bit word. */
   def this() = this(0)
 
+  /** Builds a new mutable bitset containing the elements of the given collection.
+   *
+   *  @param coll the collection of non-negative integers to include
+   *  @return a new mutable bitset containing the elements of `coll`
+   *  @throws IllegalArgumentException if `coll` contains a negative element
+   */
   override protected def fromSpecific(coll: IterableOnce[Int]^): BitSet = bitSetFactory.fromSpecific(coll)
+  /** Returns a new builder that accumulates `Int` elements into a mutable bitset. */
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
+  /** Returns a new empty mutable bitset. */
   override def empty: BitSet = bitSetFactory.empty
 
+  /** The factory used to build mutable bitsets, the [[BitSet$ `BitSet`]] companion object. */
   def bitSetFactory: BitSet.type = BitSet
 
+  /** Returns this bitset viewed as an unsorted `Set[Int]`.
+   *
+   *  No copy is made: the result is this same bitset, so its iteration
+   *  order remains increasing.
+   */
   override def unsorted: Set[Int] = this
 
+  /** The number of 64-bit words currently allocated in the underlying array. */
   protected[collection] final def nwords: Int = elems.length
 
+  /** Returns the word at the given index of the underlying array.
+   *
+   *  @param idx the word index
+   *  @return the word at index `idx`, or `0L` if `idx` is beyond the allocated words
+   */
   protected[collection] final def word(idx: Int): Long =
     if (idx < nwords) elems(idx) else 0L
 
+  /** Creates a new mutable bitset backed directly by the given array, without copying.
+   *
+   *  @param elems the array of `Long` words representing the bits; used as the
+   *               backing array of the result unless empty
+   *  @return a new bitset backed by `elems`, or the empty bitset if `elems` is empty
+   */
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet =
     if (elems.length == 0) empty
     else new BitSet(elems)
 
+  /** Adds a single element to this bitset.
+   *
+   *  Grows the underlying array if `elem` does not fit in the current capacity.
+   *
+   *  @param elem the element to add; must be non-negative
+   *  @return this bitset
+   *  @throws IllegalArgumentException if `elem` is negative
+   */
   def addOne(elem: Int): this.type = {
     require(elem >= 0)
     if (!contains(elem)) {
@@ -77,6 +120,15 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
+  /** Removes a single element from this bitset, if it is present.
+   *
+   *  The underlying array never shrinks: removing an element clears its bit
+   *  but keeps the allocated words.
+   *
+   *  @param elem the element to remove; must be non-negative
+   *  @return this bitset
+   *  @throws IllegalArgumentException if `elem` is negative
+   */
   def subtractOne(elem: Int): this.type = {
     require(elem >= 0)
     if (contains(elem)) {
@@ -86,15 +138,36 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
+  /** Removes all elements from this bitset by replacing the underlying array
+   *  with a zeroed array of the same length, keeping the current capacity.
+   */
   def clear(): Unit = {
     elems = new Array[Long](elems.length)
   }
 
+  /** Sets the word at the given index of the underlying array, growing the
+   *  array first if needed.
+   *
+   *  @param idx the word index to update
+   *  @param w the new word value
+   *  @throws IllegalArgumentException if `idx` is not less than the maximum
+   *          number of words a bitset can hold
+   */
   protected final def updateWord(idx: Int, w: Long): Unit = {
     ensureCapacity(idx)
     elems(idx) = w
   }
 
+  /** Grows the underlying array, if needed, so that it has a word at index `idx`.
+   *
+   *  The array length is repeatedly doubled (capped at the maximum size) until
+   *  it exceeds `idx`; existing words are copied over. Does nothing if the
+   *  array is already large enough.
+   *
+   *  @param idx the word index that must be within the array after this call
+   *  @throws IllegalArgumentException if `idx` is not less than the maximum
+   *          number of words a bitset can hold
+   */
   protected final def ensureCapacity(idx: Int): Unit = {
     require(idx < MaxSize)
     if (idx >= nwords) {
@@ -106,6 +179,9 @@ class BitSet(protected[collection] final var elems: Array[Long])
     }
   }
 
+  /** Returns this bitset viewed as a general `Set[Int]` without the sorted-set
+   *  constraint. No copy is made: the result is this same bitset.
+   */
   def unconstrained: collection.Set[Int] = this
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".
@@ -171,26 +247,104 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
+  /** Returns a copy of this bitset, backed by a copy of the underlying array,
+   *  so later changes to either bitset do not affect the other.
+   */
   override def clone(): BitSet = new BitSet(java.util.Arrays.copyOf(elems, elems.length))
 
+  /** Returns an immutable bitset containing the same elements as this bitset.
+   *
+   *  The underlying array is copied, so later changes to this bitset do not
+   *  affect the result.
+   */
   def toImmutable: immutable.BitSet = immutable.BitSet.fromBitMask(elems)
 
+  /** Builds a new bitset by applying a function to all elements of this bitset.
+   *
+   *  @param f the function to apply to each element; must return non-negative values
+   *  @return a new bitset containing the results of applying `f` to each element
+   *  @throws IllegalArgumentException if `f` returns a negative value for some element
+   */
   override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
+  /** Builds a new sorted set by applying a function to all elements of this bitset.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing the results of applying `f` to each element
+   */
   override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].map(f)
 
+  /** Builds a new bitset by applying a function to all elements of this bitset
+   *  and concatenating the results.
+   *
+   *  @param f the function to apply to each element; the collections it returns
+   *           must contain only non-negative values
+   *  @return a new bitset containing all elements of the collections returned by `f`
+   *  @throws IllegalArgumentException if a collection returned by `f` contains a negative value
+   */
   override def flatMap(f: Int => IterableOnce[Int]^): BitSet = strictOptimizedFlatMap(newSpecificBuilder, f)
+  /** Builds a new sorted set by applying a function to all elements of this
+   *  bitset and concatenating the results.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing all elements of the collections returned by `f`
+   */
   override def flatMap[B](f: Int => IterableOnce[B]^)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].flatMap(f)
 
+  /** Builds a new bitset by applying a partial function to all elements of
+   *  this bitset on which the function is defined.
+   *
+   *  @param pf the partial function to apply to each element; must return
+   *            non-negative values where defined
+   *  @return a new bitset containing the results of applying `pf` to each
+   *          element on which it is defined
+   *  @throws IllegalArgumentException if `pf` returns a negative value for some element
+   */
   override def collect(pf: PartialFunction[Int, Int]^): BitSet = strictOptimizedCollect(newSpecificBuilder, pf)
+  /** Builds a new sorted set by applying a partial function to all elements of
+   *  this bitset on which the function is defined.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param pf the partial function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing the results of applying `pf` to each
+   *          element on which it is defined
+   */
   override def collect[B](pf: scala.PartialFunction[Int, B]^)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].collect(pf)
 
   // necessary for disambiguation
+  /** Returns a sorted set of pairs formed by zipping the elements of this
+   *  bitset, in increasing order, with the elements of `that`.
+   *
+   *  If one of the two collections is longer than the other, its remaining
+   *  elements are dropped.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection providing the second half of each result pair
+   *  @param ev the ordering used to sort the resulting pairs
+   *  @return a new sorted set of pairs
+   */
   override def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =
     super.zip(that)
 
+  /** Adds all elements of the given collection to this bitset.
+   *
+   *  Optimized paths avoid element-by-element insertion where possible: another
+   *  bitset is combined word-by-word with `|=`, a range with step 1 or -1 is
+   *  set with whole-word masks, and a sorted set ordered by the natural `Int`
+   *  ordering (or its reverse) has capacity ensured up front for its largest
+   *  element.
+   *
+   *  @param xs the collection of elements to add; all must be non-negative
+   *  @return this bitset
+   *  @throws IllegalArgumentException if `xs` contains a negative element
+   */
   override def addAll(xs: IterableOnce[Int]^): this.type = xs match {
     case bs: collection.BitSet =>
       this |= bs
@@ -239,6 +393,14 @@ class BitSet(protected[collection] final var elems: Array[Long])
       super.addAll(other)
   }
 
+  /** Tests whether this bitset is a subset of another set.
+   *
+   *  When `that` is also a bitset, the test compares whole words instead of
+   *  testing elements one by one.
+   *
+   *  @param that the set to test against
+   *  @return `true` if every element of this bitset is also an element of `that`
+   */
   override def subsetOf(that: collection.Set[Int]): Boolean = that match {
     case bs: collection.BitSet =>
       val thisnwords = this.nwords
@@ -264,13 +426,34 @@ class BitSet(protected[collection] final var elems: Array[Long])
       super.subsetOf(other)
   }
 
+  /** Removes all elements of the given collection from this bitset.
+   *
+   *  When `xs` is also a bitset, the removal is performed word-by-word with `&~=`.
+   *
+   *  @param xs the collection of elements to remove; non-negative elements are
+   *            removed if present
+   *  @return this bitset
+   *  @throws IllegalArgumentException if `xs` is not a bitset and contains a
+   *          negative element
+   */
   override def subtractAll(xs: IterableOnce[Int]^): this.type = xs match {
     case bs: collection.BitSet => this &~= bs
     case other => super.subtractAll(other)
   }
 
+  /** Replaces this bitset with a serialization proxy during Java serialization. */
   protected def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
 
+  /** Computes the difference of this bitset and another set.
+   *
+   *  This bitset is not modified. When `that` is also a bitset, the difference
+   *  is computed word-by-word, and the result's array is trimmed to the highest
+   *  non-zero word where possible.
+   *
+   *  @param that the set of elements to exclude
+   *  @return a new bitset containing the elements of this bitset that are not
+   *          also in `that`
+   */
   override def diff(that: collection.Set[Int]): BitSet = that match {
     case bs: collection.BitSet =>
       /*
@@ -324,6 +507,18 @@ class BitSet(protected[collection] final var elems: Array[Long])
     case _ => super.diff(that)
   }
 
+  /** Builds a new bitset containing the elements of this bitset that satisfy
+   *  (or, if `isFlipped`, do not satisfy) a predicate. Implements both `filter`
+   *  and `filterNot`. This bitset is not modified.
+   *
+   *  The elements are tested from highest to lowest so that the result's array
+   *  is allocated once, sized exactly to its highest non-zero word.
+   *
+   *  @param pred the predicate to test elements against
+   *  @param isFlipped if `false`, keep elements satisfying `pred` (`filter`);
+   *                   if `true`, keep elements not satisfying it (`filterNot`)
+   *  @return a new bitset containing the retained elements
+   */
   override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
     // We filter the BitSet from highest to lowest, so we can determine exactly the highest non-zero word
     // index which lets us avoid:
@@ -348,6 +543,14 @@ class BitSet(protected[collection] final var elems: Array[Long])
     }
   }
 
+  /** Retains only the elements of this bitset that satisfy a predicate,
+   *  clearing the bits of all elements that do not.
+   *
+   *  The underlying array keeps its length even if the highest words become zero.
+   *
+   *  @param p the predicate an element must satisfy to be retained
+   *  @return this bitset
+   */
   override def filterInPlace(p: Int => Boolean): this.type = {
     val thisnwords = nwords
     var i = 0
@@ -358,16 +561,27 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
+  /** Returns a copy of the underlying array of `Long` words representing the
+   *  bits of this bitset. Changes to the returned array do not affect this bitset.
+   */
   override def toBitMask: Array[Long] = elems.clone()
 }
 
 @SerialVersionUID(3L)
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
+  /** Creates a new mutable bitset containing the elements of the given collection.
+   *
+   *  @param it the collection of elements to include; all must be non-negative
+   *  @return a new mutable bitset containing the elements of `it`
+   *  @throws IllegalArgumentException if `it` contains a negative element
+   */
   def fromSpecific(it: scala.collection.IterableOnce[Int]^): BitSet = Growable.from(empty, it)
 
+  /** Returns a new empty mutable bitset. */
   def empty: BitSet = new BitSet()
 
+  /** Returns a new builder that accumulates `Int` elements into a mutable bitset. */
   def newBuilder: Builder[Int, BitSet] = new GrowableBuilder(empty)
 
   /** A bitset containing all the bits in an array.

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -32,8 +32,14 @@ trait Buffer[A]
     with Shrinkable[A]
     with IterableFactoryDefaults[A, Buffer] { self =>
 
+  /** The companion object `Buffer`, which creates `ArrayBuffer` instances. */
   override def iterableFactory: SeqFactory[Buffer] = Buffer
 
+  /** The number of elements in this $coll, if it can be cheaply computed, -1 otherwise.
+   *
+   *  Overridden to select `Seq`'s implementation over the conflicting one inherited
+   *  from [[Growable]].
+   */
   override def knownSize: Int = super[Seq].knownSize
 
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
@@ -244,15 +250,25 @@ trait Buffer[A]
     this
   }
 
+  /** The prefix of this $coll's `toString` representation, `"Buffer"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "Buffer"
 }
 
+/** A `Buffer` that is also an `IndexedSeq`, so its elements can be accessed and
+ *  updated efficiently by index.
+ *
+ *  Adds `flatMapInPlace` and `filterInPlace`, and implements `patchInPlace` in
+ *  terms of indexed `update`.
+ *
+ *  @tparam A the element type of the buffer
+ */
 trait IndexedBuffer[A] extends IndexedSeq[A]
   with IndexedSeqOps[A, IndexedBuffer, IndexedBuffer[A]]
   with Buffer[A]
   with IterableFactoryDefaults[A, IndexedBuffer] {
 
+  /** The companion object `IndexedBuffer`, which creates `ArrayBuffer` instances. */
   override def iterableFactory: SeqFactory[IndexedBuffer] = IndexedBuffer
 
   /** Replaces the contents of this $coll with the flatmapped result.
@@ -292,6 +308,20 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
     if (i == j) this else takeInPlace(j)
   }
 
+  /** Replaces a slice of elements in this $coll by another sequence of elements.
+   *
+   *  `from` and `replaced` are clamped to the range `[0, length]`: patching at negative
+   *  indices is the same as patching starting at 0, patching at indices at or larger
+   *  than the length appends the patch to the end, and an excessive `replaced` count is
+   *  reduced to the available elements. Implemented by overwriting replaced elements in
+   *  place via `update` while the patch lasts, then inserting any remaining patch
+   *  elements or removing any remaining replaced elements.
+   *
+   *  @param from the index of the first replaced element
+   *  @param patch the replacement sequence
+   *  @param replaced the number of elements to drop in the original $coll
+   *  @return this $coll
+   */
   def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A]^, replaced: Int): this.type = {
     val replaced0 = math.min(math.max(replaced, 0), length)
     val i = math.min(math.max(from, 0), length)

--- a/library/src/scala/collection/mutable/Cloneable.scala
+++ b/library/src/scala/collection/mutable/Cloneable.scala
@@ -20,5 +20,9 @@ import language.experimental.captureChecking
   *  @tparam C    Type of the collection, covariant and with reference types as upperbound.
   */
 trait Cloneable[+C <: AnyRef] extends scala.Cloneable {
+  /** Returns a shallow copy of this collection, made with `java.lang.Object.clone`
+   *  and cast to the collection type `C`. This override also widens access from
+   *  protected to public.
+   */
   override def clone(): C = super.clone().asInstanceOf[C]
 }

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -49,6 +49,10 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   private final def sortedMapFactory: SortedMapFactory[CollisionProofHashMap] = CollisionProofHashMap
 
+  /** Creates a new, empty hash map with the default initial capacity (16) and the default load factor (0.75).
+   *
+   *  @param ordering the `Ordering` used to compare keys within a bucket's red-black tree
+   */
   def this()(implicit ordering: Ordering[K]) = this(CollisionProofHashMap.defaultInitialCapacity, CollisionProofHashMap.defaultLoadFactor)(using ordering)
 
   import CollisionProofHashMap.Node
@@ -63,6 +67,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   private var contentSize = 0
 
+  /** Returns the number of key-value pairs in this map. */
   override def size: Int = contentSize
 
   @inline private final def computeHash(o: K): Int = {
@@ -74,13 +79,33 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   @inline private final def index(hash: Int) = hash & (table.length - 1)
 
+  /** Creates a new `CollisionProofHashMap` containing the key-value pairs of `coll`, using
+   *  the same key ordering as this map.
+   *
+   *  @param coll the collection whose key-value pairs are added to the new map
+   *  @return a new `CollisionProofHashMap` containing the key-value pairs of `coll`
+   */
   override protected def fromSpecific(coll: (IterableOnce[(K, V)] @uncheckedVariance)^): CollisionProofHashMap[K, V] @uncheckedVariance = CollisionProofHashMap.from(coll)
+  /** Returns a new builder for a `CollisionProofHashMap` with the same key ordering as this map. */
   override protected def newSpecificBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] @uncheckedVariance = CollisionProofHashMap.newBuilder[K, V]
 
+  /** Returns a new, empty `CollisionProofHashMap` with the same key ordering as this map and
+   *  the default initial capacity and load factor.
+   */
   override def empty: CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V]
 
+  /** Tests whether this map contains a binding for a key.
+   *
+   *  @param key the key to test for membership
+   *  @return `true` if this map contains a binding for `key`, `false` otherwise
+   */
   override def contains(key: K): Boolean = findNode(key) ne null
 
+  /** Returns the value associated with `key` in this map, wrapped in `Some`, or `None` if
+   *  `key` is not present.
+   *
+   *  @param key the key to look up
+   */
   def get(key: K): Option[V] = findNode(key) match {
     case null => None
     case nd => Some(nd match {
@@ -89,6 +114,12 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     })
   }
 
+  /** Returns the value associated with `key`.
+   *
+   *  @param key the key to look up
+   *  @return the value bound to `key`
+   *  @throws NoSuchElementException if `key` is not in this map
+   */
   @throws[NoSuchElementException]
   override def apply(key: K): V = findNode(key) match {
     case null => default(key)
@@ -98,6 +129,14 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Returns the value associated with `key`, or `default` if `key` is not in this map.
+   *  The lookup avoids allocating an `Option`.
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value to return when `key` is absent; evaluated only in that case
+   *  @return the value bound to `key`, or `default` if there is no such binding
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val nd = findNode(key)
     if (nd eq null) default else nd match {
@@ -115,6 +154,11 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Grows the internal table, if necessary, so that `size` entries can be stored without
+   *  triggering a resize. Never shrinks the table.
+   *
+   *  @param size the expected number of entries
+   */
   override def sizeHint(size: Int): Unit = {
     val target = tableSizeFor(((size + 1).toDouble / loadFactor).toInt)
     if(target > table.length) {
@@ -123,13 +167,31 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Adds a new key/value pair to this map. If the map already contains a binding for `key`,
+   *  its value is replaced by `value`.
+   *
+   *  @param key the key to add
+   *  @param value the value to bind to `key`
+   */
   override def update(key: K, value: V): Unit = put0(key, value, getOld = false)
 
+  /** Adds a new key/value pair to this map. If the map already contains a binding for `key`,
+   *  its value is replaced by `value`.
+   *
+   *  @param key the key to add
+   *  @param value the value to bind to `key`
+   */
   override def put(key: K, value: V): Option[V] = put0(key, value, getOld = true) match {
     case null => None
     case sm => sm
   }
 
+  /** Adds a single key-value pair to this map, replacing the value of an existing binding for
+   *  the same key.
+   *
+   *  @param elem the key-value pair to add
+   *  @return this map
+   */
   def addOne(elem: (K, V)): this.type = { put0(elem._1, elem._2, getOld = false); this }
 
   @`inline` private def put0(key: K, value: V, getOld: Boolean): Some[V] | Null = {
@@ -184,6 +246,13 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Adds all key-value pairs produced by `xs` to this map, replacing the values of keys that
+   *  are already present. When the size of `xs` is known, the table is grown beforehand to
+   *  make room for the current entries plus that many more.
+   *
+   *  @param xs the key-value pairs to add
+   *  @return this map
+   */
   override def addAll(xs: IterableOnce[(K, V)]^): this.type = {
     sizeHint(xs, delta = contentSize)
     super.addAll(xs)
@@ -263,6 +332,9 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
       }
   }
 
+  /** Returns an iterator over the keys of this map. The iteration order is not specified
+   *  and may change when the map is modified.
+   */
   override def keysIterator: Iterator[K] = {
     if (isEmpty) Iterator.empty
     else new MapIterator[K] {
@@ -271,6 +343,9 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Returns an iterator over the key-value pairs of this map. The iteration order is not
+   *  specified and may change when the map is modified.
+   */
   override def iterator: Iterator[(K, V)] = {
     if (isEmpty) Iterator.empty
     else new MapIterator[(K, V)] {
@@ -351,22 +426,42 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   private def newThreshold(size: Int) = (size.toDouble * loadFactor).toInt
 
+  /** Removes all key-value pairs from this map. The internal table keeps its current capacity. */
   override def clear(): Unit = {
     java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
     contentSize = 0
   }
 
+  /** Removes the binding for `key` from this map, if present.
+   *
+   *  @param key the key whose binding is removed
+   *  @return `Some(value)` if `key` was bound to `value` before the removal, `None` if `key`
+   *          was not in the map
+   */
   override def remove(key: K): Option[V] = {
     val v = remove0(key)
     if(v.asInstanceOf[AnyRef] eq Statics.pfMarker) None else Some(v.asInstanceOf[V])
   }
 
+  /** Removes the binding for `elem` from this map, if present.
+   *
+   *  @param elem the key whose binding is removed
+   *  @return this map
+   */
   def subtractOne(elem: K): this.type = { remove0(elem); this }
 
+  /** Returns the number of key-value pairs in this map; never `-1`, since the size of a hash map is always known. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this map contains no key-value pairs. */
   override def isEmpty: Boolean = size == 0
 
+  /** Applies a function `f` to each key-value pair of this map, passed as a tuple. The order
+   *  of traversal is not specified and may change when the map is modified.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each key-value pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = {
     val len = table.length
     var i = 0
@@ -380,6 +475,13 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Applies a function `f` to each key-value pair of this map, passing the key and value as
+   *  two separate arguments, without allocating tuples. The order of traversal is not
+   *  specified and may change when the map is modified.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each key and value
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = {
     val len = table.length
     var i = 0
@@ -393,10 +495,27 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  /** Replaces this map with a serialization proxy during Java serialization. The proxy records
+   *  the current table length, load factor and key ordering so deserialization can restore an
+   *  equivalent map.
+   */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(new CollisionProofHashMap.DeserializationFactory[K, V](table.length, loadFactor, ordering), this)
 
+  /** The name of this collection class, `"CollisionProofHashMap"`, used as the prefix in `toString`. */
   override protected def className = "CollisionProofHashMap"
 
+  /** Returns the value associated with `key`; if `key` is not in this map, evaluates
+   *  `defaultValue`, adds a binding from `key` to the result, and returns it.
+   *
+   *  `defaultValue` is evaluated at most once, and only when `key` is absent. The key is
+   *  hashed and located only once for both the lookup and the insertion; if evaluating
+   *  `defaultValue` resizes this map's table, the new binding is still inserted at the
+   *  correct position.
+   *
+   *  @param key the key to look up
+   *  @param defaultValue the value to bind to `key` if it is absent; evaluated only in that case
+   *  @return the value now associated with `key`
+   */
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     val hash = computeHash(key)
     val idx = index(hash)
@@ -459,6 +578,14 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
     sortedMapFactory.from(new View.Collect(this, pf))
 
+  /** Returns a new `CollisionProofHashMap`, with the same key ordering as this map, containing
+   *  the key-value pairs of this map followed by those of `suffix`. When a key occurs in both,
+   *  the value from `suffix` ends up in the result.
+   *
+   *  @tparam V2 the value type of the returned map, a supertype of this map's value type
+   *  @param suffix the key-value pairs to add to those of this map
+   *  @return a new `CollisionProofHashMap` combining this map and `suffix`
+   */
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = sortedMapFactory.from(suffix match {
     case it: Iterable[(K, V2) @unchecked] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
@@ -471,10 +598,27 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
    */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = concat(xs)
 
+  /** Returns a new `CollisionProofHashMap` containing the key-value pairs of this map and the
+   *  pair `kv`. When `kv._1` is already a key of this map, its value in the result is `kv._2`.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of this map's value type
+   *  @param kv the key-value pair added to those of this map
+   *  @return a new `CollisionProofHashMap` combining this map and `kv`
+   */
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def + [V1 >: V](kv: (K, V1)): CollisionProofHashMap[K, V1] =
      sortedMapFactory.from(new View.Appended(this, kv))
 
+  /** Returns a new `CollisionProofHashMap` containing the key-value pairs of this map and the
+   *  given pairs. When a key occurs more than once, the value of its last occurrence ends up
+   *  in the result.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of this map's value type
+   *  @param elem1 the first key-value pair added to those of this map
+   *  @param elem2 the second key-value pair added to those of this map
+   *  @param elems the remaining key-value pairs added to those of this map
+   *  @return a new `CollisionProofHashMap` combining this map and the given pairs
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CollisionProofHashMap[K, V1] =
      sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
@@ -730,6 +874,15 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   // building
 
+  /** Builds a red-black tree from the next `size` nodes produced by `xs`, which must arrive
+   *  in ascending key order, copying each node's key, hash and value. The tree is built
+   *  perfectly balanced, with only the nodes at the maximum depth colored red. Used to rebuild
+   *  the tree buckets when the table grows.
+   *
+   *  @param xs the nodes whose keys, hashes and values are copied into the new tree
+   *  @param size the number of nodes to consume from `xs`
+   *  @return the root of the new tree, or `null` if `size` is `0`
+   */
   def fromNodes(xs: Iterator[Node], size: Int): RBNode | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): RBNode | Null = size match {
@@ -767,16 +920,49 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
   private[collection] final val ordMsg = "No implicit Ordering[${K2}] found to build a CollisionProofHashMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
 
+  /** Creates a new collision-proof hash map containing the key-value pairs of the given
+   *  collection. When the size of `it` is known, the initial capacity is chosen so that all
+   *  pairs can be added without resizing the table.
+   *
+   *  @tparam K the key type of the new map, which must have an implicit `Ordering`
+   *  @tparam V the value type of the new map
+   *  @param it the collection whose key-value pairs are added to the new map
+   *  @return a new `CollisionProofHashMap` containing the key-value pairs of `it`
+   */
   def from[K : Ordering, V](it: scala.collection.IterableOnce[(K, V)]^): CollisionProofHashMap[K, V] = {
     val k = it.knownSize
     val cap = if(k > 0) ((k + 1).toDouble / defaultLoadFactor).toInt else defaultInitialCapacity
     new CollisionProofHashMap[K, V](cap, defaultLoadFactor) ++= it
   }
 
+  /** Creates a new, empty collision-proof hash map with the default initial capacity (16) and
+   *  load factor (0.75).
+   *
+   *  @tparam K the key type of the new map, which must have an implicit `Ordering`
+   *  @tparam V the value type of the new map
+   *  @return a new, empty `CollisionProofHashMap`
+   */
   def empty[K : Ordering, V]: CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V]
 
+  /** Creates a new builder for a `CollisionProofHashMap` with the default initial capacity and
+   *  load factor.
+   *
+   *  @tparam K the key type of the map to build, which must have an implicit `Ordering`
+   *  @tparam V the value type of the map to build
+   *  @return a new builder producing a `CollisionProofHashMap`
+   */
   def newBuilder[K : Ordering, V]: Builder[(K, V), CollisionProofHashMap[K, V]] = newBuilder(defaultInitialCapacity, defaultLoadFactor)
 
+  /** Creates a new builder for a `CollisionProofHashMap` with the given initial capacity and
+   *  load factor. Size hints given to the builder are forwarded to the underlying map's
+   *  `sizeHint`.
+   *
+   *  @tparam K the key type of the map to build, which must have an implicit `Ordering`
+   *  @tparam V the value type of the map to build
+   *  @param initialCapacity the initial capacity of the map's hash table
+   *  @param loadFactor the load factor of the map's hash table
+   *  @return a new builder producing a `CollisionProofHashMap`
+   */
   def newBuilder[K : Ordering, V](initialCapacity: Int, loadFactor: Double): Builder[(K, V), CollisionProofHashMap[K, V]] =
     new GrowableBuilder[(K, V), CollisionProofHashMap[K, V]](new CollisionProofHashMap[K, V](initialCapacity, loadFactor)) {
       override def sizeHint(size: Int) = elems.sizeHint(size)
@@ -808,21 +994,50 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
 
   // Superclass for RBNode and LLNode to help the JIT with optimizing instance checks, but no shared common fields.
   // Keeping calls monomorphic where possible and dispatching manually where needed is faster.
+  /** The common supertype of the two bucket node types, `RBNode` and `LLNode`. It has no
+   *  members of its own; a bucket stores either a list of `LLNode`s or a tree of `RBNode`s,
+   *  and callers dispatch on the concrete node type.
+   */
   sealed abstract class Node
 
   /////////////////////////// Red-Black Tree Node
 
+  /** A node of a red-black tree bucket. The tree is ordered by the key `Ordering` alone; the
+   *  improved hash of the key is cached only so it can be redistributed when the table grows.
+   *
+   *  @tparam K the key type
+   *  @tparam V the value type
+   *  @param key the key stored in this node
+   *  @param hash the improved hash of `key`, cached when the entry was created
+   *  @param value the value bound to `key`
+   *  @param red `true` if this node is red, `false` if it is black
+   *  @param left the left child, or `null` if there is none
+   *  @param right the right child, or `null` if there is none
+   *  @param parent the parent node, or `null` if this node is the root of its tree
+   */
   final class RBNode[K, V](
       var key: K, var hash: Int, var value: V, var red: Boolean,
+      /** The left child, or `null` if there is none. */
       @annotation.stableNull
       var left: RBNode[K, V] | Null,
+      /** The right child, or `null` if there is none. */
       @annotation.stableNull
       var right: RBNode[K, V] | Null,
+      /** The parent node, or `null` if this node is the root of its tree. */
       @annotation.stableNull
       var parent: RBNode[K, V] | Null
     ) extends Node {
+    /** Returns a string rendering this node's key, hash, value, color and both subtrees. */
     override def toString(): String = "RBNode(" + key + ", " + hash + ", " + value + ", " + red + ", " + left + ", " + right + ")"
 
+    /** Finds the node for key `k` in the tree rooted at this node, descending left or right
+     *  according to the ordering.
+     *
+     *  @param k the key to look for
+     *  @param h the improved hash of `k`; never used, nodes are compared by the ordering alone
+     *  @param ord the ordering used to compare keys
+     *  @return the node whose key compares equal to `k`, or `null` if the tree contains no such node
+     */
     @tailrec def getNode(k: K, h: Int)(implicit ord: Ordering[K]): RBNode[K, V] | Null = {
       val cmp = compare(k, h, this)
       if (cmp < 0) {
@@ -832,18 +1047,36 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
       } else this
     }
 
+    /** Applies `f` to the key-value pair of every node in the tree rooted at this node,
+     *  passed as a tuple, in ascending key order (in-order traversal).
+     *
+     *  @tparam U the result type of `f`, which is discarded
+     *  @param f the function to apply to each key-value pair
+     */
     def foreach[U](f: ((K, V)) => U): Unit = {
       if(left ne null) left.foreach(f)
       f((key, value))
       if(right ne null) right.foreach(f)
     }
 
+    /** Applies `f` to the key and value of every node in the tree rooted at this node,
+     *  passed as two separate arguments, in ascending key order (in-order traversal).
+     *
+     *  @tparam U the result type of `f`, which is discarded
+     *  @param f the function to apply to each key and value
+     */
     def foreachEntry[U](f: (K, V) => U): Unit = {
       if(left ne null) left.foreachEntry(f)
       f(key, value)
       if(right ne null) right.foreachEntry(f)
     }
 
+    /** Applies `f` to every node in the tree rooted at this node, in ascending key order
+     *  (in-order traversal).
+     *
+     *  @tparam U the result type of `f`, which is discarded
+     *  @param f the function to apply to each node
+     */
     def foreachNode[U](f: RBNode[K, V] => U): Unit = {
       if(left ne null) left.foreachNode(f)
       f(this)

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -31,13 +31,30 @@ import language.experimental.captureChecking
 class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
   extends Builder[Elem, To] {
 
+  /** Removes all elements from the underlying collection. */
   def clear(): Unit = elems.clear()
 
+  /** Returns the underlying growable collection itself, not a copy. Elements
+   *  added to this builder afterwards are visible in the returned collection.
+   */
   def result(): To = elems
 
+  /** Adds a single element to the underlying collection.
+   *
+   *  @param elem the element to add
+   *  @return this builder
+   */
   def addOne(elem: Elem): this.type = { elems += elem; this }
 
+  /** Adds all elements produced by an `IterableOnce` to the underlying collection.
+   *
+   *  @param xs the elements to add
+   *  @return this builder
+   */
   override def addAll(xs: IterableOnce[Elem]^): this.type = { elems.addAll(xs); this }
 
+  /** Returns the number of elements in the underlying collection, if it can be
+   *  cheaply computed, -1 otherwise.
+   */
   override def knownSize: Int = elems.knownSize
 }

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -48,6 +48,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
    * - Every bucket is sorted in ascendent hash order
    * - The sum of the lengths of all buckets is equal to contentSize.
    */
+  /** Creates a new, empty hash map with the default initial capacity (16) and the default load factor (0.75). */
   def this() = this(HashMap.defaultInitialCapacity, HashMap.defaultLoadFactor)
 
   import HashMap.Node
@@ -60,6 +61,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   private var contentSize = 0
 
+  /** Returns the number of key-value pairs in this map. */
   override def size: Int = contentSize
 
   /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
@@ -94,6 +96,11 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
 
+  /** Tests whether this map contains a binding for a key.
+   *
+   *  @param key the key to test for membership
+   *  @return `true` if this map contains a binding for `key`, `false` otherwise
+   */
   override def contains(key: K): Boolean = findNode(key) ne null
 
   @`inline` private def findNode(key: K): Node[K, V] | Null = {
@@ -104,11 +111,23 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Grows the internal table, if necessary, so that `size` entries can be stored without
+   *  triggering a resize. Never shrinks the table.
+   *
+   *  @param size the expected number of entries
+   */
   override def sizeHint(size: Int): Unit = {
     val target = tableSizeFor(((size + 1).toDouble / loadFactor).toInt)
     if(target > table.length) growTable(target)
   }
 
+  /** Adds all key-value pairs produced by `xs` to this map, replacing the values of keys that
+   *  are already present. When `xs` is an `immutable.HashMap`, a `mutable.HashMap`, or a
+   *  `LinkedHashMap`, the hash codes cached in `xs` are reused instead of being recomputed.
+   *
+   *  @param xs the key-value pairs to add
+   *  @return this map
+   */
   override def addAll(xs: IterableOnce[(K, V)]^): this.type = {
     sizeHint(xs)
 
@@ -142,6 +161,19 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   // Override updateWith for performance, so we can do the update while hashing
   // the input key only once and performing one lookup into the hash table
+  /** Updates the binding for `key` based on its current, optional value: applies
+   *  `remappingFunction` to `Some(value)` if `key` is bound to `value` and to `None` otherwise,
+   *  then updates the map to agree with the result. If the function returns `Some(v)`, `key` is
+   *  bound to `v`; if it returns `None`, any binding for `key` is removed. This override hashes
+   *  `key` and searches the table only once for both the lookup and the update; the function is
+   *  applied exactly once.
+   *
+   *  @param key the key whose binding is updated
+   *  @param remappingFunction the function that maps the current, optional value to the new, optional value
+   *  @return the value now bound to `key` wrapped in `Some`, or `None` if `key` is now unbound
+   *  @throws Throwable whatever `remappingFunction` throws, in which case this map is
+   *          left unchanged
+   */
   override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
     if (getClass != classOf[HashMap[?, ?]]) {
       // subclasses of HashMap might customise `get` ...
@@ -200,6 +232,13 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Removes the bindings for all keys produced by `xs` from this map, stopping early once
+   *  this map is empty. When `xs` is an `immutable.HashSet`, a `mutable.HashSet`, or a
+   *  `LinkedHashSet`, the hash codes cached in `xs` are reused instead of being recomputed.
+   *
+   *  @param xs the keys whose bindings are removed
+   *  @return this map
+   */
   override def subtractAll(xs: IterableOnce[K]^): this.type = {
     if (size == 0) {
       return this
@@ -339,18 +378,27 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
       }
   }
 
+  /** Returns an iterator over the key-value pairs of this map. The iteration order is not
+   *  specified and may change when the map is modified.
+   */
   override def iterator: Iterator[(K, V)] =
     if(size == 0) Iterator.empty
     else new HashMapIterator[(K, V)] {
       protected def extract(nd: Node[K, V]) = (nd.key, nd.value)
     }
 
+  /** Returns an iterator over the keys of this map. The iteration order is not specified
+   *  and may change when the map is modified.
+   */
   override def keysIterator: Iterator[K] =
     if(size == 0) Iterator.empty
     else new HashMapIterator[K] {
       protected def extract(nd: Node[K, V]) = nd.key
     }
 
+  /** Returns an iterator over the values of this map. The iteration order is not specified
+   *  and may change when the map is modified.
+   */
   override def valuesIterator: Iterator[V] =
     if(size == 0) Iterator.empty
     else new HashMapIterator[V] {
@@ -365,11 +413,26 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
       protected def extract(nd: Node[K, V]) = nd
     }
 
+  /** Returns a [[Stepper]] for the key-value pairs of this map, stepping through the hash
+   *  table directly.
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   *  @param shape the implicit `StepperShape` that selects the `Stepper` type for `(K, V)` pairs
+   *  @return a `Stepper` over the key-value pairs of this map, supporting efficient splitting
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[(K, V), S]): S & EfficientSplit =
     shape.
       parUnbox(new convert.impl.AnyTableStepper[(K, V), Node[K, V]](size, table, _.next, node => (node.key, node.value), 0, table.length)).
       asInstanceOf[S & EfficientSplit]
 
+  /** Returns a [[Stepper]] for the keys of this map, stepping through the hash table directly.
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   *  @param shape the implicit `StepperShape` that selects the appropriate primitive or boxed `Stepper` for `K`
+   *  @return a `Stepper` over the keys of this map, specialized for primitives when the
+   *          resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`, and supporting
+   *          efficient splitting
+   */
   override def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S & EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
@@ -381,6 +444,14 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns a [[Stepper]] for the values of this map, stepping through the hash table directly.
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   *  @param shape the implicit `StepperShape` that selects the appropriate primitive or boxed `Stepper` for `V`
+   *  @return a `Stepper` over the values of this map, specialized for primitives when the
+   *          resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`, and supporting
+   *          efficient splitting
+   */
   override def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S & EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
@@ -444,22 +515,45 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   private def newThreshold(size: Int) = (size.toDouble * loadFactor).toInt
 
+  /** Removes all key-value pairs from this map. The internal table keeps its current capacity. */
   override def clear(): Unit = {
     java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
     contentSize = 0
   }
 
+  /** Returns the value associated with `key` in this map, wrapped in `Some`, or `None` if
+   *  `key` is not present.
+   *
+   *  @param key the key to look up
+   */
   def get(key: K): Option[V] = findNode(key) match {
     case null => None
     case nd => Some(nd.value)
   }
 
+  /** Returns the value associated with `key`, or the result of `default(key)` if `key` is not
+   *  in this map.
+   *
+   *  @param key the key to look up
+   *  @return the value bound to `key`, or `default(key)` otherwise
+   *  @throws NoSuchElementException if `key` is not in this map and the `default` method is
+   *          not overridden to return a value instead of throwing
+   */
   @throws[NoSuchElementException]
   override def apply(key: K): V = findNode(key) match {
     case null => default(key)
     case nd => nd.value
   }
 
+  /** Returns the value associated with `key`, or `default` if `key` is not in this map.
+   *  For a plain `HashMap` the lookup avoids allocating an `Option`; subclasses that might
+   *  customise `get` go through the generic implementation.
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value to return when `key` is absent; evaluated only in that case
+   *  @return the value bound to `key`, or `default` if there is no such binding
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     if (getClass != classOf[HashMap[?, ?]]) {
       // subclasses of HashMap might customise `get` ...
@@ -471,6 +565,19 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Returns the value associated with `key`; if `key` is not in this map, evaluates
+   *  `defaultValue`, adds a binding from `key` to the result, and returns it.
+   *
+   *  `defaultValue` is evaluated at most once, and only when `key` is absent. For a plain
+   *  `HashMap` the key is hashed and located only once for both the lookup and the insertion,
+   *  and if evaluating `defaultValue` resizes this map's table, the new binding is still
+   *  inserted at the correct position; subclasses that might customise `get` go through the
+   *  generic implementation.
+   *
+   *  @param key the key to look up
+   *  @param defaultValue the value to bind to `key` if it is absent; evaluated only in that case
+   *  @return the value now associated with `key`
+   */
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     if (getClass != classOf[HashMap[?, ?]]) {
       // subclasses of HashMap might customise `get` ...
@@ -495,26 +602,65 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Adds a new key/value pair to this map, returning the previously bound value as an option.
+   *  If the map already contains a binding for `key`, its value is replaced by `value`.
+   *
+   *  @param key the key to add
+   *  @param value the value to bind to `key`
+   *  @return `Some(previousValue)` if `key` was already bound to `previousValue`, `None` if
+   *          `key` was not in the map before
+   */
   override def put(key: K, value: V): Option[V] = put0(key, value, getOld = true) match {
     case null => None
     case sm => sm
   }
 
+  /** Removes the binding for `key` from this map, if present.
+   *
+   *  @param key the key whose binding is removed
+   *  @return `Some(value)` if `key` was bound to `value` before the removal, `None` if `key`
+   *          was not in the map
+   */
   override def remove(key: K): Option[V] = remove0(key) match {
     case null => None
     case nd => Some(nd.value)
   }
 
+  /** Adds a new key/value pair to this map. If the map already contains a binding for `key`,
+   *  its value is replaced by `value`.
+   *
+   *  @param key the key to add
+   *  @param value the value to bind to `key`
+   */
   override def update(key: K, value: V): Unit = put0(key, value, getOld = false)
 
+  /** Adds a single key-value pair to this map, replacing the value of an existing binding for
+   *  the same key.
+   *
+   *  @param elem the key-value pair to add
+   *  @return this map
+   */
   def addOne(elem: (K, V)): this.type = { put0(elem._1, elem._2, getOld = false); this }
 
+  /** Removes the binding for `elem` from this map, if present.
+   *
+   *  @param elem the key whose binding is removed
+   *  @return this map
+   */
   def subtractOne(elem: K): this.type = { remove0(elem); this }
 
+  /** Returns the number of key-value pairs in this map; never `-1`, since the size of a hash map is always known. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this map contains no key-value pairs. */
   override def isEmpty: Boolean = size == 0
 
+  /** Applies a function `f` to each key-value pair of this map, passed as a tuple. The order
+   *  of traversal is not specified and may change when the map is modified.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each key-value pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = {
     val len = table.length
     var i = 0
@@ -525,6 +671,13 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Applies a function `f` to each key-value pair of this map, passing the key and value as
+   *  two separate arguments, without allocating tuples. The order of traversal is not
+   *  specified and may change when the map is modified.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each key and value
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = {
     val len = table.length
     var i = 0
@@ -535,8 +688,16 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Replaces this map with a serialization proxy during Java serialization. The proxy records
+   *  the current table length and load factor so deserialization can restore an equivalent map.
+   */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(new mutable.HashMap.DeserializationFactory[K, V](table.length, loadFactor), this)
 
+  /** Removes all key-value pairs from this map for which the predicate returns `false`.
+   *
+   *  @param p the predicate used to test key-value pairs; entries for which it returns `false` are removed
+   *  @return this map
+   */
   override def filterInPlace(p: (K, V) => Boolean): this.type = {
     if (nonEmpty) {
       var bucket = 0
@@ -586,11 +747,19 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     this
   }
 
+  /** Returns the companion object [[HashMap]], used to build hash maps of the same kind. */
   override def mapFactory: MapFactory[HashMap] = HashMap
 
+  /** The name of this collection class, `"HashMap"`, used as the prefix in `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "HashMap"
 
+  /** Returns the hash code of this map, computed as an unordered [[scala.util.hashing.MurmurHash3]]
+   *  hash of the key-value pair hashes (or `MurmurHash3.emptyMapHash` when the map is empty).
+   *  Each pair hash combines the key's original hash, recovered from the value cached in the
+   *  node (via `unimproveHash`) rather than recomputed, with the value's hash code, so the
+   *  result is the same as for other maps with equal contents.
+   */
   override def hashCode(): Int = {
     if (isEmpty) MurmurHash3.emptyMapHash
     else {
@@ -614,16 +783,46 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 @SerialVersionUID(3L)
 object HashMap extends MapFactory[HashMap] {
 
+  /** Creates a new, empty hash map with the default initial capacity (16) and load factor (0.75).
+   *
+   *  @tparam K the key type of the new map
+   *  @tparam V the value type of the new map
+   *  @return a new, empty `HashMap`
+   */
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 
+  /** Creates a new hash map containing the key-value pairs of the given collection. When the
+   *  size of `it` is known, the initial capacity is chosen so that all pairs can be added
+   *  without resizing the table.
+   *
+   *  @tparam K the key type of the new map
+   *  @tparam V the value type of the new map
+   *  @param it the collection whose key-value pairs are added to the new map
+   *  @return a new `HashMap` containing the key-value pairs of `it`
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): HashMap[K, V] = {
     val k = it.knownSize
     val cap = if(k > 0) ((k + 1).toDouble / defaultLoadFactor).toInt else defaultInitialCapacity
     new HashMap[K, V](cap, defaultLoadFactor).addAll(it)
   }
 
+  /** Creates a new builder for a `HashMap` with the default initial capacity and load factor.
+   *
+   *  @tparam K the key type of the map to build
+   *  @tparam V the value type of the map to build
+   *  @return a new builder producing a `HashMap`
+   */
   def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = newBuilder(defaultInitialCapacity, defaultLoadFactor)
 
+  /** Creates a new builder for a `HashMap` with the given initial capacity and load factor.
+   *  Size hints given to the builder are forwarded to the underlying map's `sizeHint`.
+   *
+   *  @tparam K the key type of the map to build
+   *  @tparam V the value type of the map to build
+   *  @param initialCapacity the initial capacity of the map's hash table
+   *  @param loadFactor the load factor of the map's hash table
+   *  @return a new builder producing a `HashMap`
+   */
   def newBuilder[K, V](initialCapacity: Int, loadFactor: Double): Builder[(K, V), HashMap[K, V]] =
     new GrowableBuilder[(K, V), HashMap[K, V]](new HashMap[K, V](initialCapacity, loadFactor)) {
       override def sizeHint(size: Int) = elems.sizeHint(size)

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -42,6 +42,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     with IterableFactoryDefaults[A, HashSet]
     with Serializable {
 
+  /** Creates a new, empty hash set with the default initial capacity (16) and the default load factor (0.75). */
   def this() = this(HashSet.defaultInitialCapacity, HashSet.defaultLoadFactor)
 
   import HashSet.Node
@@ -59,6 +60,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   private var contentSize = 0
 
+  /** Returns the number of elements in this set. */
   override def size: Int = contentSize
 
   /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
@@ -89,6 +91,11 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
 
+  /** Tests if some element is contained in this set.
+   *
+   *  @param elem the element to test for membership
+   *  @return `true` if `elem` is contained in this set, `false` otherwise
+   */
   override def contains(elem: A): Boolean = findNode(elem) ne null
 
   @`inline` private def findNode(elem: A): Node[A] | Null = {
@@ -99,16 +106,35 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Grows the internal table, if necessary, so that `size` elements can be stored without
+   *  triggering a resize. Never shrinks the table.
+   *
+   *  @param size the expected number of elements
+   */
   override def sizeHint(size: Int): Unit = {
     val target = tableSizeFor(((size + 1).toDouble / loadFactor).toInt)
     if(target > table.length) growTable(target)
   }
 
+  /** Adds a single element to this set, growing the table first if the size threshold
+   *  (capacity times load factor) would be reached.
+   *
+   *  @param elem the element to add
+   *  @return `true` if `elem` was not yet present and has been added, `false` if an equal
+   *          element was already in the set (which is then left unchanged)
+   */
   override def add(elem: A) : Boolean = {
     if(contentSize + 1 >= threshold) growTable(table.length * 2)
     addElem(elem, computeHash(elem))
   }
 
+  /** Adds all elements produced by `xs` to this set. Elements already present are left
+   *  unchanged. When `xs` is an `immutable.HashSet`, a `mutable.HashSet`, or a
+   *  `LinkedHashSet`, the hash codes cached in `xs` are reused instead of being recomputed.
+   *
+   *  @param xs the elements to add
+   *  @return this set
+   */
   override def addAll(xs: IterableOnce[A]^): this.type = {
     sizeHint(xs, delta = 0)
     (xs: @unchecked) match {
@@ -133,6 +159,13 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Removes all elements produced by `xs` from this set, stopping early once this set is
+   *  empty. When `xs` is an `immutable.HashSet`, a `mutable.HashSet`, or a `LinkedHashSet`,
+   *  the hash codes cached in `xs` are reused instead of being recomputed.
+   *
+   *  @param xs the elements to remove
+   *  @return this set
+   */
   override def subtractAll(xs: IterableOnce[A]^): this.type = {
     if (size == 0) {
       return this
@@ -219,6 +252,11 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Removes an element from this set.
+   *
+   *  @param elem the element to remove
+   *  @return `true` if `elem` was present and has been removed, `false` if it was not in the set
+   */
   override def remove(elem: A) : Boolean = remove(elem, computeHash(elem))
 
   private abstract class HashSetIterator[B] extends AbstractIterator[B] {
@@ -249,6 +287,9 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
       }
   }
 
+  /** Returns an iterator over the elements of this set. The iteration order is not specified
+   *  and may change when the set is modified.
+   */
   override def iterator: Iterator[A] = new HashSetIterator[A] {
     override protected def extract(nd: Node[A]): A = nd.key
   }
@@ -258,6 +299,14 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     override protected def extract(nd: Node[A]): Node[A] = nd
   }
 
+  /** Returns a [[Stepper]] for the elements of this set, stepping through the hash table directly.
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   *  @param shape the implicit `StepperShape` that selects the appropriate primitive or boxed `Stepper` for `A`
+   *  @return a `Stepper` over the elements of this set, specialized for primitives when the
+   *          resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`, and supporting
+   *          efficient splitting
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
@@ -314,6 +363,11 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Removes all elements from this set for which the predicate returns `false`.
+   *
+   *  @param p the predicate used to test elements; elements for which it returns `false` are removed
+   *  @return this set
+   */
   override def filterInPlace(p: A => Boolean): this.type = {
     if (nonEmpty) {
       var bucket = 0
@@ -374,21 +428,31 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   private def newThreshold(size: Int) = (size.toDouble * loadFactor).toInt
 
+  /** Removes all elements from this set. The internal table keeps its current capacity. */
   def clear(): Unit = {
     java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
     contentSize = 0
   }
 
+  /** Returns the companion object [[HashSet]], used to build hash sets of the same kind. */
   override def iterableFactory: IterableFactory[HashSet] = HashSet
 
   @`inline` def addOne(elem: A): this.type = { add(elem); this }
 
   @`inline` def subtractOne(elem: A): this.type = { remove(elem); this }
 
+  /** Returns the number of elements in this set; never `-1`, since the size of a hash set is always known. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this set contains no elements. */
   override def isEmpty: Boolean = size == 0
 
+  /** Applies a function `f` to each element of this set. The order of traversal is not
+   *  specified and may change when the set is modified.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each element
+   */
   override def foreach[U](f: A => U): Unit = {
     val len = table.length
     var i = 0
@@ -399,10 +463,19 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  /** Replaces this set with a serialization proxy during Java serialization. The proxy records
+   *  the current table length and load factor so deserialization can restore an equivalent set.
+   */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(new HashSet.DeserializationFactory[A](table.length, loadFactor), this)
 
+  /** The name of this collection class, `"HashSet"`, used as the prefix in `toString`. */
   override protected def className = "HashSet"
 
+  /** Returns the hash code of this set, computed as an unordered [[scala.util.hashing.MurmurHash3]]
+   *  hash of the element hash codes. The element hashes are recovered from the values cached in the
+   *  nodes (via `unimproveHash`) rather than recomputed, so the result is the same as for other sets
+   *  with equal elements.
+   */
   override def hashCode(): Int = {
     val setIterator = this.iterator
     val hashIterator: Iterator[Any] =
@@ -426,16 +499,42 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 @SerialVersionUID(3L)
 object HashSet extends IterableFactory[HashSet] {
 
+  /** Creates a new hash set containing the elements of the given collection. When the size of
+   *  `it` is known, the initial capacity is chosen so that all elements can be added without
+   *  resizing the table.
+   *
+   *  @tparam B the element type of the new set
+   *  @param it the collection whose elements are added to the new set
+   *  @return a new `HashSet` containing the elements of `it`
+   */
   def from[B](it: scala.collection.IterableOnce[B]^): HashSet[B] = {
     val k = it.knownSize
     val cap = if(k > 0) ((k + 1).toDouble / defaultLoadFactor).toInt else defaultInitialCapacity
     new HashSet[B](cap, defaultLoadFactor) ++= it
   }
 
+  /** Creates a new, empty hash set with the default initial capacity (16) and load factor (0.75).
+   *
+   *  @tparam A the element type of the new set
+   *  @return a new, empty `HashSet`
+   */
   def empty[A]: HashSet[A] = new HashSet[A]
 
+  /** Creates a new builder for a `HashSet` with the default initial capacity and load factor.
+   *
+   *  @tparam A the element type of the set to build
+   *  @return a new builder producing a `HashSet`
+   */
   def newBuilder[A]: Builder[A, HashSet[A]] = newBuilder(defaultInitialCapacity, defaultLoadFactor)
 
+  /** Creates a new builder for a `HashSet` with the given initial capacity and load factor.
+   *  Size hints given to the builder are forwarded to the underlying set's `sizeHint`.
+   *
+   *  @tparam A the element type of the set to build
+   *  @param initialCapacity the initial capacity of the set's hash table
+   *  @param loadFactor the load factor of the set's hash table
+   *  @return a new builder producing a `HashSet`
+   */
   def newBuilder[A](initialCapacity: Int, loadFactor: Double): Builder[A, HashSet[A]] =
     new GrowableBuilder[A, HashSet[A]](new HashSet[A](initialCapacity, loadFactor)) {
       override def sizeHint(size: Int) = elems.sizeHint(size)

--- a/library/src/scala/collection/mutable/HashTable.scala
+++ b/library/src/scala/collection/mutable/HashTable.scala
@@ -46,6 +46,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   // However, I'm afraid it's too late now for such breaking change.
   import HashTable._
 
+  /** The load factor of this hash table, expressed in units of 0.001 (the default `750` means 75%). */
   protected var _loadFactor = defaultLoadFactor
 
   /** The actual hash table. */
@@ -54,6 +55,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   /** The number of mappings contained in this hash table. */
   protected[collection] var tableSize: Int = 0
 
+  /** Returns the number of entries in this hash table. */
   final def size: Int = tableSize
 
   /** The next size value at which to resize (capacity * load factor). */
@@ -63,8 +65,14 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   @annotation.stableNull
   protected var sizemap: Array[Int] | Null = null
 
+  /** The seed passed to `improve` when computing bucket indices. Initialized from `tableSizeSeed`
+   *  and preserved across serialization so that entries hash to the same buckets after deserialization.
+   */
   protected var seedvalue: Int = tableSizeSeed
 
+  /** Returns a seed for `improve` derived from the current table length: the number of one bits
+   *  in `table.length - 1`, which for the power-of-two table length equals log2 of the capacity.
+   */
   protected def tableSizeSeed = Integer.bitCount(table.length - 1)
 
   /** The initial size of the hash table. */
@@ -143,6 +151,13 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   final def findEntry(key: A): Entry | Null =
     findEntry0(key, index(elemHashCode(key)))
 
+  /** Finds the entry with the given key in the bucket at index `h`, by walking the bucket's
+   *  linked list and comparing keys with `elemEquals`.
+   *
+   *  @param key the key to look up
+   *  @param h the bucket index to search, as computed by `index(elemHashCode(key))`
+   *  @return the entry whose key equals `key`, or `null` if the bucket contains no such entry
+   */
   protected[collection] final def findEntry0(key: A, h: Int): Entry | Null = {
     var e = table(h).asInstanceOf[Entry | Null]
     while (e != null && !elemEquals(e.key, key)) e = e.next
@@ -158,6 +173,14 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
     addEntry0(e, index(elemHashCode(e.key)))
   }
 
+  /** Adds entry `e` at the head of the bucket at index `h`, updates the size map and table size,
+   *  and resizes the table to twice its length if the new size exceeds the threshold.
+   *
+   *  Precondition: no entry with the same key exists, and `h` is the bucket index for `e.key`.
+   *
+   *  @param e the entry to add
+   *  @param h the bucket index at which to add it
+   */
   protected[collection] final def addEntry0(e: Entry, h: Int): Unit = {
     e.next = table(h).asInstanceOf[Entry | Null]
     table(h) = e
@@ -321,14 +344,30 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    * is converted into a parallel hash table, the size map is initialized, as it will be needed
    * there.
    */
+  /** Records the addition of an entry at table index `h` by incrementing the corresponding
+   *  size map counter. Does nothing if the size map is not initialized (`sizemap` is `null`).
+   *
+   *  @param h the table index at which an entry was added
+   */
   protected final def nnSizeMapAdd(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) += 1
   }
 
+  /** Records the removal of an entry at table index `h` by decrementing the corresponding
+   *  size map counter. Does nothing if the size map is not initialized (`sizemap` is `null`).
+   *
+   *  @param h the table index from which an entry was removed
+   */
   protected final def nnSizeMapRemove(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) -= 1
   }
 
+  /** Resets the size map for a table of the given length: reallocates it if the required
+   *  number of counters differs from the current one, otherwise fills the existing counters
+   *  with zero. Does nothing if the size map is not initialized (`sizemap` is `null`).
+   *
+   *  @param tableLength the length of the table the size map should cover
+   */
   protected final def nnSizeMapReset(tableLength: Int) = if (sizemap ne null) {
     val nsize = calcSizeMapSize(tableLength)
     if (sizemap.length != nsize) sizemap = new Array[Int](nsize)
@@ -337,14 +376,31 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
 
   private[collection] final def totalSizeMapBuckets = if (sizeMapBucketSize < table.length) 1 else table.length / sizeMapBucketSize
 
+  /** Returns the number of counters a size map needs for a table of the given length:
+   *  one per `sizeMapBucketSize` table entries, plus one.
+   *
+   *  @param tableLength the length of the table the size map should cover
+   */
   protected final def calcSizeMapSize(tableLength: Int) = (tableLength >> sizeMapBucketBitSize) + 1
 
   // discards the previous sizemap and only allocates a new one
+  /** Replaces the size map with a newly allocated, all-zero array of counters sized for a
+   *  table of the given length. Does not count the entries already in the table; use
+   *  `sizeMapInitAndRebuild` for that.
+   *
+   *  @param tableLength the length of the table the size map should cover
+   */
   protected def sizeMapInit(tableLength: Int): Unit = {
     sizemap = new Array[Int](calcSizeMapSize(tableLength))
   }
 
   // discards the previous sizemap and populates the new one
+  /** Replaces the size map with a newly allocated array of counters and populates it from
+   *  the table.
+   *
+   *  The number of blocks it fills is `totalSizeMapBuckets`, which is zero for a table
+   *  shorter than 32 and one otherwise, so this counts at most the first block.
+   */
   protected final def sizeMapInitAndRebuild() = {
     sizeMapInit(table.length)
 
@@ -375,15 +431,26 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
     println(sizemap.nn.to(collection.immutable.List))
   }
 
+  /** Disables the size map by setting `sizemap` to `null`, so the `nnSizeMap*` methods become no-ops. */
   protected final def sizeMapDisable() = sizemap = null
 
+  /** Returns `true` if the size map is currently initialized (`sizemap` is not `null`). */
   protected final def isSizeMapDefined = sizemap ne null
 
   // override to automatically initialize the size map
+  /** Whether the size map should always be initialized. Always `false` here; subclasses that
+   *  need the size map (such as parallel hash tables) override this to `true`.
+   */
   protected def alwaysInitSizeMap = false
 
   /* End of size map handling code */
 
+  /** Returns `true` if the two keys are equal according to `==` (universal equality).
+   *  Subclasses may override this to use a different equivalence.
+   *
+   *  @param key1 the first key to compare
+   *  @param key2 the second key to compare
+   */
   protected def elemEquals(key1: A, key2: A): Boolean = (key1 == key2)
 
   /** Note: we take the most significant bits of the hashcode, not the lower ones
@@ -410,11 +477,22 @@ private[collection] object HashTable {
 
   private[collection] final def capacity(expectedSize: Int) = nextPositivePowerOfTwo(expectedSize)
 
+  /** Hashing utilities shared by `HashTable` implementations: key hash codes, hash code
+   *  improvement, and the size map bucket constants.
+   *
+   *  @tparam KeyType the type of the keys to be hashed
+   */
   trait HashUtils[KeyType] {
+    /** The number of bits by which a table index is shifted to obtain its size map counter index; `5`. */
     protected final def sizeMapBucketBitSize = 5
     // so that:
+    /** The number of table entries covered by one size map counter: `1 << sizeMapBucketBitSize`, i.e. 32. */
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
+    /** Returns the hash code of `key`, as computed by `key.##`.
+     *
+     *  @param key the key to hash
+     */
     protected[collection] def elemHashCode(key: KeyType) = key.##
 
     /** Defer to high-quality bit mixing in [[scala.util.hashing]].
@@ -431,7 +509,9 @@ private[collection] object HashTable {
 
   /** Returns a power of two >= `target`.
    *
-   *  @param target the minimum value for the returned power of two
+   *  @param target the minimum value for the returned power of two; above `1 << 30` the
+   *                shift overflows and the result is `Int.MinValue` rather than a power
+   *                of two
    *  @return the smallest positive power of two that is greater than or equal to `target`
    */
   private[collection] def nextPositivePowerOfTwo(target: Int): Int = 1 << -numberOfLeadingZeros(target - 1)
@@ -443,6 +523,8 @@ private[collection] object HashTable {
  *  @tparam E the concrete entry type, forming a linked list via `next`
  */
 private[collection] trait HashEntry[A, E <: HashEntry[A, E]] {
+  /** The key stored in this entry. */
   val key: A
+  /** The next entry in the same bucket, or `null` if this is the last one. */
   var next: E | Null = compiletime.uninitialized
 }

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -26,11 +26,25 @@ import language.experimental.captureChecking
 abstract class ImmutableBuilder[-A, C <: IterableOnce[?]](empty: C)
   extends ReusableBuilder[A, C] {
 
+  /** The immutable collection accumulated so far. Since the collection is
+   *  immutable, subclasses accumulate elements by replacing this value with a
+   *  new collection extended with the added element.
+   */
   protected var elems: C = empty
 
+  /** Clears this builder by restoring `elems` to the empty collection given at construction. */
   def clear(): Unit = { elems = empty }
 
+  /** Returns the collection accumulated so far. As this is a reusable builder, the
+   *  builder remains usable afterwards, and later additions replace the accumulator
+   *  rather than modifying it, so a collection already returned is unaffected. That
+   *  holds for the immutable collections this is used with; a subclass whose `addOne`
+   *  mutates the accumulator in place would break it.
+   */
   def result(): C = elems
 
+  /** Returns the number of elements accumulated so far, if it can be cheaply
+   *  computed, -1 otherwise.
+   */
   override def knownSize: Int = elems.knownSize
 }

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -16,11 +16,17 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
+/** Base trait for mutable indexed sequences: mutable sequences with efficient
+ *  random access and `length`.
+ *
+ *  @tparam T the element type of the sequence
+ */
 trait IndexedSeq[T] extends Seq[T]
   with scala.collection.IndexedSeq[T]
   with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
   with IterableFactoryDefaults[T, IndexedSeq] {
 
+  /** The factory used to build mutable indexed sequences, the [[IndexedSeq$ `IndexedSeq`]] companion object, which delegates to [[ArrayBuffer]]. */
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
 }
 

--- a/library/src/scala/collection/mutable/Iterable.scala
+++ b/library/src/scala/collection/mutable/Iterable.scala
@@ -16,11 +16,16 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{IterableFactory, IterableFactoryDefaults}
 
+/** Base trait for mutable collections that can be iterated.
+ *
+ *  @tparam A the element type of the collection
+ */
 trait Iterable[A]
   extends collection.Iterable[A]
     with collection.IterableOps[A, Iterable, Iterable[A]]
     with IterableFactoryDefaults[A, Iterable] {
 
+  /** The factory used to build mutable collections, the [[Iterable$ `Iterable`]] companion object, which delegates to [[ArrayBuffer]]. */
   override def iterableFactory: IterableFactory[Iterable] = Iterable
 }
 

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -44,6 +44,7 @@ class LinkedHashMap[K, V]
     with MapFactoryDefaults[K, V, LinkedHashMap, Iterable]
     with DefaultSerializable {
 
+  /** The factory used to build linked hash maps, the [[LinkedHashMap$ `LinkedHashMap`]] companion object. */
   override def mapFactory: MapFactory[LinkedHashMap] = LinkedHashMap
 
   // stepper / keyStepper / valueStepper are not overridden to use XTableStepper because that stepper
@@ -53,9 +54,15 @@ class LinkedHashMap[K, V]
 
   private[collection] def _firstEntry: Entry | Null = firstEntry
 
+  /** The first entry in insertion order, the head of the doubly-linked entry
+   *  list, or `null` if this map is empty.
+   */
   @annotation.stableNull
   protected var firstEntry: Entry | Null = null
 
+  /** The last entry in insertion order, the tail of the doubly-linked entry
+   *  list, or `null` if this map is empty.
+   */
   @annotation.stableNull
   protected var lastEntry: Entry | Null = null
 
@@ -70,36 +77,73 @@ class LinkedHashMap[K, V]
 
   private var contentSize = 0
 
+  /** Returns the most recently inserted key/value binding of this map.
+   *
+   *  @return the last binding in insertion order
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def last: (K, V) =
     if (size > 0) (lastEntry.nn.key, lastEntry.nn.value)
     else throw new NoSuchElementException("Cannot call .last on empty LinkedHashMap")
 
+  /** Returns the most recently inserted key/value binding of this map wrapped
+   *  in `Some`, or `None` if this map is empty.
+   */
   override def lastOption: Option[(K, V)] =
     if (size > 0) Some((lastEntry.nn.key, lastEntry.nn.value))
     else None
 
+  /** Returns the first inserted key/value binding of this map.
+   *
+   *  @return the first binding in insertion order
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def head: (K, V) =
     if (size > 0) (firstEntry.nn.key, firstEntry.nn.value)
     else throw new NoSuchElementException("Cannot call .head on empty LinkedHashMap")
 
+  /** Returns the first inserted key/value binding of this map wrapped in
+   *  `Some`, or `None` if this map is empty.
+   */
   override def headOption: Option[(K, V)] =
     if (size > 0) Some((firstEntry.nn.key, firstEntry.nn.value))
     else None
 
+  /** The number of key/value bindings in this map. */
   override def size = contentSize
+  /** The number of key/value bindings in this map; always known, never `-1`. */
   override def knownSize: Int = size
+  /** Tests whether this map contains no bindings. */
   override def isEmpty: Boolean = size == 0
 
+  /** Returns the value associated with a key, wrapped in `Some`, or `None` if
+   *  the key is not in this map.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if `key` is bound to `value` in this map, `None` otherwise
+   */
   def get(key: K): Option[V] = {
     val e = findEntry(key)
     if (e == null) None
     else Some(e.value)
   }
+  /** Grows the hash table, if needed, so that this map can hold `size` bindings
+   *  without further resizing.
+   *
+   *  The table never shrinks: a hint smaller than the current capacity does nothing.
+   *
+   *  @param size the expected number of bindings
+   */
   override def sizeHint(size: Int): Unit = {
     val target = tableSizeFor(((size + 1).toDouble / LinkedHashMap.defaultLoadFactor).toInt)
     if (target > table.length) growTable(target)
   }
 
+  /** Tests whether this map contains a binding for a key.
+   *
+   *  @param key the key to look up
+   *  @return `true` if this map contains a binding for `key`
+   */
   override def contains(key: K): Boolean = {
     if (getClass eq classOf[LinkedHashMap[?, ?]])
       findEntry(key) != null
@@ -107,18 +151,55 @@ class LinkedHashMap[K, V]
       super.contains(key) // A subclass might override `get`, use the default implementation `contains`.
   }
 
+  /** Adds a new key/value binding to this map, or updates the value if the key
+   *  is already present.
+   *
+   *  If `key` is already in this map, only its value is replaced: the binding
+   *  keeps its original position in the iteration order. A new key is appended
+   *  at the end of the iteration order.
+   *
+   *  @param key the key to bind
+   *  @param value the value to associate with `key`
+   *  @return `Some(previousValue)` if `key` was already bound, `None` otherwise
+   */
   override def put(key: K, value: V): Option[V] = put0(key, value, getOld = true) match {
     case null => None
     case sm => sm
   }
 
+  /** Adds a new key/value binding to this map, or updates the value if the key
+   *  is already present.
+   *
+   *  Like [[put]], but does not report the previous value. An existing key
+   *  keeps its position in the iteration order; a new key is appended at the end.
+   *
+   *  @param key the key to bind
+   *  @param value the value to associate with `key`
+   */
   override def update(key: K, value: V): Unit = put0(key, value, getOld = false)
 
+  /** Removes the binding for a key from this map, if present.
+   *
+   *  @param key the key to remove
+   *  @return `Some(value)` if `key` was bound to `value`, `None` if `key` was not in this map
+   */
   override def remove(key: K): Option[V] = removeEntry0(key) match {
     case null => None
     case nd => Some(nd.value)
   }
 
+  /** Returns the value associated with a key, or a default value if the key is
+   *  not in this map.
+   *
+   *  Overridden to avoid the `Option` allocation of the inherited
+   *  implementation when this is a plain `LinkedHashMap` (not a subclass).
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value to return if `key` is not in this map; evaluated
+   *                 only in that case
+   *  @return the value bound to `key`, or `default` if `key` is not in this map
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     if (getClass != classOf[LinkedHashMap[?, ?]]) {
       // subclasses of LinkedHashMap might customise `get` ...
@@ -130,6 +211,18 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Returns the value associated with a key; if the key is not in this map,
+   *  binds it to the given default value and returns that value.
+   *
+   *  A newly inserted binding is appended at the end of the iteration order.
+   *  When this is a plain `LinkedHashMap` (not a subclass), the key is hashed
+   *  and located only once.
+   *
+   *  @param key the key to look up
+   *  @param defaultValue the value to bind to `key` if it is absent; evaluated
+   *                      only in that case
+   *  @return the value bound to `key`, either previously or by this call
+   */
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     if (getClass != classOf[LinkedHashMap[?, ?]]) {
       // subclasses of LinkedHashMap might customise `get` ...
@@ -217,11 +310,25 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Adds a single key/value binding to this map, updating the value if the
+   *  key is already present.
+   *
+   *  As with [[put]], an existing key keeps its position in the iteration
+   *  order; a new key is appended at the end.
+   *
+   *  @param kv the key/value pair to add
+   *  @return this map
+   */
   def addOne(kv: (K, V)): this.type = {
     put(kv._1, kv._2)
     this
   }
 
+  /** Removes the binding for a key from this map, if present.
+   *
+   *  @param key the key to remove
+   *  @return this map
+   */
   def subtractOne(key: K): this.type = {
     remove(key)
     this
@@ -236,6 +343,7 @@ class LinkedHashMap[K, V]
       else Iterator.empty.next()
   }
 
+  /** Returns an iterator over the key/value bindings of this map, in insertion order. */
   def iterator: Iterator[(K, V)] =
     if (size == 0) Iterator.empty
     else new LinkedHashMapIterator[(K, V)] {
@@ -245,13 +353,20 @@ class LinkedHashMap[K, V]
   @deprecated("LinkedKeySet is now strict and no longer used in the implementation of .keySet", "3.8.0")
   /** Note that a LinkedKeySet could be strict. */
   protected class LinkedKeySet extends KeySet {
+    /** The factory used to build transformed sets, the [[LinkedHashSet$ `LinkedHashSet`]] companion object. */
     override def iterableFactory: IterableFactory[collection.Set] = LinkedHashSet
   }
 
+  /** Returns a set view of the keys of this map, in insertion order.
+   *
+   *  The view is backed by this map, so later changes to the map are visible
+   *  through it. Transformations of the view build linked hash sets.
+   */
   override def keySet: collection.Set[K] = new MapOps.LazyKeySet(this) {
     override def iterableFactory: IterableFactory[collection.Set] = LinkedHashSet
   }
 
+  /** Returns an iterator over the keys of this map, in insertion order. */
   override def keysIterator: Iterator[K] =
     if (size == 0) Iterator.empty
     else new LinkedHashMapIterator[K] {
@@ -267,6 +382,21 @@ class LinkedHashMap[K, V]
 
   // Override updateWith for performance, so we can do the update while hashing
   // the input key only once and performing one lookup into the hash table
+  /** Updates, inserts, or removes the binding for a key according to a
+   *  remapping function.
+   *
+   *  The function receives `Some(value)` if `key` is currently bound to
+   *  `value`, `None` otherwise. If it returns `Some(newValue)`, the binding is
+   *  updated in place (an existing key keeps its position in the iteration
+   *  order; a new key is appended at the end); if it returns `None`, any
+   *  existing binding is removed. When this is a plain `LinkedHashMap` (not a
+   *  subclass), the key is hashed and located only once.
+   *
+   *  @param key the key whose binding to update
+   *  @param remappingFunction the function computing the new binding from the current one
+   *  @return the value returned by `remappingFunction`: the new value wrapped
+   *          in `Some`, or `None` if the binding was removed or absent
+   */
   override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
     if (getClass != classOf[LinkedHashMap[?, ?]]) {
       // subclasses of LinkedHashMap might customise `get` ...
@@ -323,6 +453,7 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Returns an iterator over the values of this map, in the insertion order of their keys. */
   override def valuesIterator: Iterator[V] =
     if (size == 0) Iterator.empty
     else new LinkedHashMapIterator[V] {
@@ -330,6 +461,11 @@ class LinkedHashMap[K, V]
     }
 
 
+  /** Applies a function to each key/value binding of this map, in insertion order.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function applied to each binding, as a pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = {
     var cur = firstEntry
     while (cur ne null) {
@@ -338,6 +474,12 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Applies a function to each key/value binding of this map, in insertion
+   *  order, passing key and value as two arguments rather than as a pair.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function applied to each key and value
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = {
     var cur = firstEntry
     while (cur ne null) {
@@ -346,6 +488,7 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Removes all bindings from this map. The hash table keeps its current capacity. */
   override def clear(): Unit = {
     java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
     contentSize = 0
@@ -470,6 +613,10 @@ class LinkedHashMap[K, V]
     }
   }
 
+  /** Returns a hash code for this map, combining the hashes of its bindings
+   *  without regard to order, so it is consistent with `equals` across map
+   *  implementations.
+   */
   override def hashCode(): Int = {
     if (isEmpty) MurmurHash3.emptyMapHash
     else {
@@ -484,6 +631,7 @@ class LinkedHashMap[K, V]
       MurmurHash3.unorderedHash(tupleHashIterator, MurmurHash3.mapSeed)
     }
   }
+  /** The prefix used in the string representation of this map, `"LinkedHashMap"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "LinkedHashMap"
 }
@@ -495,8 +643,23 @@ class LinkedHashMap[K, V]
 @SerialVersionUID(3L)
 object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
+  /** Creates a new empty linked hash map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   */
   def empty[K, V] = new LinkedHashMap[K, V]
 
+  /** Creates a new linked hash map containing the key/value pairs of the given
+   *  collection, in its iteration order.
+   *
+   *  If `it` contains a key more than once, the last value for that key wins,
+   *  but the key keeps the position of its first occurrence.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param it the collection of key/value pairs
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^) = {
     val newlhm = empty[K, V]
     newlhm.sizeHint(it, delta = 0)
@@ -504,6 +667,12 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
     newlhm
   }
 
+  /** Returns a new builder that accumulates key/value pairs into a linked hash map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @return a builder for a `LinkedHashMap[K, V]`
+   */
   def newBuilder[K, V]: GrowableBuilder[(K, V), LinkedHashMap[K, V]] = new GrowableBuilder(empty[K, V])
 
   /** Class for the linked hash map entry, used internally.

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -40,6 +40,7 @@ class LinkedHashSet[A]
     with IterableFactoryDefaults[A, LinkedHashSet]
     with DefaultSerializable {
 
+  /** The factory used to build linked hash sets, the [[LinkedHashSet$ `LinkedHashSet`]] companion object. */
   override def iterableFactory: IterableFactory[LinkedHashSet] = LinkedHashSet
 
   // stepper is not overridden to use XTableStepper because that stepper would not return the
@@ -47,9 +48,15 @@ class LinkedHashSet[A]
 
   /*private*/ type Entry = LinkedHashSet.Entry[A]
 
+  /** The first entry in insertion order, the head of the doubly-linked entry
+   *  list, or `null` if this set is empty.
+   */
   @annotation.stableNull
   protected var firstEntry: Entry | Null = null
 
+  /** The last entry in insertion order, the tail of the doubly-linked entry
+   *  list, or `null` if this set is empty.
+   */
   @annotation.stableNull
   protected var lastEntry: Entry | Null = null
 
@@ -64,49 +71,107 @@ class LinkedHashSet[A]
 
   private var contentSize = 0
 
+  /** Returns the most recently inserted element of this set.
+   *
+   *  @return the last element in insertion order
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def last: A =
     if (size > 0) lastEntry.nn.key
     else throw new NoSuchElementException("Cannot call .last on empty LinkedHashSet")
 
+  /** Returns the most recently inserted element of this set wrapped in `Some`,
+   *  or `None` if this set is empty.
+   */
   override def lastOption: Option[A] =
     if (size > 0) Some(lastEntry.nn.key)
     else None
 
+  /** Returns the first inserted element of this set.
+   *
+   *  @return the first element in insertion order
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def head: A =
     if (size > 0) firstEntry.nn.key
     else throw new NoSuchElementException("Cannot call .head on empty LinkedHashSet")
 
+  /** Returns the first inserted element of this set wrapped in `Some`, or
+   *  `None` if this set is empty.
+   */
   override def headOption: Option[A] =
     if (size > 0) Some(firstEntry.nn.key)
     else None
 
+  /** The number of elements in this set. */
   override def size: Int = contentSize
+  /** The number of elements in this set; always known, never `-1`. */
   override def knownSize: Int = size
+  /** Tests whether this set contains no elements. */
   override def isEmpty: Boolean = size == 0
 
+  /** Tests whether an element is in this set.
+   *
+   *  @param elem the element to look for
+   *  @return `true` if this set contains `elem`
+   */
   def contains(elem: A): Boolean = findEntry(elem) ne null
 
+  /** Grows the hash table, if needed, so that this set can hold `size` elements
+   *  without further resizing.
+   *
+   *  The table never shrinks: a hint smaller than the current capacity does nothing.
+   *
+   *  @param size the expected number of elements
+   */
   override def sizeHint(size: Int): Unit = {
     val target = tableSizeFor(((size + 1).toDouble / LinkedHashSet.defaultLoadFactor).toInt)
     if (target > table.length) growTable(target)
   }
 
+  /** Adds an element to this set, if it is not already present.
+   *
+   *  A new element is appended at the end of the iteration order. If `elem`
+   *  is already in this set, nothing changes: in particular, the element
+   *  keeps its original position in the iteration order.
+   *
+   *  @param elem the element to add
+   *  @return `true` if `elem` was added, `false` if it was already present
+   */
   override def add(elem: A): Boolean = {
     if (contentSize + 1 >= threshold) growTable(table.length * 2)
     val hash = computeHash(elem)
     put0(elem, hash, index(hash))
   }
 
+  /** Adds an element to this set, if it is not already present.
+   *
+   *  As with [[add]], a new element is appended at the end of the iteration
+   *  order and an existing element keeps its position.
+   *
+   *  @param elem the element to add
+   *  @return this set
+   */
   def addOne(elem: A): this.type = {
     add(elem)
     this
   }
 
+  /** Removes an element from this set, if present.
+   *
+   *  @param elem the element to remove
+   *  @return this set
+   */
   def subtractOne(elem: A): this.type = {
     remove(elem)
     this
   }
 
+  /** Removes an element from this set, if present.
+   *
+   *  @param elem the element to remove
+   *  @return `true` if `elem` was present and has been removed, `false` otherwise
+   */
   override def remove(elem: A): Boolean = remove0(elem, computeHash(elem))
 
   private abstract class LinkedHashSetIterator[T] extends AbstractIterator[T] {
@@ -118,6 +183,7 @@ class LinkedHashSet[A]
       else Iterator.empty.next()
   }
 
+  /** Returns an iterator over the elements of this set, in insertion order. */
   def iterator: Iterator[A] = new LinkedHashSetIterator[A] {
     override def extract(nd: Entry): A = nd.key
   }
@@ -126,6 +192,11 @@ class LinkedHashSet[A]
     override def extract(nd: Entry): Entry = nd
   }
 
+  /** Applies a function to each element of this set, in insertion order.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function applied to each element
+   */
   override def foreach[U](f: A => U): Unit = {
     var cur: Entry | Null = firstEntry
     while (cur ne null) {
@@ -134,6 +205,7 @@ class LinkedHashSet[A]
     }
   }
 
+  /** Removes all elements from this set. The hash table keeps its current capacity. */
   override def clear(): Unit = {
     java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
     contentSize = 0
@@ -298,6 +370,10 @@ class LinkedHashSet[A]
     }
   }
 
+  /** Returns a hash code for this set, combining the hashes of its elements
+   *  without regard to order, so it is consistent with `equals` across set
+   *  implementations.
+   */
   override def hashCode(): Int = {
     val setHashIterator =
       if (isEmpty) this.iterator
@@ -314,6 +390,7 @@ class LinkedHashSet[A]
     MurmurHash3.unorderedHash(setHashIterator, MurmurHash3.setSeed)
   }
 
+  /** The prefix used in the string representation of this set, `"LinkedHashSet"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "LinkedHashSet"
 }
@@ -325,8 +402,22 @@ class LinkedHashSet[A]
 @SerialVersionUID(3L)
 object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
+  /** Creates a new empty linked hash set.
+   *
+   *  @tparam A the element type of the set
+   *  @return a new empty `LinkedHashSet[A]`
+   */
   override def empty[A]: LinkedHashSet[A] = new LinkedHashSet[A]
 
+  /** Creates a new linked hash set containing the elements of the given
+   *  collection, in its iteration order.
+   *
+   *  If `it` contains an element more than once, the element keeps the
+   *  position of its first occurrence.
+   *
+   *  @tparam E the element type of the set
+   *  @param it the collection of elements
+   */
   def from[E](it: collection.IterableOnce[E]^) = {
     val newlhs = empty[E]
     newlhs.sizeHint(it, delta = 0)
@@ -334,6 +425,11 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
     newlhs
   }
 
+  /** Returns a new builder that accumulates elements into a linked hash set.
+   *
+   *  @tparam A the element type of the set
+   *  @return a builder for a `LinkedHashSet[A]`
+   */
   def newBuilder[A]: GrowableBuilder[A, LinkedHashSet[A]] = new GrowableBuilder(empty[A])
 
   /** Class for the linked hash set entry, used internally.

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -56,16 +56,32 @@ class ListBuffer[A]
 
   private type Predecessor = ::[A] | Null
 
+  /** Returns an iterator over the elements of this buffer.
+   *
+   *  The iterator is fail-fast: if the buffer is mutated after the iterator's
+   *  creation, `hasNext` throws a [[java.util.ConcurrentModificationException]].
+   */
   def iterator: Iterator[A] = new MutationTracker.CheckedIterator(first.iterator, mutationCount)
 
+  /** The companion object `ListBuffer`, used by transformation methods to build new list buffers. */
   override def iterableFactory: SeqFactory[ListBuffer] = ListBuffer
 
+  /** Returns the element of this buffer at index `i`.
+   *
+   *  Takes time linear in `i`.
+   *
+   *  @param i the index of the element to return
+   *  @throws IndexOutOfBoundsException if `i < 0` or `i >= length`
+   */
   @throws[IndexOutOfBoundsException]
   def apply(i: Int) = first.apply(i)
 
+  /** Returns the number of elements in this buffer, in constant time. */
   def length = len
+  /** Returns the number of elements in this buffer. Never `-1`, as the size is always known. */
   override def knownSize = len
 
+  /** Returns `true` if this buffer contains no elements. */
   override def isEmpty: Boolean = len == 0
 
   private def copyElems(): Unit = {
@@ -83,6 +99,16 @@ class ListBuffer[A]
   }
 
   // Avoids copying where possible.
+  /** Returns the contents of this buffer as an immutable [[scala.collection.immutable.List]].
+   *
+   *  Takes constant time: the buffer's internal list is returned directly rather
+   *  than copied. The buffer is instead marked as aliased, and any later operation
+   *  that would modify the shared cells copies them first, so the returned list is
+   *  never affected by later changes to the buffer. Operations that abandon those
+   *  cells rather than modify them, such as `clear`, `mapInPlace` and
+   *  `flatMapInPlace`, need no copy. The elements are safely published,
+   *  so the returned list may be shared with other threads.
+   */
   override def toList: List[A] = {
     aliased = nonEmpty
     // We've accumulated a number of mutations to `List.tail` by this stage.
@@ -92,6 +118,12 @@ class ListBuffer[A]
     first
   }
 
+  /** Returns the contents of this buffer as an immutable [[scala.collection.immutable.List]], like `toList`.
+   *
+   *  The buffer remains valid afterwards: it can be mutated further, with the shared
+   *  cells copied first where an operation would modify them, leaving the returned
+   *  list unchanged, or reused after `clear()`.
+   */
   def result(): immutable.List[A] = toList
 
   /** Prepends the elements of this buffer to a given list
@@ -108,6 +140,10 @@ class ListBuffer[A]
     }
   }
 
+  /** Removes all elements from this buffer, in constant time.
+   *
+   *  Lists previously returned by `toList` or `result()` are not affected.
+   */
   def clear(): Unit = {
     mutationCount += 1
     first = Nil
@@ -116,6 +152,14 @@ class ListBuffer[A]
     aliased = false
   }
 
+  /** Appends `elem` to this buffer.
+   *
+   *  Takes constant time, unless the buffer's list is aliased by an earlier
+   *  `toList` or `result()` call, in which case the elements are first copied.
+   *
+   *  @param elem the element to append
+   *  @return this $coll
+   */
   final def addOne(elem: A): this.type = {
     ensureUnaliased()
     val last1 = new ::[A](elem, Nil)
@@ -145,6 +189,14 @@ class ListBuffer[A]
     this
   }
 
+  /** Appends all elements of `xs` to this buffer.
+   *
+   *  The elements are first copied into a fresh list, so `xs` may be this
+   *  buffer itself or a list it previously returned.
+   *
+   *  @param xs the collection containing the elements to append
+   *  @return this $coll
+   */
   override final def addAll(xs: IterableOnce[A]^): this.type = {
     val it = xs.iterator
     if (it.hasNext) {
@@ -158,6 +210,14 @@ class ListBuffer[A]
     this
   }
 
+  /** Removes the first occurrence of `elem` from this buffer, if any.
+   *
+   *  Takes time linear in the buffer size. If this buffer does not contain
+   *  `elem`, it is unchanged.
+   *
+   *  @param elem the element to remove
+   *  @return this $coll
+   */
   override def subtractOne(elem: A): this.type = {
     ensureUnaliased()
     if (isEmpty) {}
@@ -209,6 +269,15 @@ class ListBuffer[A]
   private def getNext(p: Predecessor): List[A] =
     if (p == null) first else p.next
 
+  /** Replaces the element at index `idx` with `elem`.
+   *
+   *  Takes time linear in `idx`, or in the buffer size if a previous `toList` or
+   *  `result` left it aliased, since the shared cells are copied first.
+   *
+   *  @param idx the index of the element to replace
+   *  @param elem the new element
+   *  @throws IndexOutOfBoundsException if `idx < 0` or `idx >= length`
+   */
   def update(idx: Int, elem: A): Unit = {
     ensureUnaliased()
     if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
@@ -229,6 +298,19 @@ class ListBuffer[A]
     }
   }
 
+  /** Inserts `elem` at index `idx` into this buffer.
+   *
+   *  The elements at indices `idx` and above have their indices increased by
+   *  one. Takes time linear in `idx`, or constant time when prepending
+   *  (`idx == 0`) or appending (`idx == length`), except that a buffer left
+   *  aliased by an earlier `toList` or `result` is copied first, which is
+   *  linear in its size whatever `idx` is.
+   *
+   *  @param idx the index where the element is inserted
+   *  @param elem the element to insert
+   *  @throws IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *          `0 <= idx <= length`
+   */
   def insert(idx: Int, elem: A): Unit = {
     ensureUnaliased()
     if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
@@ -241,6 +323,12 @@ class ListBuffer[A]
     }
   }
 
+  /** Prepends `elem` to this buffer, in constant time, or in time linear in its
+   *  size if an earlier `toList` or `result` left it aliased.
+   *
+   *  @param elem the element to prepend
+   *  @return this $coll
+   */
   def prepend(elem: A): this.type = {
     insert(0, elem)
     this
@@ -257,6 +345,19 @@ class ListBuffer[A]
     }
   }
 
+  /** Inserts all elements of `elems` at index `idx` into this buffer.
+   *
+   *  The elements at indices `idx` and above have their indices increased by
+   *  the number of inserted elements. If `idx == length`, the elements are
+   *  appended. The bounds are checked before `elems` is iterated, and the new
+   *  elements are copied into a fresh list before this buffer is modified, so
+   *  `elems` may be this buffer itself.
+   *
+   *  @param idx the index where the elements are inserted
+   *  @param elems the collection containing the elements to insert
+   *  @throws IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *          `0 <= idx <= length`
+   */
   def insertAll(idx: Int, elems: IterableOnce[A]^): Unit = {
     if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     val it = elems.iterator
@@ -270,6 +371,16 @@ class ListBuffer[A]
     }
   }
 
+  /** Removes and returns the element at index `idx`.
+   *
+   *  The elements at higher indices have their indices decreased by one. Takes
+   *  time linear in `idx`, or in the buffer size if an earlier `toList` or
+   *  `result` left it aliased.
+   *
+   *  @param idx the index of the element to remove
+   *  @return the removed element
+   *  @throws IndexOutOfBoundsException if `idx < 0` or `idx >= length`
+   */
   def remove(idx: Int): A = {
     ensureUnaliased()
     if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
@@ -286,6 +397,18 @@ class ListBuffer[A]
     nx.head
   }
 
+  /** Removes `count` elements starting at index `idx`.
+   *
+   *  Takes time linear in `idx + count`, or in the buffer size if `count` is
+   *  positive and an earlier `toList` or `result` left it aliased. If `count`
+   *  is zero, this buffer is unchanged and the bounds are not checked.
+   *
+   *  @param idx the index of the first element to remove
+   *  @param count the number of elements to remove
+   *  @throws IndexOutOfBoundsException if `count > 0` and the index `idx` is not in
+   *          the valid range `0 <= idx <= length - count`
+   *  @throws IllegalArgumentException if `count < 0`
+   */
   def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
       ensureUnaliased()
@@ -369,6 +492,20 @@ class ListBuffer[A]
     this
   }
 
+  /** Replaces a slice of elements in this $coll by another sequence of elements.
+   *
+   *  `from` and `replaced` are clamped: patching at negative indices is the
+   *  same as patching starting at 0, patching at indices at or larger than the
+   *  length appends the patch to the end, and an excessive `replaced` count is
+   *  reduced to the available elements. Implemented by removing the replaced
+   *  elements and inserting the patch in their place; never fails on
+   *  out-of-range arguments.
+   *
+   *  @param from the index of the first replaced element
+   *  @param patch the replacement sequence
+   *  @param replaced the number of elements to drop in the original $coll
+   *  @return this $coll
+   */
   def patchInPlace(from: Int, patch: collection.IterableOnce[A]^, replaced: Int): this.type = {
     val _len = len
     val _from = math.max(from, 0)         // normalized
@@ -409,6 +546,7 @@ class ListBuffer[A]
    */
   override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
 
+  /** The prefix of this $coll's `toString` representation, `"ListBuffer"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "ListBuffer"
 
@@ -417,9 +555,29 @@ class ListBuffer[A]
 @SerialVersionUID(3L)
 object ListBuffer extends StrictOptimizedSeqFactory[ListBuffer] {
 
+  /** Creates a list buffer containing the elements of `coll`.
+   *
+   *  @tparam A the element type
+   *  @param coll the collection providing the elements
+   *  @return a new `ListBuffer` with the elements of `coll` in order
+   */
   def from[A](coll: collection.IterableOnce[A]^): ListBuffer[A] = new ListBuffer[A].freshFrom(coll)
 
+  /** Returns a new builder that produces a `ListBuffer`.
+   *
+   *  A `ListBuffer` is itself a builder, but one producing a `List`; the
+   *  builder returned here appends to a list buffer and returns the buffer
+   *  itself as its result.
+   *
+   *  @tparam A the element type
+   *  @return a builder producing a `ListBuffer`
+   */
   def newBuilder[A]: Builder[A, ListBuffer[A]] = new GrowableBuilder(empty[A])
 
+  /** Creates a new, empty list buffer.
+   *
+   *  @tparam A the element type
+   *  @return a new empty `ListBuffer`
+   */
   def empty[A]: ListBuffer[A] = new ListBuffer[A]
 }

--- a/library/src/scala/collection/mutable/ListMap.scala
+++ b/library/src/scala/collection/mutable/ListMap.scala
@@ -40,20 +40,50 @@ class ListMap[K, V]
     with MapFactoryDefaults[K, V, ListMap, Iterable]
     with DefaultSerializable {
 
+  /** The factory used to build mutable list maps, the [[ListMap$ `ListMap`]] companion object. */
   override def mapFactory: MapFactory[ListMap] = ListMap
 
   private var elems: List[(K, V)] = List()
   private var siz: Int = 0
 
+  /** Returns the value associated with a key, wrapped in `Some`, or `None` if
+   *  the key is not in this map.
+   *
+   *  Searches the backing list linearly, taking time proportional to the size
+   *  of this map.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if `key` is bound to `value` in this map, `None` otherwise
+   */
   def get(key: K): Option[V] = elems find (_._1 == key) map (_._2)
+  /** Returns an iterator over the key/value bindings of this map, in the
+   *  order of the backing list.
+   */
   def iterator: Iterator[(K, V)] = elems.iterator
 
+  /** Adds a new key/value binding to this map, or replaces the value if the
+   *  key is already present.
+   *
+   *  Removes any existing binding for the key and prepends the new binding to
+   *  the backing list, taking time proportional to the size of this map. If
+   *  the key was already present, the originally stored key instance is kept.
+   *
+   *  @param kv the key/value pair to add
+   *  @return this map
+   */
   final override def addOne(kv: (K, V)) = {
     val (e, key0) = remove(kv._1, elems, List())
     elems = (key0, kv._2) :: e
     siz += 1; this
   }
 
+  /** Removes the binding for a key from this map, if present.
+   *
+   *  Takes time proportional to the size of this map.
+   *
+   *  @param key the key to remove
+   *  @return this map
+   */
   final override def subtractOne(key: K) = { elems = remove(key, elems, List())._1; this }
 
   @tailrec
@@ -63,11 +93,16 @@ class ListMap[K, V]
     else remove(key, elems.tail, elems.head :: acc)
   }
 
+  /** Removes all bindings from this map. */
   final override def clear(): Unit = { elems = List(); siz = 0 }
 
+  /** The number of key/value bindings in this map. */
   final override def size: Int = siz
+  /** The number of key/value bindings in this map; always known, never `-1`. */
   override def knownSize: Int = size
+  /** Tests whether this map contains no bindings. */
   override def isEmpty: Boolean = size == 0
+  /** The prefix used in the string representation of this map, `"ListMap"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "ListMap"
 }
@@ -79,7 +114,29 @@ class ListMap[K, V]
 @SerialVersionUID(3L)
 @deprecated("Use an immutable.ListMap assigned to a var instead of mutable.ListMap", "2.13.0")
 object ListMap extends MapFactory[ListMap] {
+  /** Creates a new empty mutable list map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @return a new empty `ListMap[K, V]`
+   */
   def empty[K, V]: ListMap[K, V] = new ListMap[K, V]
+  /** Creates a new mutable list map containing the key/value pairs of the
+   *  given collection.
+   *
+   *  If `it` contains a key more than once, the last value for that key wins.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param it the collection of key/value pairs
+   *  @return a new list map containing the pairs of `it`
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): ListMap[K,V] = Growable.from(empty[K, V], it)
+  /** Returns a new builder that accumulates key/value pairs into a mutable list map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @return a builder for a `ListMap[K, V]`
+   */
   def newBuilder[K, V]: Builder[(K, V), ListMap[K,V]] = new GrowableBuilder(empty[K, V])
 }

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -46,9 +46,17 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     with Serializable {
   import LongMap._
 
+  /** Creates a new empty `LongMap` whose `apply` throws `NoSuchElementException` for missing keys. */
   def this() = this(LongMap.exceptionDefault, 16, initBlank = true)
 
   // TODO: override clear() with an optimization more tailored for efficiency.
+  /** Builds a new `LongMap` containing the key/value pairs of the given collection.
+   *
+   *  If several pairs share a key, the last one wins.
+   *
+   *  @param coll the key/value pairs to build the map from
+   *  @return a new `LongMap` containing the pairs of `coll`
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(Long, V)]^): LongMap[V] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder
@@ -56,6 +64,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     b.addAll(coll)
     b.result()
   }
+  /** Returns a new empty builder producing a `LongMap` of the same value type. */
   override protected def newSpecificBuilder: Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
 
   /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping.
@@ -105,9 +114,13 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     mask = m; extraKeys = ek; zeroValue = zv; minValue = mv; _size = sz; _vacant = vc; _keys = kz; _values = vz
   }
 
+  /** Returns the number of key/value pairs in this map, counting any entries for the keys `0` and `Long.MinValue`, which are stored outside the hash table. */
   override def size: Int = _size + (extraKeys+1)/2
+  /** Returns `size`; the number of key/value pairs is always known. */
   override def knownSize: Int = size
+  /** Returns `true` if this map contains no key/value pairs. */
   override def isEmpty: Boolean = size == 0
+  /** Returns a new empty `LongMap`. Unlike this map, the result carries no default-value function: its `apply` throws `NoSuchElementException` for missing keys. */
   override def empty: LongMap[V] = new LongMap()
 
   private def imbalanced: Boolean =
@@ -152,11 +165,21 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     o
   }
 
+  /** Tests whether a key is present in this map.
+   *
+   *  @param key the key to look up
+   *  @return `true` if `key` has an associated value, `false` otherwise
+   */
   override def contains(key: Long): Boolean = {
     if (key == -key) (((key>>>63).toInt+1) & extraKeys) != 0
     else seekEntry(key) >= 0
   }
 
+  /** Optionally returns the value associated with a key.
+   *
+   *  @param key the key to look up
+   *  @return `Some` of the value associated with `key`, or `None` if `key` is not present
+   */
   override def get(key: Long): Option[V] = {
     if (key == -key) {
       if ((((key>>>63).toInt+1) & extraKeys) == 0) None
@@ -169,6 +192,13 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
+  /** Returns the value associated with a key, or a computed alternative if the key is not present.
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the alternative result; evaluated only if `key` is not present
+   *  @return the value associated with `key`, or `default` if `key` is not present
+   */
   override def getOrElse[V1 >: V](key: Long, default: => V1): V1 = {
     if (key == -key) {
       if ((((key>>>63).toInt+1) & extraKeys) == 0) default
@@ -181,6 +211,16 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
+  /** Returns the value associated with a key, computing and storing a value if the key is not present.
+   *
+   *  If `key` is not present, evaluates `defaultValue`, adds the resulting entry to
+   *  this map, and returns the result. `defaultValue` may itself query or modify this
+   *  map; the entry for `key` is added after it completes.
+   *
+   *  @param key the key to look up
+   *  @param defaultValue the value to store and return if `key` is not present; evaluated at most once
+   *  @return the value associated with `key`, either pre-existing or newly stored
+   */
   override def getOrElseUpdate(key: Long, defaultValue: => V): V = {
     if (key == -key) {
       val kbits = (key>>>63).toInt + 1
@@ -302,6 +342,12 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    */
   def repack(): Unit = repack(repackMask(mask, _size = _size, _vacant = _vacant))
 
+  /** Adds a key/value pair to this map, returning any value previously associated with the key.
+   *
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   *  @return `Some` of the value previously associated with `key`, or `None` if `key` was not present
+   */
   override def put(key: Long, value: V): Option[V] = {
     if (key == -key) {
       if (key == 0) {
@@ -384,8 +430,23 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    */
   @inline final def addOne(key: Long, value: V): this.type = { update(key, value); this }
 
+  /** Adds a key/value pair to this map and returns the map.
+   *
+   *  @param kv the key/value pair to add; any existing value for the same key is overwritten
+   *  @return this map after the entry has been added
+   */
   @inline override final def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
 
+  /** Removes a key from this map, and returns the map.
+   *
+   *  For the keys `0` and `Long.MinValue` the dedicated slot is simply emptied.
+   *  For any other key that is present, the entry is removed and its hash table
+   *  slot is marked vacant; vacant slots are reclaimed on a later `repack`.
+   *  Does nothing if `key` is not present.
+   *
+   *  @param key the key to remove
+   *  @return this map after the removal
+   */
   def subtractOne(key: Long): this.type = {
     if (key == -key) {
       if (key == 0L) {
@@ -409,6 +470,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     this
   }
 
+  /** Returns an iterator over the key/value pairs of this map.
+   *
+   *  Entries for the keys `0` and `Long.MinValue`, if present, are produced
+   *  first, in that order, followed by the remaining entries.
+   */
   def iterator: Iterator[(Long, V)] = new AbstractIterator[(Long, V)] {
     private val kz = _keys
     private val vz = _values
@@ -448,9 +514,19 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   // TODO PERF override these for efficiency. See immutable.LongMap for how to organize the code.
+  /** Returns an iterator over the keys of this map, in the same order as `iterator`. */
   override def keysIterator: Iterator[Long] = super.keysIterator
+  /** Returns an iterator over the values of this map, in the same order as `iterator`. */
   override def valuesIterator: Iterator[V] = super.valuesIterator
 
+  /** Applies a function to each key/value pair of this map.
+   *
+   *  Entries for the keys `0` and `Long.MinValue`, if present, are visited
+   *  first, in that order.
+   *
+   *  @tparam U the result type of the function; the results are discarded
+   *  @param f the function to apply to each key/value pair
+   */
   override def foreach[U](f: ((Long,V)) => U): Unit = {
     if ((extraKeys & 1) == 1) f((0L, zeroValue.asInstanceOf[V]))
     if ((extraKeys & 2) == 2) f((Long.MinValue, minValue.asInstanceOf[V]))
@@ -465,6 +541,14 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
+  /** Applies a function to each key/value pair of this map, passing key and value as separate arguments.
+   *
+   *  Unlike `foreach`, does not allocate a tuple per entry. Entries for the
+   *  keys `0` and `Long.MinValue`, if present, are visited first, in that order.
+   *
+   *  @tparam U the result type of the function; the results are discarded
+   *  @param f the function to apply to each key and value
+   */
   override def foreachEntry[U](f: (Long,V) => U): Unit = {
     if ((extraKeys & 1) == 1) f(0L, zeroValue.asInstanceOf[V])
     if ((extraKeys & 2) == 2) f(Long.MinValue, minValue.asInstanceOf[V])
@@ -479,6 +563,10 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
+  /** Returns a copy of this map with the same entries, default-value function, and internal layout.
+   *
+   *  Later changes to the copy do not affect this map, and vice versa.
+   */
   override def clone(): LongMap[V] = {
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)
     val vz = java.util.Arrays.copyOf(_values,  _values.length)
@@ -487,6 +575,14 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     lm
   }
 
+  /** Returns a new `LongMap` containing the entries of this map and one additional key/value pair.
+   *
+   *  This map is not modified.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param kv the key/value pair to add; it overrides any entry of this map with the same key
+   *  @return a new `LongMap` with the entries of this map plus `kv`
+   */
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def +[V1 >: V](kv: (Long, V1)): LongMap[V1] = {
     val lm = clone().asInstanceOf[LongMap[V1]]
@@ -494,6 +590,17 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     lm
   }
 
+  /** Returns a new `LongMap` containing the entries of this map and two or more additional key/value pairs.
+   *
+   *  This map is not modified. When keys coincide, later pairs override earlier
+   *  ones and entries of this map.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param elem1 the first key/value pair to add
+   *  @param elem2 the second key/value pair to add
+   *  @param elems the remaining key/value pairs to add, if any
+   *  @return a new `LongMap` with the entries of this map plus all the given pairs
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (Long, V1), elem2: (Long, V1), elems: (Long, V1)*): LongMap[V1]^{} = {
     // TODO: An empty capture annotation is needed in the result type to satisfy the overriding checker.
@@ -501,14 +608,40 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     if(elems.isEmpty) m else m.concat(elems)
   }
 
+  /** Returns a new `LongMap` containing the entries of this map together with those of another collection.
+   *
+   *  This map is not modified. When keys coincide, pairs of `xs` override
+   *  entries of this map, and later pairs of `xs` override earlier ones.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param xs the key/value pairs to add
+   *  @return a new `LongMap` with the entries of this map and of `xs`
+   */
   override def concat[V1 >: V](xs: scala.collection.IterableOnce[(Long, V1)]^): LongMap[V1] = {
     val lm = clone().asInstanceOf[LongMap[V1]]
     xs.iterator.foreach(kv => lm += kv)
     lm
   }
 
+  /** Returns a new `LongMap` containing the entries of this map together with those of another collection.
+   *
+   *  Alias for `concat`; this map is not modified.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param xs the key/value pairs to add
+   *  @return a new `LongMap` with the entries of this map and of `xs`
+   */
   override def ++ [V1 >: V](xs: scala.collection.IterableOnce[(Long, V1)]^): LongMap[V1] = concat(xs)
 
+  /** Returns a copy of this map with one key/value pair added or replaced.
+   *
+   *  This map is not modified.
+   *
+   *  @tparam V1 the value type of the resulting map, a supertype of this map's value type
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   *  @return a clone of this map with `key` mapped to `value`
+   */
   @deprecated("Use m.clone().addOne(k,v) instead of m.updated(k, v)", "2.13.0")
   override def updated[V1 >: V](key: Long, value: V1): LongMap[V1] =
     clone().asInstanceOf[LongMap[V1]].addOne(key, value)
@@ -630,8 +763,10 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
 
+  /** Returns a serialization proxy that rebuilds this map on deserialization; called by Java serialization. */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(LongMap.toFactory[V](LongMap), this)
 
+  /** Returns `"LongMap"`, the name used in this map's string representation. */
   override protected def className = "LongMap"
 }
 
@@ -651,12 +786,20 @@ object LongMap {
    */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
+    /** Adds a key/value pair to the map under construction.
+     *
+     *  @param entry the key/value pair to add; any existing value for the same key is overwritten
+     *  @return this builder
+     */
     override def addOne(entry: (Long, V)): this.type = {
       elems += entry
       this
     }
+    /** Resets this builder by starting a fresh, empty map; previously returned maps are unaffected. */
     def clear(): Unit = elems = new LongMap[V]
+    /** Returns the map under construction. The map is returned directly, not copied, so additions made before the next `clear` also appear in the returned map. */
     def result(): LongMap[V] = elems
+    /** Returns the number of entries added since the last `clear`. */
     override def knownSize: Int = elems.knownSize
   }
 
@@ -680,7 +823,8 @@ object LongMap {
   /** Creates a new empty `LongMap`.
    *
    *  @tparam V the type of the values
-   *  @return a new empty `LongMap` whose value type is `V`
+   *  @return a new empty `LongMap` whose value type is `V`, and whose default for an
+   *          absent key throws, as `LongMap.exceptionDefault` does
    */
   def empty[V]: LongMap[V] = new LongMap[V]
 
@@ -704,6 +848,11 @@ object LongMap {
     case _ => buildFromIterableOnce(source)
   }
 
+  /** Creates a new empty builder for a `LongMap`.
+   *
+   *  @tparam V the type of values
+   *  @return a new reusable builder producing a `LongMap`
+   */
   def newBuilder[V]: ReusableBuilder[(Long, V), LongMap[V]] = new LongMapBuilder[V]
 
   /** Creates a new `LongMap` from arrays of keys and values.
@@ -741,21 +890,62 @@ object LongMap {
     lm
   }
 
+  /** Implicitly converts this companion object to a `Factory`, so it can be passed
+   *  where a factory of `LongMap`s is expected, for example to `to(LongMap)`.
+   *
+   *  @tparam V the type of values
+   *  @param dummy this companion object; its value is never used
+   *  @return a `Factory` that builds a `LongMap` from key/value pairs
+   */
   implicit def toFactory[V](dummy: LongMap.type): Factory[(Long, V), LongMap[V]] = ToFactory.asInstanceOf[Factory[(Long, V), LongMap[V]]]
 
   @SerialVersionUID(3L)
   private object ToFactory extends Factory[(Long, AnyRef), LongMap[AnyRef]], Serializable {
+    /** Builds a `LongMap` from a collection of key/value pairs.
+     *
+     *  @param it the key/value pairs
+     *  @return a new `LongMap` containing the pairs of `it`
+     */
     def fromSpecific(it: IterableOnce[(Long, AnyRef)]^): LongMap[AnyRef] = LongMap.from[AnyRef](it)
+    /** Returns a new empty builder for a `LongMap`. */
     def newBuilder: Builder[(Long, AnyRef), LongMap[AnyRef]] = LongMap.newBuilder[AnyRef]
   }
 
+  /** Implicitly converts this companion object to a `BuildFrom`, so it can be passed
+   *  where a `BuildFrom` producing `LongMap`s is expected.
+   *
+   *  @tparam V the type of values
+   *  @param factory this companion object; its value is never used
+   *  @return a `BuildFrom` that builds a `LongMap` from key/value pairs, ignoring the source collection
+   */
   implicit def toBuildFrom[V](factory: LongMap.type): BuildFrom[Any, (Long, V), LongMap[V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (Long, V), LongMap[V]]]
   private object ToBuildFrom extends BuildFrom[Any, (Long, AnyRef), LongMap[AnyRef]] {
+    /** Builds a `LongMap` from a collection of key/value pairs.
+     *
+     *  @param from the source collection; never used
+     *  @param it the key/value pairs
+     *  @return a new `LongMap` containing the pairs of `it`
+     */
     def fromSpecific(from: Any)(it: IterableOnce[(Long, AnyRef)]^) = LongMap.from(it)
+    /** Returns a new empty builder for a `LongMap`.
+     *
+     *  @param from the source collection; never used
+     *  @return a new reusable builder producing a `LongMap`
+     */
     def newBuilder(from: Any): ReusableBuilder[(Long, AnyRef), LongMap[AnyRef]] = LongMap.newBuilder[AnyRef]
   }
 
+  /** An implicit `Factory` for `LongMap`s, for APIs that look one up implicitly.
+   *
+   *  @tparam V the type of values
+   *  @return a `Factory` that builds a `LongMap` from key/value pairs
+   */
   implicit def iterableFactory[V]: Factory[(Long, V), LongMap[V]] = toFactory(this)
+  /** An implicit `BuildFrom` that builds a `LongMap` when the source collection is a `LongMap`.
+   *
+   *  @tparam V the type of values of the resulting map
+   *  @return a `BuildFrom` that builds a `LongMap` from key/value pairs
+   */
   implicit def buildFromLongMap[V]: BuildFrom[LongMap[?], (Long, V), LongMap[V]] = toBuildFrom(this)
 
   private def repackMask(mask: Int, _size: Int, _vacant: Int): Int = {

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -31,6 +31,7 @@ trait Map[K, V]
     with Shrinkable[K]
     with MapFactoryDefaults[K, V, Map, Iterable] {
 
+  /** The factory used to build mutable maps, the [[Map$ `Map`]] companion object, which delegates to [[HashMap]]. */
   override def mapFactory: scala.collection.MapFactory[Map] = Map
 
   /*
@@ -84,11 +85,28 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
     with Shrinkable[K]
     with caps.Pure {
 
+  /** Returns this map. A mutable map is its own builder: elements are added with
+   *  `+=` and `result()` returns the map itself rather than a copy.
+   */
   def result(): C = coll
 
+  /** Returns a clone of this map with `key` removed; this map is unaffected.
+   *
+   *  @param key the key to remove from the clone
+   *  @return a new map of the same kind containing all bindings of this map
+   *          except the one for `key`
+   */
   @deprecated("Use - or remove on an immutable Map", "2.13.0")
   final def - (key: K): C = clone() -= key
 
+  /** Returns a clone of this map with the given keys removed; this map is unaffected.
+   *
+   *  @param key1 the first key to remove from the clone
+   *  @param key2 the second key to remove from the clone
+   *  @param keys the remaining keys to remove from the clone
+   *  @return a new map of the same kind containing all bindings of this map
+   *          except those for the given keys
+   */
   @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
   final def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
 
@@ -171,10 +189,17 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
     r
   }
 
+  /** Removes all bindings from this map by removing each key in turn. */
   def clear(): Unit = { keysIterator foreach -= }
 
+  /** Returns a new map of the same kind containing the same bindings as this map. */
   override def clone(): C = empty ++= this
 
+  /** Alias for [[filterInPlace]]: retains only those mappings for which `p` returns `true`.
+   *
+   *  @param p the test predicate
+   *  @return the map itself
+   */
   @deprecated("Use filterInPlace instead", "2.13.0")
   @inline final def retain(p: (K, V) => Boolean): this.type = filterInPlace(p)
 
@@ -202,6 +227,12 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
     this
   }
 
+  /** Alias for [[mapValuesInPlace]]: replaces each value with the result of
+   *  applying `f` to its key and current value.
+   *
+   *  @param f the transformation to apply
+   *  @return the map itself
+   */
   @deprecated("Use mapValuesInPlace instead", "2.13.0")
   @inline final def transform(f: (K, V) => V): this.type = mapValuesInPlace(f)
 
@@ -229,10 +260,25 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
     this
   }
 
+  /** Returns a clone of this map updated with the binding `key -> value`; this
+   *  map is unaffected.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param key the key to bind
+   *  @param value the value to associate with `key`
+   *  @return a new map of the same kind containing all bindings of this map,
+   *          with `key` bound to `value`
+   */
   @deprecated("Use m.clone().addOne((k,v)) instead of m.updated(k, v)", "2.13.0")
   def updated[V1 >: V](key: K, value: V1): CC[K, V1] =
     clone().asInstanceOf[CC[K, V1]].addOne((key, value))
 
+  /** Returns the number of bindings in this map, if it can be cheaply computed,
+   *  -1 otherwise.
+   *
+   *  This override selects the `IterableOps` implementation over the `Growable`
+   *  default of -1.
+   */
   override def knownSize: Int = super[IterableOps].knownSize
 }
 
@@ -243,34 +289,94 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
 @SerialVersionUID(3L)
 object Map extends MapFactory.Delegate[Map](HashMap) {
 
+  /** A mutable map that wraps another map and computes a default value for keys
+   *  not present in it.
+   *
+   *  The default is only used by `apply`; `get`, `contains`, `iterator`, `keys`
+   *  and other methods are unaffected. Operations that build another map of this
+   *  same type keep the default, including `concat`, `empty`, `clone` and those
+   *  going through `fromSpecific`, such as `filter`; one that builds a plain map,
+   *  such as `map`, does not.
+   *
+   *  @tparam K the type of keys in the map
+   *  @tparam V the type of values associated with keys
+   *  @param underlying the map providing the bindings
+   *  @param defaultValue the function computing a default value for keys not
+   *                      present in the underlying map
+   */
   @SerialVersionUID(3L)
   class WithDefault[K, V](val underlying: Map[K, V], val defaultValue: K -> V)
     extends AbstractMap[K, V]
       with MapOps[K, V, Map, WithDefault[K, V]] with Serializable {
 
+    /** Defines the default value computation for the map, returned by `apply`
+     *  when a key is not found.
+     *
+     *  @param key the given key value for which a binding is missing
+     *  @return the result of applying `defaultValue` to `key`
+     */
     override def default(key: K): V = defaultValue(key)
 
+    /** Returns an iterator over the key/value pairs of the underlying map. */
     def iterator: scala.collection.Iterator[(K, V)] = underlying.iterator
+    /** Returns `true` if the underlying map contains no bindings. */
     override def isEmpty: Boolean = underlying.isEmpty
+    /** Returns the number of bindings in the underlying map, if it can be cheaply computed, -1 otherwise. */
     override def knownSize: Int = underlying.knownSize
+    /** The factory of the underlying map. Maps it builds do not have a default value. */
     override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
+    /** Removes all bindings from the underlying map. */
     override def clear(): Unit = underlying.clear()
 
+    /** Returns the value associated with `key` in the underlying map as an
+     *  option. The default value is not used.
+     *
+     *  @param key the key value
+     *  @return an option value containing the value associated with `key`, or
+     *          `None` if `key` is not present in the underlying map
+     */
     def get(key: K): Option[V] = underlying.get(key)
 
+    /** Removes the binding for `elem` from the underlying map, if present.
+     *
+     *  @param elem the key whose binding is to be removed
+     *  @return this `WithDefault` map
+     */
     def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 
+    /** Adds the given key/value pair to the underlying map, replacing any
+     *  existing binding for the key.
+     *
+     *  @param elem the key/value pair to add
+     *  @return this `WithDefault` map
+     */
     def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
 
+    /** Returns a new map containing the bindings of the underlying map followed
+     *  by those of `suffix`, wrapped with the same default value function as
+     *  this map.
+     *
+     *  @tparam V2 the value type of the returned map, a supertype of `V`
+     *  @param suffix the key/value pairs to append
+     *  @return a new `WithDefault` map with the combined bindings and this map's default
+     */
     override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]^): Map[K, V2] =
       underlying.concat(suffix).withDefault(defaultValue)
 
+    /** Returns a new, empty `WithDefault` map with the same default value function as this map. */
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
+    /** Returns a new `WithDefault` map containing the elements of `coll` and
+     *  the same default value function as this map.
+     *
+     *  @param coll the key/value pairs for the new map
+     *  @return a new `WithDefault` map with those bindings and this map's default
+     */
     override protected def fromSpecific(coll: scala.collection.IterableOnce[(K, V)]^): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
+    /** Returns a builder that produces a `WithDefault` map with the same default value function as this map. */
     override protected def newSpecificBuilder: Builder[(K, V), WithDefault[K, V]] =
       Map.newBuilder.mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -29,9 +29,29 @@ import scala.collection.generic.DefaultSerializable
 @SerialVersionUID(3L)
 object OpenHashMap extends MapFactory[OpenHashMap] {
 
+  /** Creates a new empty `OpenHashMap`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   */
   def empty[K, V] = new OpenHashMap[K, V]
+  /** Creates a new `OpenHashMap` from a collection of key/value pairs.
+   *
+   *  If several pairs share a key, the last one wins.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the key/value pairs to initialize the map with
+   *  @return a new `OpenHashMap` containing the pairs of `it`
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): OpenHashMap[K,V] = empty ++= it
 
+  /** Creates a new empty builder for an `OpenHashMap`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @return a new builder that produces an `OpenHashMap` from the key/value pairs added to it
+   */
   def newBuilder[K, V]: Builder[(K, V), OpenHashMap[K,V]] =
     new GrowableBuilder[(K, V), OpenHashMap[K, V]](empty)
 
@@ -84,6 +104,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
   /** A default constructor creates a hashmap with initial size `8`. */
   def this() = this(8)
 
+  /** Returns the companion object `OpenHashMap`, which builds maps of this kind. */
   override def mapFactory: MapFactory[OpenHashMap] = OpenHashMap
 
   private val actualInitialSize = OpenHashMap.nextPositivePowerOfTwo(initialSize)
@@ -103,9 +124,12 @@ class OpenHashMap[Key, Value](initialSize : Int)
   // Used for tracking inserts so that iterators can determine if concurrent modification has occurred.
   private var modCount = 0
 
+  /** Returns the number of key/value pairs in this map. Deleted slots are not counted. */
   override def size = _size
+  /** Returns `size`; the number of key/value pairs is always known. */
   override def knownSize: Int = size
   private def size_=(s : Int): Unit = _size = s
+  /** Returns `true` if this map contains no key/value pairs. */
   override def isEmpty: Boolean = _size == 0
   /** Returns a mangled hash code of the provided key.
    *
@@ -163,14 +187,43 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   // TODO refactor `put` to extract `findOrAddEntry` and implement this in terms of that to avoid Some boxing.
+  /** Adds a new key/value pair to this map, replacing any value previously associated with the key.
+   *
+   *  Delegates to `put`, discarding its result.
+   *
+   *  @param key the key of the entry to add or update
+   *  @param value the value to associate with `key`
+   */
   override def update(key: Key, value: Value): Unit = put(key, value)
 
+  /** Adds a key/value pair to this map and returns the map.
+   *
+   *  @param kv the key/value pair to add; any existing value for the same key is overwritten
+   *  @return this map after the entry has been added
+   */
   @deprecatedOverriding("addOne should not be overridden in order to maintain consistency with put.", "2.11.0")
   def addOne (kv: (Key, Value)): this.type = { put(kv._1, kv._2); this }
 
+  /** Removes a key from this map, and returns the map.
+   *
+   *  Does nothing if `key` is not present.
+   *
+   *  @param key the key to remove
+   *  @return this map after the removal
+   */
   @deprecatedOverriding("subtractOne should not be overridden in order to maintain consistency with remove.", "2.11.0")
   def subtractOne (key: Key): this.type = { remove(key); this }
 
+  /** Adds a key/value pair to this map, returning any value previously associated with the key.
+   *
+   *  A new entry reuses the first deleted slot on its probe path, if any;
+   *  the table grows once the entry being added would take the number of occupied or
+   *  deleted slots past half of them.
+   *
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   *  @return `Some` of the value previously associated with `key`, or `None` if `key` was not present
+   */
   override def put(key: Key, value: Value): Option[Value] =
     put(key, hashOf(key), value)
 
@@ -211,6 +264,15 @@ class OpenHashMap[Key, Value](initialSize : Int)
     deleted += 1
   }
 
+  /** Removes a key from this map, returning the value previously associated with it.
+   *
+   *  A removed entry's slot is not emptied but marked as deleted, so that
+   *  probe sequences for other keys remain intact; deleted slots are
+   *  reclaimed when an entry is added over one or when the table grows.
+   *
+   *  @param key the key to remove
+   *  @return `Some` of the value previously associated with `key`, or `None` if `key` was not present
+   */
   override def remove(key : Key): Option[Value] = {
     val entry = table(findIndex(key, hashOf(key)))
     if (entry != null && entry.value != None) {
@@ -220,6 +282,11 @@ class OpenHashMap[Key, Value](initialSize : Int)
     } else None
   }
 
+  /** Optionally returns the value associated with a key.
+   *
+   *  @param key the key to look up
+   *  @return `Some` of the value associated with `key`, or `None` if `key` is not present
+   */
   def get(key : Key) : Option[Value] = {
     val hash = hashOf(key)
     var index = hash & mask
@@ -247,9 +314,11 @@ class OpenHashMap[Key, Value](initialSize : Int)
     override protected def nextResult(node: Entry): (Key, Value) = (node.key, node.value.get)
   }
 
+  /** Returns an iterator over the keys of this map, following the same concurrent modification contract as `iterator`. */
   override def keysIterator: Iterator[Key] = new OpenHashMapIterator[Key] {
     override protected def nextResult(node: Entry): Key = node.key
   }
+  /** Returns an iterator over the values of this map, following the same concurrent modification contract as `iterator`. */
   override def valuesIterator: Iterator[Value] = new OpenHashMapIterator[Value] {
     override protected def nextResult(node: Entry): Value = node.value.get
   }
@@ -274,6 +343,12 @@ class OpenHashMap[Key, Value](initialSize : Int)
     protected def nextResult(node: Entry): A
   }
 
+  /** Returns a copy of this map with the same key/value pairs.
+   *
+   *  The copy is built by inserting each entry into a fresh table, so deleted
+   *  slots are not carried over. Later changes to the copy do not affect this
+   *  map, and vice versa.
+   */
   override def clone() = {
     val it = new OpenHashMap[Key, Value]
     foreachUndeletedEntry(entry => it.put(entry.key, entry.hash, entry.value.get))
@@ -297,6 +372,14 @@ class OpenHashMap[Key, Value](initialSize : Int)
       f((entry.key, entry.value.get))}
     )
   }
+  /** Loops over the key, value mappings of this map, passing key and value as separate arguments.
+   *
+   *  Unlike `foreach`, does not allocate a tuple per entry. The contract for
+   *  modifying the map during the loop is the same as for `foreach`.
+   *
+   *  @tparam U  The return type of the specified function `f`, return result of which is ignored.
+   *  @param f   The function to apply to each key, value mapping.
+   */
   override def foreachEntry[U](f : (Key, Value) => U): Unit = {
     val startModCount = modCount
     foreachUndeletedEntry(entry => {
@@ -309,16 +392,29 @@ class OpenHashMap[Key, Value](initialSize : Int)
     table.foreach(entry => if (entry != null && entry.value != None) f(entry))
   }
 
+  /** Applies a transformation function to all values stored in this map.
+   *
+   *  @param f the transformation to apply to each key/value pair; its result replaces the value stored for that key
+   *  @return this map after each value has been replaced
+   */
   override def mapValuesInPlace(f : (Key, Value) => Value): this.type = {
     foreachUndeletedEntry(entry => entry.value = Some(f(entry.key, entry.value.get)))
     this
   }
 
+  /** Retains only those entries for which a predicate returns `true`.
+   *
+   *  The slots of removed entries are marked as deleted, as with `remove`.
+   *
+   *  @param f the predicate used to test each key/value pair
+   *  @return this map after the entries failing the predicate have been removed
+   */
   override def filterInPlace(f : (Key, Value) => Boolean): this.type = {
     foreachUndeletedEntry(entry => if (!f(entry.key, entry.value.get)) deleteSlot(entry))
     this
   }
 
+  /** Returns `"OpenHashMap"`, the name used in this map's string representation. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "OpenHashMap"
 }

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -107,13 +107,24 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   resarr.p_size0 += 1
   /** Alias for [[size]]. */
   def length: Int = resarr.length - 1  // adjust length accordingly
+  /** The number of elements in this priority queue. */
   override def size: Int = length
+  /** The number of elements in this priority queue; always known, never `-1`. */
   override def knownSize: Int = length
+  /** Tests whether this priority queue contains no elements. */
   override def isEmpty: Boolean = resarr.p_size0 < 2
 
   // not eligible for EvidenceIterableFactoryDefaults since C != CC[A] (PriorityQueue[A] != Iterable[A])
+  /** Builds a new priority queue, with this queue's ordering, from the
+   *  elements of a collection.
+   *
+   *  @param coll the collection of elements
+   *  @return a new priority queue containing the elements of `coll`
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[A]^): PriorityQueue[A] = PriorityQueue.from(coll)
+  /** Returns a new builder that accumulates elements into a priority queue with this queue's ordering. */
   override protected def newSpecificBuilder: Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder
+  /** Returns a new empty priority queue with this queue's ordering. */
   override def empty: PriorityQueue[A] = PriorityQueue.empty
 
   /** Replaces the contents of this $coll with the mapped result.
@@ -127,9 +138,20 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     this
   }
 
+  /** Returns this priority queue itself: a `PriorityQueue` is its own builder,
+   *  so no copy is made and later modification affects the result.
+   */
   def result() = this
 
   private def toA(x: AnyRef | Null): A = x.asInstanceOf[A]
+  /** Restores the heap invariant by sifting the element at index `m` upwards,
+   *  swapping it with its parent as long as it is greater than the parent.
+   *
+   *  @param as the array whose values are compared (index 0 is unused); the swaps are
+   *            made in the queue's own backing array, so this has the effect described
+   *            only when `as` is that array
+   *  @param m the index of the element to sift up
+   */
   protected def fixUp(as: Array[AnyRef | Null], m: Int): Unit = {
     var k: Int = m
     // use `ord` directly to avoid allocating `OrderingOps`
@@ -139,6 +161,14 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     }
   }
 
+  /** Restores the heap invariant by sifting the element at index `m` downwards,
+   *  swapping it with its greater child as long as a child is greater than it.
+   *
+   *  @param as the heap array (index 0 is unused)
+   *  @param m the index of the element to sift down
+   *  @param n the index of the last element of the heap
+   *  @return `true` if any swap was made, `false` otherwise
+   */
   protected def fixDown(as: Array[AnyRef | Null], m: Int, n: Int): Boolean = {
     // returns true if any swaps were done (used in heapify)
     var k: Int = m
@@ -172,6 +202,15 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     this
   }
 
+  /** Adds all elements of a collection to this priority queue.
+   *
+   *  The elements are appended to the heap array first and the heap invariant
+   *  is restored in a single pass afterwards, which is cheaper than adding
+   *  them one at a time.
+   *
+   *  @param xs the elements to add
+   *  @return this priority queue
+   */
   override def addAll(xs: IterableOnce[A]^): this.type = {
     val from = resarr.p_size0
     for (x <- xs.iterator) unsafeAdd(x)
@@ -382,6 +421,18 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     pq
   }
 
+  /** Copies elements of this priority queue to an array, in the same
+   *  unspecified order as `iterator`, not in priority order.
+   *
+   *  Copying starts at index `start` in `xs` and stops when `len` elements
+   *  have been copied, or when the end of this queue or of `xs` is reached.
+   *
+   *  @tparam B a supertype of the element type, the element type of `xs`
+   *  @param xs the destination array
+   *  @param start the starting index in `xs`
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements copied to `xs`
+   */
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if (copied > 0) {
@@ -390,17 +441,28 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     copied
   }
 
+  /** The companion object of this priority queue, [[PriorityQueue$ `PriorityQueue`]]. */
   @deprecated("Use `PriorityQueue` instead", "2.13.0")
   def orderedCompanion: PriorityQueue.type = PriorityQueue
 
+  /** Replaces this priority queue with a serialization proxy during Java serialization. */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(PriorityQueue.evidenceIterableFactory[A], this)
 
+  /** The name used in the string representation of this priority queue, `"PriorityQueue"`. */
   override protected def className = "PriorityQueue"
 }
 
 
 @SerialVersionUID(3L)
 object PriorityQueue extends SortedIterableFactory[PriorityQueue] {
+  /** Returns a new builder that accumulates elements into a priority queue.
+   *
+   *  The builder establishes the heap invariant once, in `result()`, rather
+   *  than on each addition.
+   *
+   *  @tparam A the element type of the queue, which must have an implicit `Ordering`
+   *  @return a builder for a `PriorityQueue[A]`
+   */
   def newBuilder[A : Ordering]: Builder[A, PriorityQueue[A]] = {
     new Builder[A, PriorityQueue[A]] {
       val pq = new PriorityQueue[A]
@@ -410,8 +472,19 @@ object PriorityQueue extends SortedIterableFactory[PriorityQueue] {
     }
   }
 
+  /** Creates a new empty priority queue.
+   *
+   *  @tparam A the element type of the queue, which must have an implicit `Ordering`
+   *  @return a new empty `PriorityQueue[A]`
+   */
   def empty[A : Ordering]: PriorityQueue[A] = new PriorityQueue[A]
 
+  /** Creates a new priority queue containing the elements of the given collection.
+   *
+   *  @tparam E the element type of the queue, which must have an implicit `Ordering`
+   *  @param it the collection of elements
+   *  @return a new priority queue containing the elements of `it`
+   */
   def from[E : Ordering](it: IterableOnce[E]^): PriorityQueue[E] = {
     val b = newBuilder[E]
     b ++= it

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -40,11 +40,17 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
     with Cloneable[Queue[A]]
     with DefaultSerializable {
 
+  /** Creates an empty queue whose backing array can hold at least `initialSize` elements.
+   *
+   *  @param initialSize the initial capacity hint, 16 by default
+   */
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) =
     this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
+  /** The factory used to build queues, the [[Queue$ `Queue`]] companion object. */
   override def iterableFactory: SeqFactory[Queue] = Queue
 
+  /** The prefix used in the string representation of this queue, `"Queue"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "Queue"
 
@@ -113,12 +119,22 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
    */
   @`inline` final def front: A = head
 
+  /** Returns a copy of this queue, containing the same elements in the same
+   *  order. Called by `clone()`.
+   */
   override protected def klone(): Queue[A] = {
     val bf = newSpecificBuilder
     bf ++= this
     bf.result()
   }
 
+  /** Wraps an array in a new queue, without copying.
+   *
+   *  @param array the backing array, allocated by `ArrayDeque.alloc` so that
+   *               its length is a power of 2
+   *  @param end the number of elements: `array` holds them at indices `0` until `end`
+   *  @return a new queue backed by `array`
+   */
   override protected def ofArray(array: Array[AnyRef | Null], end: Int): Queue[A] =
     new Queue(array, start = 0, end)
 
@@ -131,10 +147,31 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 @SerialVersionUID(3L)
 object Queue extends StrictOptimizedSeqFactory[Queue] {
 
+  /** Creates a new queue containing the elements of the given collection, in
+   *  its iteration order.
+   *
+   *  The first element of `source` is at the front of the new queue.
+   *
+   *  @tparam A the element type of the queue
+   *  @param source the collection of elements
+   *  @return a new queue containing the elements of `source`
+   */
   def from[A](source: IterableOnce[A]^): Queue[A] = empty ++= source
 
+  /** Creates a new empty queue.
+   *
+   *  @tparam A the element type of the queue
+   *  @return a new empty `Queue[A]`
+   */
   def empty[A]: Queue[A] = new Queue
 
+  /** Returns a new builder that accumulates elements into a queue.
+   *
+   *  The first element added to the builder is at the front of the resulting queue.
+   *
+   *  @tparam A the element type of the queue
+   *  @return a builder for a `Queue[A]`
+   */
   def newBuilder[A]: Builder[A, Queue[A]] = new GrowableBuilder[A, Queue[A]](empty)
 
 }

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -16,12 +16,18 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{IterableFactoryDefaults, SeqFactory}
 
+/** Base trait for mutable sequences: ordered collections whose elements can be
+ *  replaced in place with `update`.
+ *
+ *  @tparam A the element type of the sequence
+ */
 trait Seq[A]
   extends Iterable[A]
     with collection.Seq[A]
     with SeqOps[A, Seq, Seq[A]]
     with IterableFactoryDefaults[A, Seq] {
 
+  /** The factory used to build mutable sequences, the [[Seq$ `Seq`]] companion object, which delegates to [[ArrayBuffer]]. */
   override def iterableFactory: SeqFactory[Seq] = Seq
 }
 
@@ -45,6 +51,7 @@ transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
     with Cloneable[C]
     with caps.Pure {
 
+  /** Returns a new sequence of the same kind containing the same elements as this sequence. */
   override def clone(): C = {
     val b = newSpecificBuilder
     b ++= this

--- a/library/src/scala/collection/mutable/SeqMap.scala
+++ b/library/src/scala/collection/mutable/SeqMap.scala
@@ -35,6 +35,7 @@ trait SeqMap[K, V] extends Map[K, V]
   with collection.SeqMap[K, V]
   with MapOps[K, V, SeqMap, SeqMap[K, V]]
   with MapFactoryDefaults[K, V, SeqMap, Iterable] {
+  /** The factory used to build mutable maps that maintain insertion order, the [[SeqMap$ `SeqMap`]] companion object, which delegates to [[LinkedHashMap]]. */
   override def mapFactory: MapFactory[SeqMap] = SeqMap
 }
 

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -26,6 +26,7 @@ trait Set[A]
     with SetOps[A, Set, Set[A]]
     with IterableFactoryDefaults[A, Set] {
 
+  /** The factory used to build mutable sets, the [[Set$ `Set`]] companion object, which delegates to [[HashSet]]. */
   override def iterableFactory: IterableFactory[Set] = Set
 }
 
@@ -45,6 +46,9 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     with Growable[A]
     with Shrinkable[A] {
 
+  /** Returns this set. A mutable set is its own builder: elements are added with
+   *  `+=` and `result()` returns the set itself rather than a copy.
+   */
   def result(): C = coll
 
   /** Checks whether the set contains the given element, and adds it if not.
@@ -90,9 +94,20 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     res
   }
 
+  /** Returns a new set of the same kind containing those elements of this set
+   *  that are not also contained in `that`.
+   *
+   *  @param that the set of elements to exclude
+   *  @return a new set containing all elements of this set that are not in `that`
+   */
   def diff(that: collection.Set[A]): C =
     foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
 
+  /** Alias for [[filterInPlace]]: removes all elements from this set for which
+   *  `p` returns `false`.
+   *
+   *  @param p the test predicate; elements for which `p` returns `true` are retained
+   */
   @deprecated("Use filterInPlace instead", "2.13.0")
   @inline final def retain(p: A => Boolean): Unit = filterInPlace(p)
 
@@ -119,8 +134,15 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     this
   }
 
+  /** Returns a new set of the same kind containing the same elements as this set. */
   override def clone(): C = empty ++= this
 
+  /** Returns the number of elements in this set, if it can be cheaply computed,
+   *  -1 otherwise.
+   *
+   *  This override selects the `IterableOps` implementation over the `Growable`
+   *  default of -1.
+   */
   override def knownSize: Int = super[IterableOps].knownSize
 }
 

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -28,8 +28,10 @@ trait SortedMap[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
     with SortedMapFactoryDefaults[K, V, SortedMap, Iterable, Map] {
 
+  /** Returns this map itself, with its static type widened to its unsorted counterpart `Map` */
   override def unsorted: Map[K, V] = this
 
+  /** Returns the [[SortedMap]] object, the default factory for mutable sorted maps, which creates `TreeMap`s */
   override def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
   /** The same sorted map with a given default function.
@@ -59,8 +61,17 @@ transparent trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y,
   extends collection.SortedMapOps[K, V, CC, C]
     with MapOps[K, V, Map, C] {
 
+  /** Widens the type of this map to its unsorted counterpart. */
   def unsorted: Map[K, V]
 
+  /** Returns a copy of this map, created with `clone()`, in which `value` is associated with `key`; this map itself
+   *  is unchanged.
+   *
+   *  @tparam V1 the type of the added value, a supertype of `V`
+   *  @param key the key to associate the value with
+   *  @param value the value to associate with `key`
+   *  @return a mutable copy of this map with `key` bound to `value`
+   */
   @deprecated("Use m.clone().addOne((k,v)) instead of m.updated(k, v)", "2.13.0")
   override def updated[V1 >: V](key: K, value: V1): CC[K, V1] =
     clone().asInstanceOf[CC[K, V1]].addOne((key, value))
@@ -69,6 +80,15 @@ transparent trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y,
 @SerialVersionUID(3L)
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
+  /** A mutable sorted map whose `apply` returns `defaultValue(key)` for keys that are not present instead of
+   *  throwing an exception. All operations are delegated to the underlying sorted map; methods such as `get`,
+   *  `contains`, `iterator`, and `keys` are not affected by the default.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param underlying the sorted map to which all operations are delegated
+   *  @param defaultValue the function computing a default value for keys that are not present
+   */
   @SerialVersionUID(3L)
   final class WithDefault[K, V](underlying: SortedMap[K, V], defaultValue: K -> V)
     extends Map.WithDefault[K, V](underlying, defaultValue)
@@ -76,31 +96,76 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
       with SortedMapOps[K, V, SortedMap, WithDefault[K, V]]
       with Serializable {
 
+    /** Returns the sorted map factory of the underlying map; maps created by that factory do not have this map's default */
     override def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
 
+    /** Returns an iterator over the key-value pairs of the underlying map whose keys are greater than or equal to
+     *  `start`, in the map's key ordering.
+     *
+     *  @param start the lower bound (inclusive) on the keys of the entries to return
+     */
     def iteratorFrom(start: K): scala.collection.Iterator[(K, V)] = underlying.iteratorFrom(start)
 
+    /** Returns an iterator over the keys of the underlying map that are greater than or equal to `start`, in the
+     *  map's key ordering.
+     *
+     *  @param start the lower bound (inclusive) on the keys to return
+     */
     def keysIteratorFrom(start: K): scala.collection.Iterator[K] = underlying.keysIteratorFrom(start)
 
+    /** Returns the key ordering of the underlying sorted map */
     implicit def ordering: Ordering[K] = underlying.ordering
 
+    /** Returns a ranged projection of the underlying map, wrapped in a new `WithDefault` with the same default
+     *  function.
+     *
+     *  @param from the lower bound (inclusive) of the projection wrapped in a `Some`, or `None` if there is no lower bound
+     *  @param until the upper bound (exclusive) of the projection wrapped in a `Some`, or `None` if there is no upper bound
+     *  @return a `WithDefault` wrapper around the ranged projection of the underlying map
+     */
     def rangeImpl(from: Option[K], until: Option[K]): WithDefault[K, V] =
       new WithDefault[K, V](underlying.rangeImpl(from, until), defaultValue)
 
     // Need to override following methods to match type signatures of `SortedMap.WithDefault`
     // for operations preserving default value
+    /** Removes the entry with key `elem` from the underlying map, if one exists.
+     *
+     *  @param elem the key of the entry to remove
+     *  @return this map, with its default function intact
+     */
     override def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 
+    /** Adds the key-value pair `elem` to the underlying map, replacing the value of an existing entry with an equal
+     *  key.
+     *
+     *  @param elem the key-value pair to add
+     *  @return this map, with its default function intact
+     */
     override def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
 
+    /** Returns a new `WithDefault` with the same default function, wrapping an empty map of the same type as the underlying map */
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
+    /** Returns a new sorted map containing the entries of the underlying map followed by those of `suffix`, with
+     *  the same default function as this map.
+     *
+     *  @tparam V2 the type of the values of the resulting map, a supertype of `V`
+     *  @param suffix the key-value pairs to append
+     *  @return a new sorted map with the combined entries and this map's default function
+     */
     override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]^): SortedMap[K, V2] =
       underlying.concat(suffix).withDefault(defaultValue)
 
+    /** Returns a new `WithDefault` with the same default function, wrapping a map that is built from the key-value
+     *  pairs of `coll` with the underlying map's factory.
+     *
+     *  @param coll the key-value pairs of the new map
+     *  @return a new `WithDefault` containing the entries of `coll`
+     */
     override protected def fromSpecific(coll: scala.collection.IterableOnce[(K, V)]^): WithDefault[K, V] =
       new WithDefault[K, V](sortedMapFactory.from(coll), defaultValue)
 
+    /** Returns a builder that collects key-value pairs into a new sorted map and wraps the result in a `WithDefault` with the same default function */
     override protected def newSpecificBuilder: Builder[(K, V), WithDefault[K, V]] =
       SortedMap.newBuilder.mapResult((p: SortedMap[K, V]) => new WithDefault[K, V](p, defaultValue))
   }

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -27,8 +27,10 @@ trait SortedSet[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
     with SortedSetFactoryDefaults[A, SortedSet, Set] {
 
+  /** Returns this set itself, with its static type widened to its unsorted counterpart `Set` */
   override def unsorted: Set[A] = this
 
+  /** Returns the [[SortedSet]] object, the default factory for mutable sorted sets, which creates `TreeSet`s */
   override def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
 }
 
@@ -44,6 +46,7 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   extends SetOps[A, Set, C]
     with collection.SortedSetOps[A, CC, C] {
 
+  /** Widens the type of this set to its unsorted counterpart. */
   def unsorted: Set[A]
 }
 

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -44,11 +44,19 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
     with Cloneable[Stack[A]]
     with DefaultSerializable {
 
+  /** Creates an empty stack whose backing array can hold at least `initialSize` elements.
+   *
+   *  @param initialSize the initial capacity hint, 16 by default
+   *  @throws IllegalArgumentException if `initialSize` is negative or too large to
+   *          allocate, since `ArrayDeque.alloc` rejects it
+   */
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) =
     this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
+  /** The factory used to build stacks, the [[Stack$ `Stack`]] companion object. */
   override def iterableFactory: SeqFactory[Stack] = Stack
 
+  /** The prefix used in the string representation of this stack, `"Stack"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "Stack"
 
@@ -114,12 +122,21 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
    */
   @`inline` final def top: A = head
 
+  /** Returns a copy of this stack, containing the same elements in the same
+   *  order. Called by `clone()`.
+   */
   override protected def klone(): Stack[A] = {
     val bf = newSpecificBuilder
     bf ++= this
     bf.result()
   }
 
+  /** Wraps an array in a new stack, without copying.
+   *
+   *  @param array the backing array, used as given; its length must be a power of 2
+   *  @param end the number of elements: `array` holds them at indices `0` until `end`
+   *  @return a new stack backed by `array`
+   */
   override protected def ofArray(array: Array[AnyRef | Null], end: Int): Stack[A] =
     new Stack(array, start = 0, end)
 
@@ -132,10 +149,32 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 @SerialVersionUID(3L)
 object Stack extends StrictOptimizedSeqFactory[Stack] {
 
+  /** Creates a new stack containing the elements of the given collection, in
+   *  its iteration order.
+   *
+   *  The first element of `source` ends up on top of the stack, unlike what
+   *  building a stack by pushing the elements one at a time would produce.
+   *
+   *  @tparam A the element type of the stack
+   *  @param source the collection of elements
+   *  @return a new stack containing the elements of `source`
+   */
   def from[A](source: IterableOnce[A]^): Stack[A] = empty ++= source
 
+  /** Creates a new empty stack.
+   *
+   *  @tparam A the element type of the stack
+   *  @return a new empty `Stack[A]`
+   */
   def empty[A]: Stack[A] = new Stack
 
+  /** Returns a new builder that accumulates elements into a stack.
+   *
+   *  The first element added to the builder becomes the top of the resulting stack.
+   *
+   *  @tparam A the element type of the stack
+   *  @return a builder for a `Stack[A]`
+   */
   def newBuilder[A]: Builder[A, Stack[A]] = new GrowableBuilder[A, Stack[A]](empty)
 
 }

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -59,6 +59,9 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   with java.lang.CharSequence
   with Serializable {
 
+  /** Constructs a string builder with no characters in it and an
+   *  initial capacity of 16 characters.
+   */
   def this() = this(new java.lang.StringBuilder)
 
   /** Constructs a string builder with no characters in it and an
@@ -86,24 +89,56 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this(new java.lang.StringBuilder(initValue.length + initCapacity).append(initValue))
 
   // Methods required to make this an IndexedSeq:
+  /** Returns the character at the specified index.
+   *
+   *  @param i the index of the character to return
+   *  @return the character at index `i`
+   *  @throws IndexOutOfBoundsException if `i` is out of bounds
+   */
   def apply(i: Int): Char = underlying.charAt(i)
 
+  /** Returns a new string builder containing the characters of `coll`.
+   *
+   *  @param coll the characters for the new string builder
+   *  @return a new string builder with the characters of `coll` appended to it
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[Char]^): StringBuilder =
     new StringBuilder() appendAll coll
 
+  /** Returns a builder that produces a `StringBuilder`, backed by a new empty string builder. */
   override protected def newSpecificBuilder: Builder[Char, StringBuilder] =
     new GrowableBuilder(new StringBuilder())
 
+  /** Returns a new empty string builder. */
   override def empty: StringBuilder = new StringBuilder()
 
+  /** Returns the number of characters in this builder. */
   @inline def length: Int = underlying.length
 
+  /** Setter alias for [[setLength]]: sets the length of the character sequence to
+   *  `n`, truncating it or padding it with null characters (`'\u0000'`) as needed.
+   *
+   *  @throws IndexOutOfBoundsException if `n` is negative
+   */
   def length_=(n: Int): Unit = underlying.setLength(n)
 
+  /** Returns the number of characters in this builder, which is always known.
+   *
+   *  This override selects the `IndexedSeqOps` implementation, which returns
+   *  `length`, over the `Growable` default, which returns -1.
+   */
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
+  /** Appends the given character to this builder.
+   *
+   *  @param x the character to append
+   *  @return this string builder
+   */
   def addOne(x: Char): this.type = { underlying.append(x); this }
 
+  /** Removes all characters from this builder, setting its length to 0.
+   *  The builder's capacity is unchanged, and it can be used again.
+   */
   def clear(): Unit = underlying.setLength(0)
 
   /** Overloaded version of `addAll` that takes a string.
@@ -116,10 +151,26 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   /** Alias for `addAll`. */
   def ++= (s: String): this.type = addAll(s)
 
+  /** Returns the contents of this builder as a `String`.
+   *
+   *  Unlike most builders, calling `result()` does not reset this builder:
+   *  it may be called repeatedly, interleaved with further modifications.
+   */
   def result() = underlying.toString
 
+  /** Returns the contents of this builder as a `String`. Equivalent to [[result]]. */
   override def toString(): String = result()
 
+  /** Returns an array containing the characters of this builder.
+   *
+   *  When `B` is `Char` itself, the characters are copied directly, as by
+   *  [[toCharArray]]; for any other element type the generic implementation
+   *  inherited from the collections library is used.
+   *
+   *  @tparam B the element type of the resulting array, a supertype of `Char`
+   *  @param ct a class tag whose runtime class determines the component type
+   *            of the resulting array
+   */
   override def toArray[B >: Char](implicit ct: scala.reflect.ClassTag[B]) =
     ct.runtimeClass match {
       case java.lang.Character.TYPE => toCharArray.asInstanceOf[Array[B]]
@@ -139,6 +190,11 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   // append* methods delegate to the underlying java.lang.StringBuilder:
 
+  /** Appends the given string to this builder.
+   *
+   *  @param xs the string to append
+   *  @return this string builder
+   */
   def appendAll(xs: String): this.type = {
     underlying.append(xs)
     this
@@ -242,12 +298,55 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *  @return     This StringBuilder.
    */
   def append(x: Boolean): this.type = { underlying.append(x) ; this }
+  /** Appends the string representation of the given `Byte` value,
+   *  as produced by `String.valueOf`, to this builder. The value is
+   *  widened to an `Int` before conversion.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Byte): this.type = append(x.toInt)
+  /** Appends the string representation of the given `Short` value,
+   *  as produced by `String.valueOf`, to this builder. The value is
+   *  widened to an `Int` before conversion.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Short): this.type = append(x.toInt)
+  /** Appends the string representation of the given `Int` value,
+   *  as produced by `String.valueOf`, to this builder.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Int): this.type = { underlying.append(x) ; this }
+  /** Appends the string representation of the given `Long` value,
+   *  as produced by `String.valueOf`, to this builder.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Long): this.type = { underlying.append (x) ; this }
+  /** Appends the string representation of the given `Float` value,
+   *  as produced by `String.valueOf`, to this builder.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Float): this.type = { underlying.append (x) ; this }
+  /** Appends the string representation of the given `Double` value,
+   *  as produced by `String.valueOf`, to this builder.
+   *
+   *  @param x the value to append
+   *  @return this string builder
+   */
   def append(x: Double): this.type = { underlying.append(x) ; this }
+  /** Appends the given character to this builder.
+   *
+   *  @param x the character to append
+   *  @return this string builder
+   */
   def append(x: Char): this.type = { underlying.append(x) ; this }
 
   /** Removes a subsequence of Chars from this sequence, starting at the
@@ -347,12 +446,69 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *  @return       this StringBuilder.
    */
   def insert(index: Int, x: Boolean): this.type = insert(index, String.valueOf(x))
+  /** Inserts the string representation of the given `Byte` value,
+   *  as produced by `String.valueOf`, at the given index. The value is
+   *  widened to an `Int` before conversion.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Byte): this.type    = insert(index, x.toInt)
+  /** Inserts the string representation of the given `Short` value,
+   *  as produced by `String.valueOf`, at the given index. The value is
+   *  widened to an `Int` before conversion.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Short): this.type   = insert(index, x.toInt)
+  /** Inserts the string representation of the given `Int` value,
+   *  as produced by `String.valueOf`, at the given index.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Int): this.type     = insert(index, String.valueOf(x))
+  /** Inserts the string representation of the given `Long` value,
+   *  as produced by `String.valueOf`, at the given index.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Long): this.type    = insert(index, String.valueOf(x))
+  /** Inserts the string representation of the given `Float` value,
+   *  as produced by `String.valueOf`, at the given index.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Float): this.type   = insert(index, String.valueOf(x))
+  /** Inserts the string representation of the given `Double` value,
+   *  as produced by `String.valueOf`, at the given index.
+   *
+   *  @param index the index at which to insert
+   *  @param x the value to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Double): this.type  = insert(index, String.valueOf(x))
+  /** Inserts the given character at the given index.
+   *
+   *  @param index the index at which to insert
+   *  @param x the character to insert
+   *  @return this string builder
+   *  @throws StringIndexOutOfBoundsException if the index is out of bounds
+   */
   def insert(index: Int, x: Char): this.type    = insert(index, String.valueOf(x))
 
   /** Sets the length of the character sequence.  If the current sequence
@@ -364,6 +520,14 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def setLength(len: Int): Unit = underlying.setLength(len)
 
+  /** Replaces the character at index `idx` with `elem`.
+   *
+   *  Equivalent to [[setCharAt]]; enables assignment syntax `sb(idx) = elem`.
+   *
+   *  @param idx the index of the character to replace
+   *  @param elem the replacement character
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   */
   def update(idx: Int, elem: Char): Unit = underlying.setCharAt(idx, elem)
 
 
@@ -506,6 +670,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 }
 
 object StringBuilder {
+  /** Returns a new empty string builder, with the default initial capacity of 16 characters. */
   @deprecated("Use `new StringBuilder()` instead of `StringBuilder.newBuilder`", "2.13.0")
   def newBuilder = new StringBuilder
 }

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -39,6 +39,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     with SortedMapFactoryDefaults[K, V, TreeMap, Iterable, Map]
     with DefaultSerializable {
 
+  /** Returns the companion object [[TreeMap]], the factory used to create new tree maps of the same type */
   override def sortedMapFactory: TreeMap.type = TreeMap
 
   /** Creates an empty `TreeMap`.
@@ -47,36 +48,61 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(using ord)
 
+  /** Returns an iterator over the key-value pairs of this tree map, in ascending order of keys */
   def iterator: Iterator[(K, V)] = {
     if (isEmpty) Iterator.empty
     else RB.iterator(tree)
   }
 
+  /** Returns an iterator over the keys of this tree map, in ascending order */
   override def keysIterator: Iterator[K] = {
     if (isEmpty) Iterator.empty
     else RB.keysIterator(tree, None)
   }
 
+  /** Returns an iterator over the values of this tree map, in ascending order of the associated keys */
   override def valuesIterator: Iterator[V] = {
     if (isEmpty) Iterator.empty
     else RB.valuesIterator(tree, None)
   }
 
+  /** Returns an iterator over the keys of this tree map that are greater than or equal to `start`, in ascending
+   *  order.
+   *
+   *  @param start the lower bound (inclusive) on the keys to return
+   */
   def keysIteratorFrom(start: K): Iterator[K] = {
     if (isEmpty) Iterator.empty
     else RB.keysIterator(tree, Some(start))
   }
 
+  /** Returns an iterator over the key-value pairs of this tree map whose keys are greater than or equal to `start`,
+   *  in ascending order of keys.
+   *
+   *  @param start the lower bound (inclusive) on the keys of the entries to return
+   */
   def iteratorFrom(start: K): Iterator[(K, V)] = {
     if (isEmpty) Iterator.empty
     else RB.iterator(tree, Some(start))
   }
 
+  /** Returns an iterator over the values of the entries of this tree map whose keys are greater than or equal to
+   *  `start`, in ascending order of the associated keys.
+   *
+   *  @param start the lower bound (inclusive) on the keys of the entries whose values to return
+   */
   override def valuesIteratorFrom(start: K): Iterator[V] = {
     if (isEmpty) Iterator.empty
     else RB.valuesIterator(tree, Some(start))
   }
 
+  /** Returns a [[Stepper]] for the key-value pairs of this tree map. The stepper visits the pairs in ascending
+   *  order of keys and supports efficient splitting, so the converters in [[scala.jdk.StreamConverters]] can create
+   *  parallel streams from it.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[(K, V), S]): S & EfficientSplit =
     shape.parUnbox(
       scala.collection.convert.impl.AnyBinaryTreeStepper.from[(K, V), RB.Node[K, V]](
@@ -84,6 +110,14 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
       )
     )
 
+  /** Returns a [[Stepper]] for the keys of this tree map. The stepper visits the keys in ascending order and
+   *  supports efficient splitting, so the converters in [[scala.jdk.StreamConverters]] can create parallel streams
+   *  from it.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a stepper over the keys, using a primitive-typed `Stepper` subclass when the resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`
+   */
   override def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Node[K, V]
@@ -96,6 +130,14 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns a [[Stepper]] for the values of this tree map. The stepper visits the values in ascending order of the
+   *  associated keys and supports efficient splitting, so the converters in [[scala.jdk.StreamConverters]] can
+   *  create parallel streams from it.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a stepper over the values, using a primitive-typed `Stepper` subclass when the resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`
+   */
   override def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Node[K, V]
@@ -108,12 +150,29 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Adds the key-value pair `elem` to this tree map. If the map already contains an entry whose key is equal to
+   *  `elem._1` under the ordering, that entry's value is replaced by `elem._2`.
+   *
+   *  @param elem the key-value pair to add
+   *  @return this tree map
+   */
   def addOne(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
 
+  /** Removes the entry with key `elem` from this tree map, if one exists; otherwise does nothing.
+   *
+   *  @param elem the key of the entry to remove
+   *  @return this tree map
+   */
   def subtractOne(elem: K): this.type = { RB.delete(tree, elem); this }
 
+  /** Removes all entries from this tree map, leaving it empty */
   override def clear(): Unit = RB.clear(tree)
 
+  /** Returns the value associated with `key` in this tree map.
+   *
+   *  @param key the key to look up
+   *  @return a `Some` containing the value associated with `key`, or `None` if the key is not present
+   */
   def get(key: K): Option[V] = RB.get(tree, key)
 
   /** Creates a ranged projection of this map. Any mutations in the ranged projection will update the original map and
@@ -132,23 +191,60 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    */
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
+  /** Applies `f` to each key-value pair of this tree map, in ascending order of keys, for its side effects.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each key-value pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
+  /** Applies `f` to the key and value of each entry of this tree map, passed as two separate arguments, in ascending
+   *  order of keys, for its side effects.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to the key and value of each entry
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = RB.foreachEntry(tree, f)
 
+  /** Returns the number of entries in this tree map, in O(1) time */
   override def size: Int = RB.size(tree)
+  /** Returns the number of entries in this tree map; never -1, because the size is always known */
   override def knownSize: Int = size
+  /** Returns `true` if this tree map contains no entries */
   override def isEmpty: Boolean = RB.isEmpty(tree)
 
+  /** Returns `true` if this tree map contains an entry whose key is equal to `key` under the ordering.
+   *
+   *  @param key the key to look for
+   */
   override def contains(key: K): Boolean = RB.contains(tree, key)
 
+  /** Returns the entry with the smallest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def head: (K, V) = RB.min(tree).get
 
+  /** Returns the entry with the largest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def last: (K, V) = RB.max(tree).get
 
+  /** Returns the entry with the smallest key greater than or equal to `key`, if any.
+   *
+   *  @param key the lower bound (inclusive) for the key lookup
+   *  @return a `Some` containing the entry with the smallest key greater than or equal to `key`, or `None` if no such entry exists
+   */
   override def minAfter(key: K): Option[(K, V)] = RB.minAfter(tree, key)
 
+  /** Returns the entry with the largest key strictly less than `key`, if any.
+   *
+   *  @param key the upper bound (exclusive) for the key lookup
+   *  @return a `Some` containing the entry with the largest key strictly less than `key`, or `None` if no such entry exists
+   */
   override def maxBefore(key: K): Option[(K, V)] = RB.maxBefore(tree, key)
 
+  /** Returns `"TreeMap"`, the name used in this map's string representation */
   override protected def className: String = "TreeMap"
 
 
@@ -251,11 +347,32 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 @SerialVersionUID(3L)
 object TreeMap extends SortedMapFactory[TreeMap] {
 
+  /** Returns a new `TreeMap` containing the key-value pairs of `it`, ordered by the implicit `Ordering` on the keys.
+   *  If `it` contains several pairs whose keys are equal under the ordering, the value of the last such pair wins.
+   *
+   *  @tparam K the type of the keys, which must have an implicit `Ordering`
+   *  @tparam V the type of the values
+   *  @param it the key-value pairs of the new tree map
+   *  @return a new `TreeMap` containing the entries of `it`
+   */
   def from[K : Ordering, V](it: IterableOnce[(K, V)]^): TreeMap[K, V] =
     Growable.from(empty[K, V], it)
 
+  /** Returns a new, empty `TreeMap` ordered by the implicit `Ordering` on the keys.
+   *
+   *  @tparam K the type of the keys, which must have an implicit `Ordering`
+   *  @tparam V the type of the values
+   *  @return an empty `TreeMap`
+   */
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
 
+  /** Returns a new builder that builds a `TreeMap` by inserting the supplied key-value pairs into an initially
+   *  empty tree map.
+   *
+   *  @tparam K the type of the keys, which must have an implicit `Ordering`
+   *  @tparam V the type of the values
+   *  @return a builder for a new `TreeMap`
+   */
   def newBuilder[K: Ordering, V]: Builder[(K, V), TreeMap[K, V]] = new GrowableBuilder(empty[K, V])
 
 }

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -47,12 +47,27 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
    */
   def this()(implicit ord: Ordering[A]) = this(RB.Tree.empty)(using ord)
 
+  /** Returns the companion object [[TreeSet]], the factory used to create new tree sets of the same type */
   override def sortedIterableFactory: SortedIterableFactory[TreeSet] = TreeSet
 
+  /** Returns an iterator over the elements of this tree set, in ascending order */
   def iterator: collection.Iterator[A] = RB.keysIterator(tree)
 
+  /** Returns an iterator over the elements of this tree set that are greater than or equal to `start`, in ascending
+   *  order.
+   *
+   *  @param start the lower bound (inclusive) on the elements to return
+   */
   def iteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
 
+  /** Returns a [[Stepper]] for the elements of this tree set. The stepper visits the elements in ascending order
+   *  and supports efficient splitting, so the converters in [[scala.jdk.StreamConverters]] can create parallel
+   *  streams from it.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a stepper over the elements, using a primitive-typed `Stepper` subclass when the resolved `StepperShape` corresponds to `Int`, `Long`, or `Double`
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Node[A, Null]
@@ -65,38 +80,97 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Adds `elem` to this tree set. If the set already contains an element equal to `elem` under the ordering, the
+   *  set is unchanged.
+   *
+   *  @param elem the element to add
+   *  @return this tree set
+   */
   def addOne(elem: A): this.type = {
     RB.insert(tree, elem, null)
     this
   }
 
+  /** Removes the element equal to `elem` under the ordering from this tree set, if one exists; otherwise does
+   *  nothing.
+   *
+   *  @param elem the element to remove
+   *  @return this tree set
+   */
   def subtractOne(elem: A): this.type = {
     RB.delete(tree, elem)
     this
   }
 
+  /** Removes all elements from this tree set, leaving it empty */
   def clear(): Unit = RB.clear(tree)
 
+  /** Returns `true` if this tree set contains an element equal to `elem` under the ordering.
+   *
+   *  @param elem the element to look for
+   */
   def contains(elem: A): Boolean = RB.contains(tree, elem)
 
+  /** Returns this set itself, with its static type widened to `collection.Set`; no bounds are removed */
   def unconstrained: collection.Set[A] = this
 
+  /** Creates a ranged projection of this set. Any mutations in the ranged projection affect the original set and
+   *  vice versa.
+   *
+   *  Only elements between this projection's bounds will ever appear as elements of this set, independently of
+   *  whether the elements are added through the original set or through this view. That means that if one inserts an
+   *  element in a view whose key is outside the view's bounds, calls to `contains` will _not_ consider the newly
+   *  added element. Mutations are always reflected in the original set, though.
+   *
+   *  @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
+   *             bound.
+   *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
+   *              bound.
+   *  @return a new `TreeSet` that is a ranged projection of this set, sharing the same underlying data
+   */
   def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = new TreeSetProjection(from, until)
 
+  /** Returns `"TreeSet"`, the name used in this set's string representation */
   override protected def className: String = "TreeSet"
 
+  /** Returns the number of elements in this tree set, in O(1) time */
   override def size: Int = RB.size(tree)
+  /** Returns the number of elements in this tree set; never -1, because the size is always known */
   override def knownSize: Int = size
+  /** Returns `true` if this tree set contains no elements */
   override def isEmpty: Boolean = RB.isEmpty(tree)
 
+  /** Returns the smallest element of this tree set.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def head: A = RB.minKey(tree).get
 
+  /** Returns the largest element of this tree set.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def last: A = RB.maxKey(tree).get
 
+  /** Returns the smallest element greater than or equal to `key`, if any.
+   *
+   *  @param key the lower bound (inclusive) for the lookup
+   *  @return a `Some` containing the smallest element greater than or equal to `key`, or `None` if no such element exists
+   */
   override def minAfter(key: A): Option[A] = RB.minKeyAfter(tree, key)
 
+  /** Returns the largest element strictly less than `key`, if any.
+   *
+   *  @param key the upper bound (exclusive) for the lookup
+   *  @return a `Some` containing the largest element strictly less than `key`, or `None` if no such element exists
+   */
   override def maxBefore(key: A): Option[A] = RB.maxKeyBefore(tree, key)
 
+  /** Applies `f` to each element of this tree set, in ascending order, for its side effects.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function to apply to each element
+   */
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
 
 
@@ -196,8 +270,24 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
 @SerialVersionUID(3L)
 object TreeSet extends SortedIterableFactory[TreeSet] {
 
+  /** Returns a new, empty `TreeSet` ordered by the implicit `Ordering`.
+   *
+   *  @tparam A the type of the elements, which must have an implicit `Ordering`
+   *  @return an empty `TreeSet`
+   */
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
+  /** Returns a new `TreeSet` containing the elements of `it`, ordered by `ordering`.
+   *
+   *  When `it` is itself a `TreeSet` with an equal ordering, its tree is copied node by node; when it is another
+   *  sorted set with an equal ordering, or a `Range` ordered by `Ordering.Int` or its reverse, the new tree is built
+   *  in one pass from the already ordered elements; otherwise the elements are inserted one by one.
+   *
+   *  @tparam E the type of the elements
+   *  @param it the elements of the new tree set
+   *  @param ordering the ordering used to compare elements
+   *  @return a new `TreeSet` containing the elements of `it`
+   */
   def from[E](it: IterableOnce[E]^)(implicit ordering: Ordering[E]): TreeSet[E] =
     (it: @unchecked) match {
       case ts: TreeSet[E] if ordering == ts.ordering =>
@@ -214,6 +304,13 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
         new TreeSet[E](t)
     }
 
+  /** Returns a new builder that builds a `TreeSet` by inserting the supplied elements into an initially empty tree.
+   *  The builder is reusable: calling `result()` and then `clear()` allows building another, independent tree set.
+   *
+   *  @tparam A the type of the elements
+   *  @param ordering the ordering used to compare elements
+   *  @return a builder for a new `TreeSet`
+   */
   def newBuilder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = new ReusableBuilder[A, TreeSet[A]] {
     private var tree: RB.Tree[A, Null] = RB.Tree.empty
     def addOne(elem: A): this.type = { RB.insert(tree, elem, null); this }

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -68,11 +68,21 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   private[collection] def lastPtr_=(last: Unrolled[T]) = lastptr = last
   private[collection] def size_=(s: Int) = sz = s
 
+  /** The factory used by the default `fromSpecific`, `newSpecificBuilder` and
+   *  `empty` implementations: the companion object `UnrolledBuffer`.
+   */
   protected def evidenceIterableFactory: UnrolledBuffer.type = UnrolledBuffer
+  /** The `ClassTag` of the element type, passed as evidence to `evidenceIterableFactory`. */
   protected def iterableEvidence: ClassTag[T] = tag
 
+  /** The factory used by generic transformation methods such as `map`: the
+   *  `untagged` companion factory, which uses `ClassTag.Any` since no
+   *  `ClassTag` for the new element type is available, so elements of the
+   *  resulting buffers are stored boxed.
+   */
   override def iterableFactory: SeqFactory[UnrolledBuffer] = UnrolledBuffer.untagged
 
+  /** Creates a new, empty node associated with this buffer, holding an array of 32 elements. */
   protected def newUnrolled = new Unrolled[T](this)
 
   // The below would allow more flexible behavior without requiring inheritance
@@ -90,6 +100,9 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   // def setLengthPolicy(nextLength: Int => Int): Unit = { myLengthPolicy = nextLength }
   private[collection] def calcNextLength(sz: Int) = sz // myLengthPolicy(sz)
 
+  /** The companion object `UnrolledBuffer`, which requires a `ClassTag` for
+   *  the element type to create a buffer.
+   */
   def classTagCompanion: UnrolledBuffer.type = UnrolledBuffer
 
   /** Concatenates the target unrolled buffer to this unrolled buffer.
@@ -115,18 +128,37 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     this
   }
 
+  /** Appends `elem` to this buffer, in constant time.
+   *
+   *  When the last node's array is full, a new node is allocated; existing
+   *  arrays are never reallocated or copied.
+   *
+   *  @param elem the element to append
+   *  @return this $coll
+   */
   def addOne(elem: T) = {
     lastptr = lastptr.append(elem)
     sz += 1
     this
   }
 
+  /** Removes all elements from this buffer.
+   *
+   *  A fresh, empty node is allocated; existing nodes are left untouched.
+   *  `concat` relies on this when it clears the buffer whose nodes it has
+   *  taken over.
+   */
   def clear(): Unit = {
     headptr = newUnrolled
     lastptr = headptr
     sz = 0
   }
 
+  /** Returns an iterator over the elements of this buffer, walking the chain
+   *  of internal arrays.
+   *
+   *  The iterator does not check for concurrent mutation of the buffer.
+   */
   def iterator: Iterator[T] = new AbstractIterator[T] {
     var pos: Int = -1
     var node: Unrolled[T] | Null = headptr
@@ -149,18 +181,45 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   }
 
   // this should be faster than the iterator
+  /** Applies `f` to each element of this buffer.
+   *
+   *  Overridden to traverse the internal arrays directly, which is faster than
+   *  going through `iterator`.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each element for its side effect
+   */
   override def foreach[U](f: T => U) = headptr.foreach(f)
 
+  /** Returns this buffer itself: an `UnrolledBuffer` is its own [[Builder]]. */
   def result() = this
 
+  /** Returns the number of elements in this buffer, in constant time. */
   def length = sz
 
+  /** Returns the number of elements in this buffer. Never `-1`, as the size is always known. */
   override def knownSize: Int = sz
 
+  /** Returns the element at index `idx`.
+   *
+   *  Takes `O(n/m)` time, where `n` is the buffer length and `m` the size of
+   *  the internal arrays: the node chain is walked to locate the element.
+   *
+   *  @param idx the index of the element to return
+   *  @throws IndexOutOfBoundsException if `idx < 0` or `idx >= length`
+   */
   def apply(idx: Int) =
     if (idx >= 0 && idx < sz) headptr(idx)
     else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
+  /** Replaces the element at index `idx` with `newelem`.
+   *
+   *  Takes `O(n/m)` time, like `apply`.
+   *
+   *  @param idx the index of the element to replace
+   *  @param newelem the new element
+   *  @throws IndexOutOfBoundsException if `idx < 0` or `idx >= length`
+   */
   def update(idx: Int, newelem: T) =
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
     else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
@@ -175,32 +234,93 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     this
   }
 
+  /** Removes and returns the element at index `idx`.
+   *
+   *  The elements after it within its node are shifted left. If the node's
+   *  remaining elements together with those of the next node then fall below
+   *  the waterline (see [[UnrolledBuffer.waterline]]), the two nodes are
+   *  merged.
+   *
+   *  @param idx the index of the element to remove
+   *  @return the removed element
+   *  @throws IndexOutOfBoundsException if `idx < 0` or `idx >= length`
+   */
   def remove(idx: Int) =
     if (idx >= 0 && idx < sz) {
       sz -= 1
       headptr.remove(idx, this)
     } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
+  /** Removes `count` elements starting at index `idx`, by removing the element
+   *  at `idx` repeatedly, `count` times.
+   *
+   *  If `count <= 0`, this buffer is unchanged and the bounds are not checked;
+   *  in particular, a negative `count` does not throw an exception. If fewer
+   *  than `count` elements exist at or after `idx`, those up to the end of the
+   *  buffer are removed before the bounds check of the next removal fails.
+   *
+   *  @param idx the index of the first element to remove
+   *  @param count the number of elements to remove
+   *  @throws IndexOutOfBoundsException if `count > 0` and the index `idx` is not in
+   *          the valid range `0 <= idx <= length - count`; the elements before the
+   *          failing index remain removed
+   */
   @tailrec final def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
       remove(idx)
       remove(idx, count-1)
     }
 
+  /** Prepends `elem` to this buffer.
+   *
+   *  The existing elements of the head node are shifted right; if the head
+   *  node's array is full, a new head node is allocated instead.
+   *
+   *  @param elem the element to prepend
+   *  @return this $coll
+   */
   def prepend(elem: T) = {
     headptr = headptr prepend elem
     sz += 1
     this
   }
 
+  /** Inserts `elem` at index `idx` into this buffer, like `insertAll` with a
+   *  single element.
+   *
+   *  @param idx the index where the element is inserted; if `idx == length`,
+   *             the element is appended
+   *  @param elem the element to insert
+   *  @throws IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *          `0 <= idx <= length`
+   */
   def insert(idx: Int, elem: T): Unit =
     insertAll(idx, elem :: Nil)
 
+  /** Inserts all elements of `elems` at index `idx` into this buffer.
+   *
+   *  The node containing index `idx` is split at that position, the new elements
+   *  are appended to its front half, and the rear half is linked back after them.
+   *  Inserting at the end of a node appends to it instead, with no split.
+   *
+   *  @param idx the index where the elements are inserted; if `idx == length`,
+   *             the elements are appended
+   *  @param elems the collection containing the elements to insert
+   *  @throws IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *          `0 <= idx <= length`
+   */
   def insertAll(idx: Int, elems: IterableOnce[T]^): Unit =
     if (idx >= 0 && idx <= sz) {
       sz += headptr.insertAll(idx, elems, this)
     } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
+  /** Removes the first occurrence of `elem` from this buffer, if any.
+   *
+   *  If this buffer does not contain `elem`, it is unchanged.
+   *
+   *  @param elem the element to remove
+   *  @return this $coll
+   */
   override def subtractOne(elem: T): this.type = {
     if (headptr.subtractOne(elem, this)) {
       sz -= 1
@@ -208,6 +328,23 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     this
   }
 
+  /** Replaces `replaced` elements starting at index `from` with the elements
+   *  of `patch`, as `remove(from, replaced)` followed by
+   *  `insertAll(from, patch)`.
+   *
+   *  Unlike the general `Buffer.patchInPlace` contract, out-of-range arguments
+   *  are not clamped: an out-of-range `from` or an excessive `replaced` count
+   *  leads to an exception from the underlying `remove` or `insertAll`, which
+   *  may leave the buffer partially modified.
+   *
+   *  @param from the index of the first replaced element
+   *  @param patch the replacement sequence
+   *  @param replaced the number of elements to drop in the original $coll
+   *  @return this $coll
+   *  @throws IndexOutOfBoundsException if `replaced > 0` and `from` is not in the
+   *          valid range `0 <= from <= length - replaced`, or if `replaced <= 0`
+   *          and `from` is not in the valid range `0 <= from <= length`
+   */
   def patchInPlace(from: Int, patch: collection.IterableOnce[T]^, replaced: Int): this.type = {
     remove(from, replaced)
     insertAll(from, patch)
@@ -235,8 +372,12 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     }
   }
 
+  /** Returns a copy of this buffer: a new `UnrolledBuffer` with fresh internal
+   *  nodes holding the same elements. The elements themselves are not copied.
+   */
   override def clone(): UnrolledBuffer[T] = new UnrolledBuffer[T] ++= this
 
+  /** The prefix of this $coll's `toString` representation, `"UnrolledBuffer"`. */
   override protected def className = "UnrolledBuffer"
 }
 
@@ -244,18 +385,44 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 @SerialVersionUID(3L)
 object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] { self =>
 
+  /** A `SeqFactory` view of this companion that creates unrolled buffers using
+   *  `ClassTag.Any` as the element evidence, so that no `ClassTag` is required.
+   */
   val untagged: SeqFactory[UnrolledBuffer] = new ClassTagSeqFactory.AnySeqDelegate(self)
 
+  /** Creates a new, empty unrolled buffer.
+   *
+   *  @tparam A the element type; its `ClassTag` determines the type of the internal arrays
+   *  @return a new empty `UnrolledBuffer`
+   */
   def empty[A : ClassTag]: UnrolledBuffer[A] = new UnrolledBuffer[A]
 
+  /** Creates an unrolled buffer containing the elements of `source`.
+   *
+   *  @tparam A the element type; its `ClassTag` determines the type of the internal arrays
+   *  @param source the collection providing the elements
+   *  @return a new `UnrolledBuffer` with the elements of `source` in order
+   */
   def from[A : ClassTag](source: scala.collection.IterableOnce[A]^): UnrolledBuffer[A] = newBuilder[A].addAll(source)
 
+  /** Creates a new, empty unrolled buffer, which serves as its own builder.
+   *
+   *  @tparam A the element type; its `ClassTag` determines the type of the internal arrays
+   *  @return a new empty `UnrolledBuffer`
+   */
   def newBuilder[A : ClassTag]: UnrolledBuffer[A] = new UnrolledBuffer[A]
 
+  /** The numerator, 50, of the waterline fraction
+   *  `waterline / waterlineDenom` (50/100): after a removal, a node is merged
+   *  with its successor when their combined element count falls below this
+   *  fraction of the node's array length.
+   */
   final val waterline: Int = 50
 
+  /** The denominator, 100, of the waterline fraction; see [[waterline]]. */
   final def waterlineDenom: Int = 100
 
+  /** An alias for `waterlineDenom`. */
   @deprecated("Use waterlineDenom instead.", "2.13.0")
   final val waterlineDelim: Int = waterlineDenom
 
@@ -273,6 +440,12 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
     private def nextlength = if (buff eq null) unrolledlength else buff.calcNextLength(array.length)
 
     // adds and returns itself or the new unrolled if full
+    /** Appends `elem` to this node, or to a freshly allocated successor node if
+     *  this node's array is full.
+     *
+     *  @param elem the element to append
+     *  @return the node the element was stored in: this node, or the new successor
+     */
     @tailrec final def append(elem: T): Unrolled[T] = if (size < array.length) {
       array(size) = elem
       size += 1
@@ -281,6 +454,11 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
       next = new Unrolled[T](0, new Array[T](nextlength), null, buff)
       next.nn append elem
     }
+    /** Applies `f` to each element of this node and all following nodes.
+     *
+     *  @tparam U the result type of `f`, which is discarded
+     *  @param f the function applied to each element for its side effect
+     */
     def foreach[U](f: T => U): Unit = {
       var unrolled: Unrolled[T] | Null = this
       var i = 0
@@ -296,6 +474,11 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
         unrolled = unrolled.next
       }
     }
+    /** Replaces each element of this node and all following nodes with `f`
+     *  applied to it.
+     *
+     *  @param f the mapping function
+     */
     def mapInPlace(f: T => T): Unit = {
       var unrolled: Unrolled[T] | Null = this
       var i = 0
@@ -311,12 +494,45 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
         unrolled = unrolled.next
       }
     }
+    /** Returns the element at index `idx`, counting from the start of this
+     *  node and following the node chain as needed.
+     *
+     *  Assumes `idx` is within bounds; the public `UnrolledBuffer` methods
+     *  check bounds before delegating here.
+     *
+     *  @param idx the index, relative to this node, of the element to return
+     *  @return the element at index `idx`
+     */
     @tailrec final def apply(idx: Int): T =
       if (idx < size) array(idx) else next.nn.apply(idx - size)
+    /** Replaces the element at index `idx`, counting from the start of this
+     *  node and following the node chain as needed, with `newelem`.
+     *
+     *  Assumes `idx` is within bounds; the public `UnrolledBuffer` methods
+     *  check bounds before delegating here.
+     *
+     *  @param idx the index, relative to this node, of the element to replace
+     *  @param newelem the new element
+     */
     @tailrec final def update(idx: Int, newelem: T): Unit =
       if (idx < size) array(idx) = newelem else next.nn.update(idx - size, newelem)
+    /** Returns the node holding the element at index `idx`, counting from the
+     *  start of this node.
+     *
+     *  Assumes `idx` is within bounds.
+     *
+     *  @param idx the index, relative to this node, to locate
+     *  @return the node containing that index
+     */
     @tailrec final def locate(idx: Int): Unrolled[T] =
       if (idx < size) this else next.nn.locate(idx - size)
+    /** Inserts `elem` before the first element of this node, shifting the
+     *  existing elements right, or into a freshly allocated head node if this
+     *  node's array is full.
+     *
+     *  @param elem the element to prepend
+     *  @return the new head of the chain: this node, or the newly allocated one
+     */
     def prepend(elem: T) = if (size < array.length) {
       // shift the elements of the array right
       // then insert the element
@@ -341,6 +557,19 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
       }
     }
     // returns pointer to new last if changed
+    /** Removes and returns the element at index `idx`, counting from the start
+     *  of this node.
+     *
+     *  The elements after it in its node are shifted left, and the node is
+     *  merged with its successor if their combined element count falls below
+     *  the waterline. When such a merge discards the chain's last node,
+     *  `buffer`'s last-node pointer is updated to the merged node.
+     *
+     *  @param idx the index, relative to this node, of the element to remove
+     *  @param buffer the buffer this chain belongs to, whose last-node pointer
+     *                may need updating
+     *  @return the removed element
+     */
     @tailrec final def remove(idx: Int, buffer: UnrolledBuffer[T]): T =
       if (idx < size) {
         // remove the element
@@ -352,6 +581,14 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
         r
       } else next.nn.remove(idx - size, buffer)
 
+    /** Removes the first occurrence of `elem` in this node or any following
+     *  node, via `remove`.
+     *
+     *  @param elem the element to remove
+     *  @param buffer the buffer this chain belongs to, whose last-node pointer
+     *                may need updating
+     *  @return `true` if an occurrence was found and removed, `false` otherwise
+     */
     @tailrec final def subtractOne(elem: T, buffer: UnrolledBuffer[T]): Boolean = {
       var i = 0
       while (i < size) {
@@ -373,6 +610,14 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
       }
       nullout(i, i + 1)
     }
+    /** Merges the next node into this one if the combined element count of the
+     *  two nodes is below the waterline fraction (see
+     *  [[UnrolledBuffer.waterline]]) of this node's array length.
+     *
+     *  @return `true` if a merge happened and the absorbed node was the last
+     *          one in the chain, so the buffer's last-node pointer must be
+     *          updated to this node; `false` otherwise
+     */
     protected def tryMergeWithNext() = if (next != null && (size + next.nn.size) < (array.length * waterline / waterlineDenom)) {
       // copy the next array, then discard the next node
       Array.copy(next.nn.array, 0, array, size, next.nn.size)
@@ -381,6 +626,22 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
       if (next eq null) true else false // checks if last node was thrown out
     } else false
 
+    /** Inserts all elements of `t` at index `idx`, counting from the start of
+     *  this node.
+     *
+     *  The node containing the index is split at that position into a front half
+     *  and a fresh rear-half node; the new elements are appended after the front
+     *  half, the rear half is linked back after them, and a waterline merge of the
+     *  two is attempted. Inserting at the end of the node appends to it instead,
+     *  with no split. `buffer`'s last-node pointer
+     *  is updated when the insertion changes the chain's last node.
+     *
+     *  @param idx the index, relative to this node, at which to insert
+     *  @param t the collection containing the elements to insert
+     *  @param buffer the buffer this chain belongs to, whose last-node pointer
+     *                may need updating
+     *  @return the number of elements inserted
+     */
     @tailrec final def insertAll(idx: Int, t: scala.collection.IterableOnce[T]^, buffer: UnrolledBuffer[T]): Int = {
       if (idx < size) {
         // divide this node at the appropriate position and insert all into head
@@ -432,12 +693,22 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
     // assumes this is the last node
     // `thathead` and `thatlast` are head and last node
     // of the other unrolled list, respectively
+    /** Appends the chain starting at `thathead` after this node, which must be
+     *  the last node of its own chain, then attempts a waterline merge.
+     *
+     *  @param thathead the head node of the other chain
+     *  @return `true` if the merge absorbed the entire other chain, so that
+     *          this node is still the last one; `false` otherwise
+     */
     def bind(thathead: Unrolled[T]) = {
       assert(next eq null)
       next = thathead
       tryMergeWithNext()
     }
 
+    /** Returns a debug string showing, for this node and all following nodes,
+     *  the fill ratio (`size/capacity`) and the elements.
+     */
     override def toString(): String =
       array.take(size).mkString(s"Unrolled@${System.identityHashCode(this).toHexString}[$size/${array.length}](", ", ", ")") + " -> " + (if (next ne null) next.toString else "")
   }

--- a/library/src/scala/collection/mutable/WeakHashMap.scala
+++ b/library/src/scala/collection/mutable/WeakHashMap.scala
@@ -38,8 +38,11 @@ import scala.collection.convert.JavaCollectionWrappers.{JMapWrapper, JMapWrapper
 class WeakHashMap[K, V] extends JMapWrapper[K, V](new java.util.WeakHashMap)
     with JMapWrapperLike[K, V, WeakHashMap, WeakHashMap[K, V]]
     with MapFactoryDefaults[K, V, WeakHashMap, Iterable] {
+  /** Returns a new empty `WeakHashMap` of the same key and value types. */
   override def empty = new WeakHashMap[K, V]
+  /** Returns the companion object `WeakHashMap`, which builds maps of this kind. */
   override def mapFactory: MapFactory[WeakHashMap] = WeakHashMap
+  /** Returns `"WeakHashMap"`, the name used in this map's string representation. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "WeakHashMap"
 }
@@ -50,8 +53,31 @@ class WeakHashMap[K, V] extends JMapWrapper[K, V](new java.util.WeakHashMap)
  */
 @SerialVersionUID(3L)
 object WeakHashMap extends MapFactory[WeakHashMap] {
+  /** Creates a new empty `WeakHashMap`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @return a new empty `WeakHashMap`
+   */
   def empty[K, V]: WeakHashMap[K,V] = new WeakHashMap[K, V]
+  /** Creates a new `WeakHashMap` from a collection of key/value pairs.
+   *
+   *  If several pairs share a key, the last one wins. Like any `WeakHashMap`,
+   *  the result holds its keys weakly, so entries whose keys are no longer
+   *  strongly referenced elsewhere may disappear from it.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the key/value pairs to initialize the map with
+   *  @return a new `WeakHashMap` containing the pairs of `it`
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): WeakHashMap[K,V] = Growable.from(empty[K, V], it)
+  /** Creates a new empty builder for a `WeakHashMap`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @return a new builder that produces a `WeakHashMap` from the key/value pairs added to it
+   */
   def newBuilder[K, V]: Builder[(K, V), WeakHashMap[K,V]] = new GrowableBuilder(WeakHashMap.empty[K, V])
 }
 

--- a/library/src/scala/collection/mutable/package.scala
+++ b/library/src/scala/collection/mutable/package.scala
@@ -18,14 +18,23 @@ import language.experimental.captureChecking
 package object mutable {
   @deprecated("Use ArraySeq instead of WrappedArray; it can represent both, boxed and unboxed arrays", "2.13.0")
   type WrappedArray[X] = ArraySeq[X]
+  /** Alias for the [[ArraySeq]] companion object, kept so that code written against
+   *  the old name can still call factory methods such as `WrappedArray(1, 2, 3)`.
+   */
   @deprecated("Use ArraySeq instead of WrappedArray; it can represent both, boxed and unboxed arrays", "2.13.0")
   val WrappedArray = ArraySeq
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   type Traversable[X] = Iterable[X]
+  /** Alias for the [[Iterable]] companion object, kept so that code written against
+   *  the old name can still call factory methods such as `Traversable(1, 2, 3)`.
+   */
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
   @deprecated("Use Stack instead of ArrayStack; it now uses an array-based implementation", "2.13.0")
   type ArrayStack[X] = Stack[X]
+  /** Alias for the [[Stack]] companion object, kept so that code written against
+   *  the old name can still call factory methods such as `ArrayStack(1, 2, 3)`.
+   */
   @deprecated("Use Stack instead of ArrayStack; it now uses an array-based implementation", "2.13.0")
   val ArrayStack = Stack
 


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for `scala.collection.mutable` APIs that are completely missing any Scaladoc documentation. It covers the buffers and array-backed sequences, the hash and tree maps and sets, the builders and the specialised maps such as `LongMap`, `AnyRefMap` and `OpenHashMap`. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.