### PR TITLE
collection, core (10): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -124,6 +124,17 @@ object ArrayOps {
       b.result()
     }
 
+    /** Builds a new array by applying a function to all elements of this array
+     *  and using the elements of the results after converting them to `Iterable`s.
+     *
+     *  @tparam BS the type returned by `f`, convertible to an `Iterable` of `B`
+     *  @tparam B the element type of the returned array
+     *  @param f the function to apply to each element
+     *  @param asIterable the conversion applied to each result of `f`
+     *  @param m the class tag for the element type `B`, required to create the result array
+     *  @return a new array resulting from applying `f` to each element of this
+     *          array and concatenating the converted results
+     */
     def flatMap[BS, B](f: A => BS)(implicit asIterable: BS => Iterable[B], m: ClassTag[B]): Array[B] =
       flatMap[B](x => asIterable(f(x)))
 
@@ -442,6 +453,13 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     slice(lo, xs.length)
   }
 
+  /** Returns an iterator over the elements of this array.
+   *
+   *  The array is matched on its runtime element type so that primitive arrays
+   *  get an iterator specialized to that primitive type.
+   *
+   *  @throws NullPointerException if this array is `null`
+   */
   def iterator: Iterator[A] =
     ((xs: Any @unchecked) match {
       case xs: Array[AnyRef]  => new ArrayOps.ArrayIterator(xs)
@@ -457,6 +475,19 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
       case null               => throw new NullPointerException
     }).asInstanceOf[Iterator[A]]
 
+  /** Returns a stepper for the elements of this array.
+   *
+   *  The implicit [[scala.collection.StepperShape]] parameter defines the
+   *  resulting `Stepper` type according to the element type of this array:
+   *  a primitive-typed stepper for `Int`/`Long`/`Double` (and related) element
+   *  types, an [[scala.collection.AnyStepper]] otherwise. The returned stepper
+   *  supports efficient splitting, so it can be used to create a parallel
+   *  stream via the converters in [[scala.jdk.StreamConverters]].
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a `Stepper` over the elements of this array
+   */
   def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import convert.impl._
     val s = (shape.shape: @unchecked) match {
@@ -989,6 +1020,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     ys
   }
 
+  /** Replaces each element of this array with the result of applying `f` to it.
+   *
+   *  @param f the function to apply to each element
+   *  @return this array itself after the in-place update; no new array is allocated
+   */
   def mapInPlace(f: A => A): Array[A] = {
     var i = 0
     while (i < xs.length) {
@@ -1016,6 +1052,17 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     b.result()
   }
 
+  /** Builds a new array by applying a function to all elements of this array
+   *  and using the elements of the results after converting them to `Iterable`s.
+   *
+   *  @tparam BS the type returned by `f`, convertible to an `Iterable` of `B`
+   *  @tparam B the element type of the returned array
+   *  @param f the function to apply to each element
+   *  @param asIterable the conversion applied to each result of `f`
+   *  @param m the class tag for the element type `B`, required to create the result array
+   *  @return a new array resulting from applying `f` to each element of this
+   *          array and concatenating the converted results
+   */
   def flatMap[BS, B](f: A => BS)(implicit asIterable: BS => Iterable[B]^, m: ClassTag[B]): Array[B] =
     flatMap[B](x => asIterable(f(x)))
 
@@ -1519,6 +1566,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` final def toSeq: immutable.Seq[A] = toIndexedSeq
 
+  /** Returns an immutable indexed sequence containing the elements of this
+   *  array, copied so that later changes to this array are not visible through
+   *  the result.
+   */
   def toIndexedSeq: immutable.IndexedSeq[A] =
     immutable.ArraySeq.unsafeWrapArray(Array.copyOf(xs, xs.length))
 

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -36,11 +36,27 @@ import scala.collection.mutable.Builder
  *  @define Coll `BitSet`
  */
 trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] { self: BitSet =>
+  /** Creates a bitset of the same kind as this bitset from the given
+   *  collection of elements, delegating to `bitSetFactory`.
+   *
+   *  @param coll the collection of elements to include; all must be non-negative
+   *  @return a bitset containing the elements of `coll`; the immutable factory returns
+   *          `coll` itself when it is already an immutable bitset
+   *  @throws IllegalArgumentException if `coll` contains a negative element
+   */
   override protected def fromSpecific(coll: IterableOnce[Int]^): BitSet = bitSetFactory.fromSpecific(coll)
+  /** Returns a builder for bitsets of the same kind as this bitset, obtained from `bitSetFactory`. */
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
+  /** Returns an empty bitset of the same kind as this bitset, obtained from `bitSetFactory`. */
   override def empty: BitSet = bitSetFactory.empty
+  /** The prefix used in the string representation of this set, `"BitSet"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "BitSet"
+  /** Returns this bitset viewed as an unsorted `Set[Int]`.
+   *
+   *  No copy is made: the result is this same bitset, so its iteration
+   *  order remains increasing.
+   */
   override def unsorted: Set[Int] = this
 }
 
@@ -49,8 +65,16 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   private[collection] final val ordMsg = "No implicit Ordering[${B}] found to build a SortedSet[${B}]. You may want to upcast to a Set[Int] first by calling `unsorted`."
   private[collection] final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Int, ${B})]. You may want to upcast to a Set[Int] first by calling `unsorted`."
 
+  /** Returns the empty bitset; this factory delegates to [[immutable.BitSet]]. */
   def empty: BitSet = immutable.BitSet.empty
+  /** Returns a builder for immutable bitsets. */
   def newBuilder: Builder[Int, BitSet] = immutable.BitSet.newBuilder
+  /** Creates an immutable bitset containing the elements of the given collection.
+   *
+   *  @param it the collection of elements to include; all must be non-negative
+   *  @return a new immutable bitset containing the elements of `it`
+   *  @throws IllegalArgumentException if `it` contains a negative element
+   */
   def fromSpecific(it: IterableOnce[Int]^): BitSet = immutable.BitSet.fromSpecific(it)
 
   @SerialVersionUID(3L)
@@ -92,10 +116,15 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
 
+  /** The factory used to build bitsets of the same kind as this bitset. */
   def bitSetFactory: SpecificIterableFactory[Int, C]
 
+  /** Returns this bitset viewed as an unsorted `Set[Int]`. */
   def unsorted: Set[Int]
 
+  /** The ordering of this bitset, always [[scala.math.Ordering.Int]]:
+   *  elements are iterated in increasing numeric order.
+   */
   final def ordering: Ordering[Int] = Ordering.Int
 
   /** The number of words (each with 64 bits) making up the set. */
@@ -116,11 +145,32 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
    */
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): C
 
+  /** Tests whether this bitset contains the given integer.
+   *
+   *  Tests a single bit of a single word, so the check runs in constant time.
+   *
+   *  @param elem the integer to test
+   *  @return `true` if `elem` is non-negative and its bit is set in this
+   *          bitset, `false` otherwise (in particular, always `false` for
+   *          negative values)
+   */
   def contains(elem: Int): Boolean =
     0 <= elem && (word(elem >> LogWL) & (1L << elem)) != 0L
 
+  /** Returns an iterator over the elements of this bitset in increasing order. */
   def iterator: Iterator[Int] = iteratorFrom(0)
 
+  /** Returns an iterator over all elements of this bitset greater than or
+   *  equal to `start`, in increasing order.
+   *
+   *  The iterator starts directly at the word containing `start` rather than
+   *  scanning from the beginning.
+   *
+   *  @param start the lower bound (inclusive) of the iterator; a
+   *               non-positive value yields all elements
+   *  @return an iterator over the elements of this bitset that are greater
+   *          than or equal to `start`
+   */
   def iteratorFrom(start: Int): Iterator[Int] = new AbstractIterator[Int] {
     private var currentPos = if (start > 0) start >> LogWL else 0
     private var currentWord = if (start > 0) word(currentPos) & (-1L << (start & (WordLength - 1))) else word(0)
@@ -141,6 +191,18 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     }
   }
 
+  /** Returns a [[scala.collection.Stepper]] for the elements of this bitset
+   *  that supports efficient splitting, enabling parallel processing.
+   *
+   *  Yields an [[scala.collection.IntStepper]] that works on unboxed values,
+   *  wrapped in a boxing [[scala.collection.AnyStepper]] if the reference
+   *  shape is requested.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a stepper over the elements of this bitset, marked with
+   *          [[scala.collection.Stepper.EfficientSplit]]
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Int, S]): S & EfficientSplit = {
     val st = scala.collection.convert.impl.BitSetStepper.from(this)
     val r =
@@ -152,6 +214,11 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     r.asInstanceOf[S & EfficientSplit]
   }
 
+  /** The number of elements in this bitset.
+   *
+   *  Computed by counting the set bits of each word, so it takes time
+   *  proportional to the number of words rather than the number of elements.
+   */
   override def size: Int = {
     var s = 0
     var i = nwords
@@ -162,6 +229,7 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     s
   }
 
+  /** Tests whether this bitset is empty, that is, whether every word is zero. */
   override def isEmpty: Boolean = 0 until nwords forall (i => word(i) == 0)
 
   @inline private def smallestInt: Int = {
@@ -189,17 +257,50 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     throw new UnsupportedOperationException("empty.largestInt")
   }
 
+  /** Returns the largest element of this bitset under the given ordering.
+   *
+   *  For the standard `Int` ordering, the result is found directly from the
+   *  highest set bit; for the reversed `Int` ordering, from the lowest set
+   *  bit. Any other ordering falls back to the general implementation, which
+   *  iterates over all elements.
+   *
+   *  @tparam B the type over which the ordering is defined (a supertype of `Int`)
+   *  @param ord the ordering used to compare elements
+   *  @return the largest element of this bitset with respect to `ord`
+   *  @throws UnsupportedOperationException if this bitset is empty
+   */
   override def max[B >: Int](implicit ord: Ordering[B]): Int =
     if (Ordering.Int eq ord) largestInt
     else if (Ordering.Int isReverseOf ord) smallestInt
     else super.max(using ord)
 
 
+  /** Returns the smallest element of this bitset under the given ordering.
+   *
+   *  For the standard `Int` ordering, the result is found directly from the
+   *  lowest set bit; for the reversed `Int` ordering, from the highest set
+   *  bit. Any other ordering falls back to the general implementation, which
+   *  iterates over all elements.
+   *
+   *  @tparam B the type over which the ordering is defined (a supertype of `Int`)
+   *  @param ord the ordering used to compare elements
+   *  @return the smallest element of this bitset with respect to `ord`
+   *  @throws UnsupportedOperationException if this bitset is empty
+   */
   override def min[B >: Int](implicit ord: Ordering[B]): Int =
     if (Ordering.Int eq ord) smallestInt
     else if (Ordering.Int isReverseOf ord) largestInt
     else super.min(using ord)
 
+  /** Applies the function `f` to each element of this bitset in increasing
+   *  order.
+   *
+   *  Scans the words and their set bits directly instead of creating an
+   *  iterator.
+   *
+   *  @tparam U the result type of `f`, ignored
+   *  @param f the function applied to each element for its side effects
+   */
   override def foreach[U](f: Int => U): Unit = {
     /* NOTE: while loops are significantly faster as of 2.11 and
        one major use case of bitsets is performance. Also, there
@@ -229,6 +330,20 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     a
   }
 
+  /** Creates a bitset containing the elements of this bitset that fall
+   *  within the given optional bounds.
+   *
+   *  The result is built from a masked copy of this bitset's words, so it is
+   *  a new independent bitset, not a projection: later changes to either
+   *  bitset are not reflected in the other.
+   *
+   *  @param from the lower bound (inclusive) of the range; `None` if there
+   *              is no lower bound
+   *  @param until the upper bound (exclusive) of the range; `None` if there
+   *               is no upper bound
+   *  @return a new bitset containing the elements of this bitset that are
+   *          within the given bounds
+   */
   def rangeImpl(from: Option[Int], until: Option[Int]): C = {
     val a = coll.toBitMask
     val len = a.length
@@ -253,6 +368,17 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     coll.fromBitMaskNoCopy(a)
   }
 
+  /** Computes the union of this bitset and another collection.
+   *
+   *  When `other` is also a bitset, the union is computed word-by-word with
+   *  bitwise "or"; otherwise the elements of `other` are added individually.
+   *
+   *  @param other the collection of elements to add
+   *  @return a new bitset containing all elements of this bitset and all
+   *          elements of `other`
+   *  @throws IllegalArgumentException if `other` is not a bitset and
+   *          contains a negative element
+   */
   override def concat(other: collection.IterableOnce[Int]^): C = other match {
     case otherBitset: BitSet =>
       val len = coll.nwords max otherBitset.nwords
@@ -263,6 +389,16 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     case _ => super.concat(other)
   }
 
+  /** Computes the intersection of this bitset and another set.
+   *
+   *  When `other` is also a bitset, the intersection is computed
+   *  word-by-word with bitwise "and"; otherwise this bitset is filtered by
+   *  membership in `other`.
+   *
+   *  @param other the set to intersect with
+   *  @return a new bitset containing the elements of this bitset that are
+   *          also in `other`
+   */
   override def intersect(other: Set[Int]): C = other match {
     case otherBitset: BitSet =>
       val len = coll.nwords min otherBitset.nwords
@@ -273,6 +409,16 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     case _ => super.intersect(other)
   }
 
+  /** Computes the difference of this bitset and another set.
+   *
+   *  When `other` is also a bitset, the difference is computed word-by-word
+   *  with bitwise "and not"; otherwise it falls back to the general set
+   *  difference.
+   *
+   *  @param other the set of elements to exclude
+   *  @return a new bitset containing the elements of this bitset that are
+   *          not also in `other`
+   */
   abstract override def diff(other: Set[Int]): C = other match {
     case otherBitset: BitSet =>
       val len = coll.nwords
@@ -307,10 +453,37 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
    */
   def map(f: Int => Int): C = fromSpecific(new View.Map(this, f))
 
+  /** Builds a new bitset by applying a function to all elements of this
+   *  bitset and concatenating the resulting collections.
+   *
+   *  @param f the function to apply to each element
+   *  @return a new bitset containing the elements of the collections
+   *          returned by `f` for the elements of this bitset
+   *  @throws IllegalArgumentException if a collection returned by `f`
+   *          contains a negative value
+   */
   def flatMap(f: Int => IterableOnce[Int]^): C = fromSpecific(new View.FlatMap(this, f))
 
+  /** Builds a new bitset by applying a partial function to all elements of
+   *  this bitset on which the function is defined.
+   *
+   *  @param pf the partial function to apply to each element
+   *  @return a new bitset containing the results of applying `pf` to each
+   *          element of this bitset on which it is defined
+   *  @throws IllegalArgumentException if `pf` returns a negative value for
+   *          some element
+   */
   def collect(pf: PartialFunction[Int, Int]^): C = fromSpecific(super[SortedSetOps].collect(pf))
 
+  /** Splits this bitset into a pair of bitsets according to a predicate.
+   *
+   *  The first bitset is obtained by filtering with `p`; the second is the
+   *  difference of this bitset and the first.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of bitsets: the first containing all elements of this
+   *          bitset that satisfy `p`, the second containing those that do not
+   */
   override def partition(p: Int => Boolean): (C, C) = {
     val left = filter(p)
     (left, this &~ left)

--- a/library/src/scala/collection/BufferedIterator.scala
+++ b/library/src/scala/collection/BufferedIterator.scala
@@ -31,5 +31,6 @@ trait BufferedIterator[+A] extends Iterator[A] {
    */
   def headOption : Option[A] = if (hasNext) Some(head) else None
 
+  /** Returns this iterator itself, because it is already buffered. */
   override def buffered: this.type = this
 }

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -30,6 +30,18 @@ import caps.unsafe.unsafeAssumePure
  */
 @implicitNotFound(msg = "Cannot construct a collection of type ${C} with elements of type ${A} based on a collection of type ${From}.")
 trait BuildFrom[-From, -A, +C] extends Any { self: BuildFrom[From, A, C] =>
+  /** Builds a collection of type `C` from the elements of `it`.
+   *
+   *  The source collection `from` determines how the result is built (typically by
+   *  supplying its factory); the elements of the result come from `it`.
+   *
+   *  Building with `fromSpecific` is preferred over `newBuilder` because it can be
+   *  lazy for lazy collections.
+   *
+   *  @param from the source collection
+   *  @param it the elements of the resulting collection
+   *  @return a collection of type `C` containing the elements of `it`
+   */
   def fromSpecific(from: From)(it: IterableOnce[A]^): C^{it}
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
@@ -85,24 +97,37 @@ object BuildFrom extends BuildFromLowPriority1 {
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.from(it)
   }
 
+  /** Builds a bit set of the same concrete type as the source bit set.
+   *
+   *  @tparam C the concrete bit set type (e.g. `immutable.BitSet`, `mutable.BitSet`)
+   *  @return a `BuildFrom` instance that builds a `C` from `Int` elements, using the
+   *          `bitSetFactory` of the source bit set
+   */
   implicit def buildFromBitSet[C <: BitSet & BitSetOps[C]]: BuildFrom[C, Int, C] =
     new BuildFrom[C, Int, C] {
       def fromSpecific(from: C)(it: IterableOnce[Int]^): C = from.bitSetFactory.fromSpecific(it)
       def newBuilder(from: C): Builder[Int, C] = from.bitSetFactory.newBuilder
     }
 
+  /** A `BuildFrom` instance that builds a `String` from `Char` elements. */
   implicit val buildFromString: BuildFrom[String, Char, String] =
     new BuildFrom[String, Char, String] {
       def fromSpecific(from: String)(it: IterableOnce[Char]^): String = Factory.stringFactory.fromSpecific(it)
       def newBuilder(from: String): Builder[Char, String] = Factory.stringFactory.newBuilder
     }
 
+  /** A `BuildFrom` instance that builds a [[scala.collection.immutable.WrappedString]] from `Char` elements. */
   implicit val buildFromWrappedString: BuildFrom[WrappedString, Char, WrappedString] =
     new BuildFrom[WrappedString, Char, WrappedString] {
       def fromSpecific(from: WrappedString)(it: IterableOnce[Char]^): WrappedString = WrappedString.fromSpecific(it)
       def newBuilder(from: WrappedString): mutable.Builder[Char, WrappedString] = WrappedString.newBuilder
     }
 
+  /** Builds an `Array` from any source array.
+   *
+   *  @tparam A the element type of the resulting array, which must have a `ClassTag`
+   *  @return a `BuildFrom` instance that builds an `Array[A]` from elements of type `A`
+   */
   implicit def buildFromArray[A : ClassTag]: BuildFrom[Array[?], A, Array[A]] =
     new BuildFrom[Array[?], A, Array[A]] {
       def fromSpecific(from: Array[?])(it: IterableOnce[A]^): Array[A] =
@@ -117,6 +142,12 @@ object BuildFrom extends BuildFromLowPriority1 {
       def fromSpecific(from: IArray[Any])(it: IterableOnce[A]^): IArray[A] = IArray.from(it)
       def newBuilder(from: IArray[Any]): Builder[A, IArray[A]] = IArray.newBuilder[A]
 
+  /** Builds a [[View]] from any source view.
+   *
+   *  @tparam A the element type of the source view
+   *  @tparam B the element type of the resulting view
+   *  @return a `BuildFrom` instance that builds a `View[B]` from elements of type `B`
+   */
   implicit def buildFromView[A, B]: BuildFrom[View[A], B, View[B]] =
     new BuildFrom[View[A], B, View[B]] {
       def fromSpecific(from: View[A])(it: IterableOnce[B]^): View[B]^{it} = View.from(it)
@@ -125,6 +156,10 @@ object BuildFrom extends BuildFromLowPriority1 {
 
 }
 
+/** `BuildFrom` instances that the compiler tries only after those declared directly
+ *  in the `BuildFrom` companion object, e.g. so that `buildFromString` is preferred
+ *  over `fallbackStringCanBuildFrom` when building a `String` from `Char` elements.
+ */
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
   /** Builds the source collection type from an Iterable with SortedOps.
@@ -142,6 +177,13 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
     def fromSpecific(from: CC[A0])(it: IterableOnce[A]^): CC[A] = (from: SortedSetOps[A0, CC, ?]).sortedIterableFactory.from(it)
   }
 
+  /** Builds an `immutable.IndexedSeq` from a `String` source when the element type is
+   *  not `Char`, i.e. when [[BuildFrom.buildFromString]] does not apply.
+   *
+   *  @tparam A the element type of the resulting sequence
+   *  @return a `BuildFrom` instance that builds an `immutable.IndexedSeq[A]` from
+   *          elements of type `A`, with a `String` as the source collection
+   */
   implicit def fallbackStringCanBuildFrom[A]: BuildFrom[String, A, immutable.IndexedSeq[A]] =
     new BuildFrom[String, A, immutable.IndexedSeq[A]] {
       def fromSpecific(from: String)(it: IterableOnce[A]^): immutable.IndexedSeq[A] = immutable.IndexedSeq.from(it)
@@ -149,6 +191,10 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
   }
 }
 
+/** `BuildFrom` instances of the lowest priority, tried only after those in
+ *  [[BuildFromLowPriority1]] and the `BuildFrom` companion object, e.g. so that
+ *  `buildFromSortedSetOps` is preferred over `buildFromIterableOps` for sorted sets.
+ */
 trait BuildFromLowPriority2 {
   /** Builds the source collection type from an IterableOps.
    *
@@ -163,6 +209,11 @@ trait BuildFromLowPriority2 {
     def fromSpecific(from: CC[A0])(it: IterableOnce[A]^): CC[A]^{it} = (from: IterableOps[A0, CC, ?]).iterableFactory.from(it)
   }
 
+  /** Builds an [[Iterator]] from any source iterator.
+   *
+   *  @tparam A the element type of the resulting iterator
+   *  @return a `BuildFrom` instance that builds an `Iterator[A]` from elements of type `A`
+   */
   implicit def buildFromIterator[A]: BuildFrom[Iterator[?], A, Iterator[A]] = new BuildFrom[Iterator[?], A, Iterator[A]] {
     def newBuilder(from: Iterator[?]): mutable.Builder[A, Iterator[A]] = Iterator.newBuilder
     def fromSpecific(from: Iterator[?])(it: IterableOnce[A]^): Iterator[A]^{it} = Iterator.from(it)

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -47,6 +47,7 @@ into trait Factory[-A, +C] extends Any { self: Factory[A, C] =>
 
 object Factory {
 
+  /** A [[Factory]] that builds a `String` from `Char` elements. */
   implicit val stringFactory: Factory[Char, String] = new StringFactory
   @SerialVersionUID(3L)
   private class StringFactory extends Factory[Char, String] with Serializable {
@@ -58,6 +59,12 @@ object Factory {
     def newBuilder: Builder[Char, String] = new mutable.StringBuilder()
   }
 
+  /** A [[Factory]] that builds an `Array` from its elements.
+   *
+   *  @tparam A the element type of the array; a `ClassTag` for it must be available
+   *            so that a properly typed array can be allocated
+   *  @return a `Factory` that builds an `Array[A]`
+   */
   implicit def arrayFactory[A: ClassTag]: Factory[A, Array[A]] = new ArrayFactory[A]
   @SerialVersionUID(3L)
   private class ArrayFactory[A: ClassTag] extends Factory[A, Array[A]] with Serializable {
@@ -292,6 +299,14 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     from(xss.foldLeft(View.empty[A])(_ ++ _))
   }
 
+  /** A [[Factory]] view of this factory, with the element type fixed to `A`.
+   *
+   *  Allows this factory to be used wherever a `Factory[A, CC[A]]` is expected,
+   *  for example as the argument of `to` (`xs.to(List)`).
+   *
+   *  @tparam A the type of the ${coll}'s elements
+   *  @return a [[Factory]] that delegates to this factory to build a `CC[A]`
+   */
   implicit def iterableFactory[A]: Factory[A, CC[A]] = IterableFactory.toFactory(this)
 }
 
@@ -312,17 +327,57 @@ object IterableFactory {
     def newBuilder: Builder[A, CC[A]] = factory.newBuilder[A]
   }
 
+  /** Fixes the element type of `factory` to `A` and adapts it to the [[BuildFrom]] typeclass.
+   *
+   *  The resulting instance ignores its source collection (its `From` type is `Any`)
+   *  and always builds with the given `factory`.
+   *
+   *  @tparam A Type of elements
+   *  @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
+   *  @param factory The factory to adapt
+   *  @return A [[BuildFrom]] that uses the given `factory` to build a collection of
+   *         elements of type `A`, regardless of the source collection
+   */
   implicit def toBuildFrom[A, CC[_]](factory: IterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
     new BuildFrom[Any, A, CC[A]] {
       def fromSpecific(from: Any)(it: IterableOnce[A]^) = factory.from(it)
       def newBuilder(from: Any) = factory.newBuilder
     }
 
+  /** An `IterableFactory` that forwards all operations to another factory.
+   *
+   *  Useful for defining a collection companion object as a delegate to an existing
+   *  factory, e.g. `object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable)`.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
+    /** Creates a collection of type `CC[A]` with the specified elements, by forwarding to `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @param elems the elements of the created collection
+     *  @return a new `CC[A]` with elements `elems`
+     */
     override def apply[A](elems: A*): CC[A] = delegate.apply(elems*)
+    /** An empty collection of type `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @return an empty `CC[A]`
+     */
     def empty[A]: CC[A] = delegate.empty
+    /** Creates a collection of type `CC[E]` from the elements of `it`, by forwarding to `delegate`.
+     *
+     *  @tparam E the type of the collection's elements
+     *  @param it the source collection
+     *  @return a new `CC[E]` with the elements of `it`
+     */
     def from[E](it: IterableOnce[E]^): CC[E]^{it} = delegate.from(it)
+    /** Returns a new builder for a `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     */
     def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder[A]
   }
 }
@@ -332,33 +387,111 @@ object IterableFactory {
  */
 trait SeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends IterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
+  /** An extractor for sequence patterns, e.g. `case Seq(a, b, rest*) => ...`.
+   *
+   *  The extraction itself never fails: the returned wrapper always reports
+   *  `isEmpty == false`, and the pattern matcher checks the pattern's arity
+   *  against the sequence via the wrapper's `lengthCompare`.
+   *
+   *  @tparam A the type of the sequence's elements
+   *  @param x the sequence to extract elements from
+   *  @return a [[SeqFactory.UnapplySeqWrapper]] exposing the elements of `x`
+   */
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
 }
 
 object SeqFactory {
+  /** A `SeqFactory` that forwards all operations to another factory.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure](delegate: SeqFactory[CC]) extends SeqFactory[CC] {
+    /** Creates a collection of type `CC[A]` with the specified elements, by forwarding to `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @param elems the elements of the created collection
+     *  @return a new `CC[A]` with elements `elems`
+     */
     override def apply[A](elems: A*): CC[A] = delegate.apply(elems*)
+    /** An empty collection of type `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @return an empty `CC[A]`
+     */
     def empty[A]: CC[A] = delegate.empty
+    /** Creates a collection of type `CC[E]` from the elements of `it`, by forwarding to `delegate`.
+     *
+     *  @tparam E the type of the collection's elements
+     *  @param it the source collection
+     *  @return a new `CC[E]` with the elements of `it`
+     */
     def from[E](it: IterableOnce[E]^): CC[E] = delegate.from(it)
+    /** Returns a new builder for a `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements
+     */
     def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder[A]
   }
 
+  /** The wrapper returned by `unapplySeq`, exposing the matched sequence's elements
+   *  to the pattern matcher.
+   *
+   *  This is a name-based extractor result: the pattern matcher calls `isEmpty`,
+   *  `get`, `lengthCompare`, `apply`, `drop` and `toSeq` as needed. Being a value
+   *  class, the wrapper itself costs no allocation and no intermediate `Option` is
+   *  built; a vararg pattern still allocates through `drop` and `toSeq`.
+   *
+   *  @tparam A the type of the sequence's elements
+   *  @param c the matched sequence
+   */
   final class UnapplySeqWrapper[A](private val c: SeqOps[A, Seq, Seq[A]]) extends AnyVal {
+    /** Always `false`: the extraction itself never fails (the pattern's arity is checked via `lengthCompare`). */
     def isEmpty: false = false
+    /** Returns this wrapper itself, whose members give the pattern matcher access to the matched elements. */
     def get: UnapplySeqWrapper[A] = this
+    /** Compares the length of the matched sequence to a test value.
+     *
+     *  @param len the test value
+     *  @return a negative value if the sequence is shorter than `len`, zero if it
+     *          contains exactly `len` elements, and a positive value if it is longer
+     */
     def lengthCompare(len: Int): Int = c.lengthCompare(len)
+    /** Returns the element of the matched sequence at index `i`.
+     *
+     *  @param i the index, starting from 0
+     */
     def apply(i: Int): A = c(i)
+    /** Returns all elements of the matched sequence except the first `n`, used to
+     *  bind a trailing varargs sub-pattern such as `rest*`.
+     *
+     *  @param n the number of leading elements to skip
+     *  @return the remaining elements as a `Seq`: if the matched sequence is a
+     *          `scala.Seq` its own `drop` is used, otherwise the remaining
+     *          elements are copied to a new `Seq` via a view
+     */
     def drop(n: Int): scala.Seq[A] = c match {
       case seq: scala.Seq[A @unchecked] => seq.drop(n)
       case _                 => c.view.drop(n).toSeq
     }
+    /** Returns the elements of the matched sequence as a `Seq`. */
     def toSeq: scala.Seq[A] = c.toSeq
   }
 }
 
+/** A `SeqFactory` for strict collection types, overriding `fill`, `tabulate` and
+ *  `concat` with builder-based implementations that avoid creating intermediate views.
+ */
 trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends SeqFactory[CC] {
 
+  /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation, re-evaluated for every position
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
   override def fill[A](n: Int)(elem: => A): CC[A] = {
     val b = newBuilder[A]
     b.sizeHint(n)
@@ -370,6 +503,13 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] ex
     b.result()
   }
 
+  /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+   */
   override def tabulate[A](n: Int)(f: Int => A): CC[A] = {
     val b = newBuilder[A]
     b.sizeHint(n)
@@ -381,6 +521,12 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] ex
     b.result()
   }
 
+  /** Concatenates all argument collections into a single $coll.
+   *
+   *  @tparam A the element type of the $coll
+   *  @param xss the collections that are to be concatenated.
+   *  @return the concatenation of all the collections.
+   */
   override def concat[A](xss: Iterable[A]*): CC[A] = {
     val b = newBuilder[A]
     val knownSizes = xss.view.map(_.knownSize)
@@ -403,11 +549,27 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] ex
  *  @define Coll `Iterable`
  */
 trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
+  /** An empty $coll of type `C`. */
   def empty: C
+  /** Creates a $coll with the specified elements.
+   *
+   *  @param xs the elements of the created $coll
+   *  @return a new $coll with elements `xs`
+   */
   def apply(xs: A*): C = fromSpecific(xs)
+  /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @param n the number of elements contained in the $coll
+   *  @param elem the element computation, re-evaluated for every position
+   *  @return a $coll that contains the results of `n` evaluations of `elem`
+   */
   def fill(n: Int)(elem: => A): C = fromSpecific(new View.Fill(n)(elem))
+  /** Returns a new builder for a $coll of type `C`. */
   def newBuilder: Builder[A, C]
 
+  /** This factory itself, made available implicitly as a [[Factory]] so that it can
+   *  be used wherever a `Factory[A, C]` is expected, for example as the argument of `to`.
+   */
   implicit def specificIterableFactory: Factory[A, C] = this
 }
 
@@ -483,17 +645,60 @@ object MapFactory {
     def newBuilder: Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]
   }
 
+  /** Fixes the key and value types of `factory` to `K` and `V`, respectively, and
+   *  adapts it to the [[BuildFrom]] typeclass.
+   *
+   *  The resulting instance ignores its source collection (its `From` type is `Any`)
+   *  and always builds with the given `factory`.
+   *
+   *  @tparam K Type of keys
+   *  @tparam V Type of values
+   *  @tparam CC Collection type constructor of the factory (e.g. `Map`, `HashMap`, etc.)
+   *  @param factory The factory to adapt
+   *  @return A [[BuildFrom]] that uses the given `factory` to build a map with keys of
+   *         type `K` and values of type `V`, regardless of the source collection
+   */
   implicit def toBuildFrom[K, V, CC[_, _]](factory: MapFactory[CC]): BuildFrom[Any, (K, V), CC[K, V]] =
     new BuildFrom[Any, (K, V), CC[K, V]] {
       def fromSpecific(from: Any)(it: IterableOnce[(K, V)]^) = factory.from(it)
       def newBuilder(from: Any) = factory.newBuilder[K, V]
     }
 
+  /** A `MapFactory` that forwards all operations to another factory.
+   *
+   *  @tparam C Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[C[_, _] <: caps.Pure](delegate: MapFactory[C]) extends MapFactory[C] {
+    /** Creates a map of type `C[K, V]` that contains the given key-value pairs, by forwarding to `delegate`.
+     *
+     *  @tparam K the type of the keys
+     *  @tparam V the type of the values
+     *  @param elems the key-value pairs to include in the map
+     *  @return a new `C[K, V]` containing the given `elems`
+     */
     override def apply[K, V](elems: (K, V)*): C[K, V] = delegate.apply(elems*)
+    /** Creates a map of type `C[K, V]` from the key-value pairs of `it`, by forwarding to `delegate`.
+     *
+     *  @tparam K the type of the keys
+     *  @tparam V the type of the values
+     *  @param it the source collection of key-value pairs
+     *  @return a new `C[K, V]` containing the bindings from `it`
+     */
     def from[K, V](it: IterableOnce[(K, V)]^): C[K, V] = delegate.from(it)
+    /** An empty map of type `C[K, V]`, obtained from `delegate`.
+     *
+     *  @tparam K the type of the keys
+     *  @tparam V the type of the values
+     *  @return an empty `C[K, V]`
+     */
     def empty[K, V]: C[K, V] = delegate.empty
+    /** Returns a new builder for a `C[K, V]`, obtained from `delegate`.
+     *
+     *  @tparam K the type of the keys
+     *  @tparam V the type of the values
+     */
     def newBuilder[K, V]: Builder[(K, V), C[K, V]] = delegate.newBuilder
   }
 }
@@ -511,10 +716,27 @@ object MapFactory {
  */
 trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 
+  /** Creates a target $coll from an existing source collection.
+   *
+   *  @tparam E the type of the ${coll}'s elements, for which an implicit `Ev` instance must exist
+   *  @param it Source collection
+   *  @return a new $coll with the elements of `it`
+   */
   def from[E : Ev](it: IterableOnce[E]^): CC[E]
 
+  /** An empty $coll.
+   *
+   *  @tparam A the type of the ${coll}'s elements, for which an implicit `Ev` instance must exist
+   *  @return an empty $coll of type `CC[A]`
+   */
   def empty[A : Ev]: CC[A]
 
+  /** Creates a $coll with the specified elements.
+   *
+   *  @tparam A the type of the ${coll}'s elements, for which an implicit `Ev` instance must exist
+   *  @param xs the elements of the created $coll
+   *  @return a new $coll with elements `xs`
+   */
   def apply[A : Ev](xs: A*): CC[A] = from(xs)
 
   /** Produces a $coll containing the results of some element computation a number of times.
@@ -557,8 +779,20 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
    */
   def unfold[A : Ev, S](init: S)(f: S => Option[(A, S)]): CC[A] = from(new View.Unfold(init)(f))
 
+  /** Returns a new builder for $Coll objects.
+   *
+   *  @tparam A the type of the ${coll}'s elements, for which an implicit `Ev` instance must exist
+   */
   def newBuilder[A : Ev]: Builder[A, CC[A]]
 
+  /** A [[Factory]] view of this factory, with the element type fixed to `A`.
+   *
+   *  Allows this factory to be used wherever a `Factory[A, CC[A]]` is expected,
+   *  for example as the argument of `to`.
+   *
+   *  @tparam A the type of the ${coll}'s elements, for which an implicit `Ev` instance must exist
+   *  @return a [[Factory]] that delegates to this factory to build a `CC[A]`
+   */
   implicit def evidenceIterableFactory[A : Ev]: Factory[A, CC[A]] = EvidenceIterableFactory.toFactory(this)
 }
 
@@ -580,17 +814,56 @@ object EvidenceIterableFactory {
     def newBuilder: Builder[A, CC[A]] = factory.newBuilder[A]
   }
 
+  /** Fixes the element type of `factory` to `A` and adapts it to the [[BuildFrom]] typeclass.
+   *
+   *  The resulting instance ignores its source collection (its `From` type is `Any`)
+   *  and always builds with the given `factory`.
+   *
+   *  @tparam Ev Type constructor of the evidence (usually `Ordering` or `ClassTag`)
+   *  @tparam A Type of elements
+   *  @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)
+   *  @param factory The factory to adapt
+   *  @return A [[BuildFrom]] that uses the given `factory` to build a collection of
+   *         elements of type `A`, regardless of the source collection
+   */
   implicit def toBuildFrom[Ev[_], A: Ev, CC[_]](factory: EvidenceIterableFactory[CC, Ev]): BuildFrom[Any, A, CC[A]] = new EvidenceIterableFactoryToBuildFrom(factory)
   private class EvidenceIterableFactoryToBuildFrom[Ev[_], A: Ev, CC[_]](factory: EvidenceIterableFactory[CC, Ev]) extends BuildFrom[Any, A, CC[A]] {
     def fromSpecific(from: Any)(it: IterableOnce[A]^) = factory.from[A](it)
     def newBuilder(from: Any): Builder[A, CC[A]] = factory.newBuilder[A]
   }
 
+  /** An `EvidenceIterableFactory` that forwards all operations to another factory.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @tparam Ev Type constructor of the evidence (usually `Ordering` or `ClassTag`)
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[_], Ev[_]](delegate: EvidenceIterableFactory[CC, Ev]) extends EvidenceIterableFactory[CC, Ev] {
+    /** Creates a collection of type `CC[A]` with the specified elements, by forwarding to `delegate`.
+     *
+     *  @tparam A the type of the collection's elements, for which an implicit `Ev` instance must exist
+     *  @param xs the elements of the created collection
+     *  @return a new `CC[A]` with elements `xs`
+     */
     override def apply[A: Ev](xs: A*): CC[A] = delegate.apply(xs*)
+    /** An empty collection of type `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements, for which an implicit `Ev` instance must exist
+     *  @return an empty `CC[A]`
+     */
     def empty[A : Ev]: CC[A] = delegate.empty
+    /** Creates a collection of type `CC[E]` from the elements of `it`, by forwarding to `delegate`.
+     *
+     *  @tparam E the type of the collection's elements, for which an implicit `Ev` instance must exist
+     *  @param it the source collection
+     *  @return a new `CC[E]` with the elements of `it`
+     */
     def from[E : Ev](it: IterableOnce[E]^): CC[E] = delegate.from(it)
+    /** Returns a new builder for a `CC[A]`, obtained from `delegate`.
+     *
+     *  @tparam A the type of the collection's elements, for which an implicit `Ev` instance must exist
+     */
     def newBuilder[A : Ev]: Builder[A, CC[A]] = delegate.newBuilder[A]
   }
 }
@@ -601,6 +874,13 @@ object EvidenceIterableFactory {
 trait SortedIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, Ordering]
 
 object SortedIterableFactory {
+  /** A [[SortedIterableFactory]] that forwards all operations to another factory.
+   *
+   *  The required evidence is an implicit `Ordering` of the element type.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[_]](delegate: EvidenceIterableFactory[CC, Ordering])
     extends EvidenceIterableFactory.Delegate[CC, Ordering](delegate) with SortedIterableFactory[CC]
@@ -737,6 +1017,13 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
 }
 
 object ClassTagIterableFactory {
+  /** A [[ClassTagIterableFactory]] that forwards all operations to another factory.
+   *
+   *  The required evidence is an implicit `ClassTag` of the element type.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[_]](delegate: EvidenceIterableFactory[CC, ClassTag])
     extends EvidenceIterableFactory.Delegate[CC, ClassTag](delegate) with ClassTagIterableFactory[CC]
@@ -746,15 +1033,92 @@ object ClassTagIterableFactory {
    */
   @SerialVersionUID(3L)
   class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
+    /** An empty collection of type `CC[A]`, obtained from `delegate` using `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @return an empty `CC[A]`
+     */
     def empty[A]: CC[A] = delegate.empty(using ClassTag.Any).asInstanceOf[CC[A]]
+    /** Creates a collection of type `CC[A]` from the elements of `it`, by forwarding to
+     *  `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @param it the source collection
+     *  @return a new `CC[A]` with the elements of `it`
+     */
     def from[A](it: IterableOnce[A]^): CC[A] = delegate.from[Any](it)(using ClassTag.Any).asInstanceOf[CC[A]]
+    /** Returns a new builder for a `CC[A]`, obtained from `delegate` using `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the type of the collection's elements
+     */
     def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder(using ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
+    /** Creates a collection of type `CC[A]` with the specified elements, by forwarding to
+     *  `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the type of the collection's elements
+     *  @param elems the elements of the created collection
+     *  @return a new `CC[A]` with elements `elems`
+     */
     override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems*)(using ClassTag.Any).asInstanceOf[CC[A]]
+    /** Produces a collection containing repeated applications of a function to a start value,
+     *  by forwarding to `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the element type of the collection
+     *  @param start the start value of the collection
+     *  @param len the number of elements contained in the collection
+     *  @param f the function that's repeatedly applied
+     *  @return a `CC[A]` with `len` values in the sequence `start, f(start), f(f(start)), ...`
+     */
     override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    /** Produces a collection that uses a function `f` to produce elements of type `A` and
+     *  update an internal state of type `S`, by forwarding to `delegate` with `ClassTag.Any`
+     *  as the evidence.
+     *
+     *  @tparam A Type of the elements
+     *  @tparam S Type of the internal state
+     *  @param init State initial value
+     *  @param f Computes the next element (or returns `None` to signal the end of the collection)
+     *  @return a `CC[A]` that produces elements using `f` until `f` returns `None`
+     */
     override def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = delegate.unfold[A, S](init)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    /** Produces a collection containing a sequence of increasing integers, by forwarding to
+     *  `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the element type of the collection
+     *  @param start the first element of the collection
+     *  @param end the end value of the collection (the first value NOT contained)
+     *  @param i the `Integral` instance for `A`
+     *  @return a `CC[A]` with values `start, start + 1, ..., end - 1`
+     */
     override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    /** Produces a collection containing equally spaced values in some integer interval, by
+     *  forwarding to `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the element type of the collection
+     *  @param start the start value of the collection
+     *  @param end the end value of the collection (the first value NOT contained)
+     *  @param step the difference between successive elements of the collection (must be positive or negative)
+     *  @param i the `Integral` instance for `A`
+     *  @return a `CC[A]` with values `start, start + step, ...` up to, but excluding `end`
+     */
     override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    /** Produces a collection containing the results of some element computation a number of
+     *  times, by forwarding to `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the element type of the collection
+     *  @param n the number of elements contained in the collection
+     *  @param elem the element computation, re-evaluated for every position
+     *  @return a `CC[A]` that contains the results of `n` evaluations of `elem`
+     */
     override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(using ClassTag.Any).asInstanceOf[CC[A]]
+    /** Produces a collection containing values of a given function over a range of integer
+     *  values starting from 0, by forwarding to `delegate` with `ClassTag.Any` as the evidence.
+     *
+     *  @tparam A the element type of the collection
+     *  @param n the number of elements in the collection
+     *  @param f the function computing element values
+     *  @return a `CC[A]` consisting of elements `f(0), ..., f(n - 1)`
+     */
     override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(using ClassTag.Any).asInstanceOf[CC[A]]
   }
 }
@@ -764,10 +1128,25 @@ object ClassTagIterableFactory {
  */
 trait ClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends ClassTagIterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
+  /** An extractor for sequence patterns, e.g. `case Seq(a, b, rest*) => ...`.
+   *
+   *  The extraction itself never fails: the returned wrapper always reports
+   *  `isEmpty == false`, and the pattern matcher checks the pattern's arity
+   *  against the sequence via the wrapper's `lengthCompare`.
+   *
+   *  @tparam A the type of the sequence's elements
+   *  @param x the sequence to extract elements from
+   *  @return a [[SeqFactory.UnapplySeqWrapper]] exposing the elements of `x`
+   */
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
 }
 
 object ClassTagSeqFactory {
+  /** A [[ClassTagSeqFactory]] that forwards all operations to another factory.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure](delegate: ClassTagSeqFactory[CC])
     extends ClassTagIterableFactory.Delegate[CC](delegate) with ClassTagSeqFactory[CC]
@@ -780,8 +1159,18 @@ object ClassTagSeqFactory {
     extends ClassTagIterableFactory.AnyIterableDelegate[CC](delegate) with SeqFactory[CC]
 }
 
+/** A [[ClassTagSeqFactory]] for strict collection types, overriding `fill` and
+ *  `tabulate` with builder-based implementations that avoid creating intermediate views.
+ */
 trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends ClassTagSeqFactory[CC] {
 
+  /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation, re-evaluated for every position
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
   override def fill[A : ClassTag](n: Int)(elem: => A): CC[A] = {
     val b = newBuilder[A]
     b.sizeHint(n)
@@ -793,6 +1182,13 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.
     b.result()
   }
 
+  /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+   */
   override def tabulate[A : ClassTag](n: Int)(f: Int => A): CC[A] = {
     val b = newBuilder[A]
     b.sizeHint(n)
@@ -817,14 +1213,48 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.
  */
 trait SortedMapFactory[+CC[_, _]] extends Serializable { this: SortedMapFactory[CC] =>
 
+  /** An empty sorted map, whose keys are ordered by the implicit `Ordering`.
+   *
+   *  @tparam K the type of the keys, which must have an `Ordering`
+   *  @tparam V the type of the values
+   *  @return an empty map of type `CC[K, V]`
+   */
   def empty[K : Ordering, V]: CC[K, V]
 
+  /** A sorted map that contains the key-value pairs of the given collection, with keys
+   *  ordered by the implicit `Ordering`.
+   *
+   *  @tparam K the type of the keys, which must have an `Ordering`
+   *  @tparam V the type of the values
+   *  @param it the source collection of key-value pairs
+   *  @return a new map of type `CC[K, V]` containing the bindings from `it`
+   */
   def from[K : Ordering, V](it: IterableOnce[(K, V)]^): CC[K, V]
 
+  /** A sorted map that contains the given key-value bindings, with keys ordered by the
+   *  implicit `Ordering`.
+   *
+   *  @tparam K the type of the keys, which must have an `Ordering`
+   *  @tparam V the type of the values
+   *  @param elems the key-value pairs to include in the map
+   *  @return a new map of type `CC[K, V]` containing the given `elems`
+   */
   def apply[K : Ordering, V](elems: (K, V)*): CC[K, V] = from(elems)
 
+  /** The default builder for sorted maps of type `CC`.
+   *
+   *  @tparam K the type of the keys, which must have an `Ordering`
+   *  @tparam V the type of the values
+   *  @return a new `Builder` that accepts key-value pairs and produces a `CC[K, V]`
+   */
   def newBuilder[K : Ordering, V]: Builder[(K, V), CC[K, V]]
 
+  /** The default Factory instance for sorted maps.
+   *
+   *  @tparam K the type of the keys, which must have an `Ordering`
+   *  @tparam V the type of the values
+   *  @return a `Factory` that builds a `CC[K, V]` from a collection of key-value pairs
+   */
   implicit def sortedMapFactory[K : Ordering, V]: Factory[(K, V), CC[K, V]] = SortedMapFactory.toFactory(this)
 
 }
@@ -849,17 +1279,60 @@ object SortedMapFactory {
     def newBuilder: Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]
   }
 
+  /** Fixes the key and value types of `factory` to `K` and `V`, respectively, and
+   *  adapts it to the [[BuildFrom]] typeclass.
+   *
+   *  The resulting instance ignores its source collection (its `From` type is `Any`)
+   *  and always builds with the given `factory`.
+   *
+   *  @tparam K Type of keys, which must have an `Ordering`
+   *  @tparam V Type of values
+   *  @tparam CC Collection type constructor of the factory (e.g. `TreeMap`)
+   *  @param factory The factory to adapt
+   *  @return A [[BuildFrom]] that uses the given `factory` to build a map with keys of
+   *         type `K` and values of type `V`, regardless of the source collection
+   */
   implicit def toBuildFrom[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]): BuildFrom[Any, (K, V), CC[K, V]] = new SortedMapFactoryToBuildFrom(factory)
   private class SortedMapFactoryToBuildFrom[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]) extends BuildFrom[Any, (K, V), CC[K, V]] {
     def fromSpecific(from: Any)(it: IterableOnce[(K, V)]^) = factory.from(it)
     def newBuilder(from: Any) = factory.newBuilder[K, V]
   }
 
+  /** A `SortedMapFactory` that forwards all operations to another factory.
+   *
+   *  @tparam CC Collection type constructor of both this factory and the underlying factory
+   *  @param delegate The factory that all operations are forwarded to
+   */
   @SerialVersionUID(3L)
   class Delegate[CC[_, _]](delegate: SortedMapFactory[CC]) extends SortedMapFactory[CC] {
+    /** Creates a sorted map of type `CC[K, V]` that contains the given key-value pairs, by forwarding to `delegate`.
+     *
+     *  @tparam K the type of the keys, which must have an `Ordering`
+     *  @tparam V the type of the values
+     *  @param elems the key-value pairs to include in the map
+     *  @return a new `CC[K, V]` containing the given `elems`
+     */
     override def apply[K: Ordering, V](elems: (K, V)*): CC[K, V] = delegate.apply(elems*)
+    /** Creates a sorted map of type `CC[K, V]` from the key-value pairs of `it`, by forwarding to `delegate`.
+     *
+     *  @tparam K the type of the keys, which must have an `Ordering`
+     *  @tparam V the type of the values
+     *  @param it the source collection of key-value pairs
+     *  @return a new `CC[K, V]` containing the bindings from `it`
+     */
     def from[K : Ordering, V](it: IterableOnce[(K, V)]^): CC[K, V] = delegate.from(it)
+    /** An empty sorted map of type `CC[K, V]`, obtained from `delegate`.
+     *
+     *  @tparam K the type of the keys, which must have an `Ordering`
+     *  @tparam V the type of the values
+     *  @return an empty `CC[K, V]`
+     */
     def empty[K : Ordering, V]: CC[K, V] = delegate.empty
+    /** Returns a new builder for a `CC[K, V]`, obtained from `delegate`.
+     *
+     *  @tparam K the type of the keys, which must have an `Ordering`
+     *  @tparam V the type of the values
+     */
     def newBuilder[K : Ordering, V]: Builder[(K, V), CC[K, V]] = delegate.newBuilder
   }
 }

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -28,9 +28,11 @@ import scala.math.Ordering
 trait IndexedSeq[+A] extends Seq[A]
   with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
   with IterableFactoryDefaults[A, IndexedSeq] {
+  /** The prefix used in the string representation of this sequence, `"IndexedSeq"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "IndexedSeq"
 
+  /** The factory used to build indexed sequences, the [[IndexedSeq$ `IndexedSeq`]] companion object. */
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
 }
 
@@ -45,8 +47,25 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
  */
 transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self: IndexedSeqOps[A, CC, C]^ =>
 
+  /** Returns an iterator over the elements of this sequence.
+   *
+   *  The iterator accesses elements by index, so each step costs one call
+   *  to `apply`.
+   */
   def iterator: Iterator[A]^{this} = view.iterator
 
+  /** Returns a [[scala.collection.Stepper]] for the elements of this sequence
+   *  that supports efficient splitting, enabling parallel processing.
+   *
+   *  The stepper accesses elements by index. For elements of type `Int`, `Long`
+   *  or `Double`, a primitive-typed stepper is used that does not box the
+   *  elements.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return an indexed stepper over the elements of this sequence, marked with
+   *          [[scala.collection.Stepper.EfficientSplit]]
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
@@ -58,6 +77,11 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns an iterator over the elements of this sequence in reverse order.
+   *
+   *  The iterator accesses elements by index, from `length - 1` down to `0`,
+   *  without copying the sequence.
+   */
   override def reverseIterator: Iterator[A]^{this} = view.reverseIterator
 
   /* TODO 2.14+ uncomment and delete related code in IterableOnce
@@ -72,42 +96,173 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
 
   //override def foldLeft[B](z: B)(op: (B, A) => B): B = foldl(0, length, z, op)
 
+  /** Applies the binary operator `op` between all elements of this sequence and
+   *  `z`, going right to left.
+   *
+   *  Elements are accessed by index, from the last element down to the first,
+   *  so no reversed intermediate collection is built.
+   *
+   *  @tparam B the result type of the binary operator
+   *  @param z the start value, combined with the last element first
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements of this
+   *          sequence, going right to left with the start value `z` on the
+   *          right, or `z` if this sequence is empty
+   */
   override def foldRight[B](z: B)(op: (A, B) => B): B = foldr(0, length, z, op)
 
   //override def reduceLeft[B >: A](op: (B, A) => B): B = if (length > 0) foldl(1, length, apply(0), op) else super.reduceLeft(op)
 
   //override def reduceRight[B >: A](op: (A, B) => B): B = if (length > 0) foldr(0, length - 1, apply(length - 1), op) else super.reduceRight(op)
 
+  /** Returns an [[IndexedSeqView]] over the elements of this sequence.
+   *
+   *  The view supports indexed access and is not evaluated: it reflects any
+   *  changes to the underlying sequence.
+   */
   override def view: IndexedSeqView[A]^{this} = new IndexedSeqView.Id[A](this)
 
+  /** Returns an [[IndexedSeqView]] over the elements of this sequence between
+   *  indices `from` (inclusive) and `until` (exclusive).
+   *
+   *  @param from the index of the first element of the view
+   *  @param until the index following the last element of the view
+   *  @return a non-strict view of the specified slice of this sequence
+   */
   @deprecated("Use .view.slice(from, until) instead of .view(from, until)", "2.13.0")
   override def view(from: Int, until: Int): IndexedSeqView[A]^{this} = view.slice(from, until)
 
+  /** Returns a non-strict view of this sequence in reverse order.
+   *
+   *  The view accesses elements by index, so no copy is made. It is used by
+   *  the default implementations of reversal-based operations.
+   */
   override protected def reversed: Iterable[A]^{this} = new IndexedSeqView.Reverse(this)
 
   // Override transformation operations to use more efficient views than the default ones
+  /** Returns a copy of this sequence with the element `elem` prepended.
+   *
+   *  The result is built from an indexed view, so the elements of this
+   *  sequence are accessed by index rather than through an iterator.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param elem the prepended element
+   *  @return a new collection consisting of `elem` followed by all elements
+   *          of this sequence
+   */
   override def prepended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new IndexedSeqView.Prepended(elem, this))
 
+  /** Returns a collection containing the first `n` elements of this sequence.
+   *
+   *  The result is built from an indexed view of the selected elements.
+   *
+   *  @param n the number of elements to take
+   *  @return a collection consisting of the first `n` elements of this
+   *          sequence, all elements if `n` is greater than the length, or an
+   *          empty collection if `n` is non-positive
+   */
   override def take(n: Int): C^{this} = fromSpecific(new IndexedSeqView.Take(this, n))
 
+  /** Returns a collection containing the last `n` elements of this sequence.
+   *
+   *  The result is built from an indexed view of the selected elements.
+   *
+   *  @param n the number of elements to take
+   *  @return a collection consisting of the last `n` elements of this
+   *          sequence, all elements if `n` is greater than the length, or an
+   *          empty collection if `n` is non-positive
+   */
   override def takeRight(n: Int): C^{this} = fromSpecific(new IndexedSeqView.TakeRight(this, n))
 
+  /** Returns a collection containing all elements of this sequence except the
+   *  first `n`.
+   *
+   *  The result is built from an indexed view of the selected elements, so the
+   *  dropped prefix is skipped rather than iterated over.
+   *
+   *  @param n the number of elements to drop
+   *  @return a collection consisting of all elements of this sequence except
+   *          the first `n`: all elements if `n` is non-positive, or an empty
+   *          collection if `n` is greater than or equal to the length
+   */
   override def drop(n: Int): C^{this} = fromSpecific(new IndexedSeqView.Drop(this, n))
 
+  /** Returns a collection containing all elements of this sequence except the
+   *  last `n`.
+   *
+   *  The result is built from an indexed view of the selected elements.
+   *
+   *  @param n the number of elements to drop
+   *  @return a collection consisting of all elements of this sequence except
+   *          the last `n`: all elements if `n` is non-positive, or an empty
+   *          collection if `n` is greater than or equal to the length
+   */
   override def dropRight(n: Int): C^{this} = fromSpecific(new IndexedSeqView.DropRight(this, n))
 
+  /** Builds a new collection by applying a function to all elements of this
+   *  sequence.
+   *
+   *  The result is built from an indexed view, so the elements of this
+   *  sequence are accessed by index rather than through an iterator.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param f the function to apply to each element
+   *  @return a new collection consisting of the results of applying `f` to
+   *          each element of this sequence, in order
+   */
   override def map[B](f: A => B): CC[B]^{this, f} = iterableFactory.from(new IndexedSeqView.Map(this, f))
 
+  /** Returns a new collection with the elements of this sequence in reverse
+   *  order.
+   *
+   *  The result is built from an indexed view that accesses the elements of
+   *  this sequence from the last down to the first, so no intermediate
+   *  reversed collection is created.
+   */
   override def reverse: C^{this} = fromSpecific(new IndexedSeqView.Reverse(this))
 
+  /** Returns a collection containing the elements of this sequence between
+   *  indices `from` (inclusive) and `until` (exclusive).
+   *
+   *  The result is built from an indexed view of the selected elements, so the
+   *  skipped prefix is not iterated over.
+   *
+   *  @param from the index of the first element to include; a negative value is
+   *              treated as 0
+   *  @param until the index following the last element to include; the value is
+   *               clamped to lie between 0 and the length of this sequence
+   *  @return a collection containing the elements of this sequence at indices
+   *          `from` up to but not including `until`, or an empty collection if
+   *          `until` does not exceed `from`
+   */
   override def slice(from: Int, until: Int): C^{this} = fromSpecific(new IndexedSeqView.Slice(this, from, until))
 
+  /** Groups elements in fixed size blocks by passing a "sliding window" over
+   *  them, advancing the starting index by `step` for each block.
+   *
+   *  Each block is produced with `slice`, so elements are accessed by index
+   *  and only the elements of each window are copied. The returned iterator is
+   *  empty if this sequence is empty; otherwise the last block may be smaller
+   *  than `size` if fewer than `size` elements remain.
+   *
+   *  @param size the number of elements per group
+   *  @param step the distance between the first elements of successive groups
+   *  @return an iterator producing collections of `size` elements, except
+   *          possibly the last one, which may be smaller
+   *  @throws IllegalArgumentException if `size` or `step` is less than 1
+   *  @throws java.util.ConcurrentModificationException from the returned
+   *          iterator, if the length of this sequence changes during iteration
+   */
   override def sliding(size: Int, step: Int): Iterator[C^{this}]^{this} = {
     require(size >= 1 && step >= 1, s"size=$size and step=$step, but both must be positive")
     val it = new IndexedSeqSlidingIterator[A, CC, C](this, size, step)
     it.asInstanceOf[Iterator[Nothing]] // TODO: seems like CC cannot figure this out yet
   }
 
+  /** Returns the first element of this sequence, `apply(0)`.
+   *
+   *  @throws NoSuchElementException if this sequence is empty
+   */
   override def head: A =
     if (!isEmpty) apply(0)
     else throw new NoSuchElementException(s"head of empty ${
@@ -117,8 +272,15 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
       }
     }")
 
+  /** Returns the first element of this sequence wrapped in `Some`, or `None`
+   *  if this sequence is empty.
+   */
   override def headOption: Option[A] = if (isEmpty) None else Some(head)
 
+  /** Returns the last element of this sequence, `apply(length - 1)`.
+   *
+   *  @throws NoSuchElementException if this sequence is empty
+   */
   override def last: A =
     if (!isEmpty) apply(length - 1)
     else throw new NoSuchElementException(s"last of empty ${
@@ -130,19 +292,74 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
 
   // We already inherit an efficient `lastOption = if (isEmpty) None else Some(last)`
 
+  /** Compares the length of this sequence to a test value.
+   *
+   *  Because indexed sequences have an efficient `length`, this compares
+   *  `length` and `len` directly rather than iterating.
+   *
+   *  @param len the test value that gets compared with the length
+   *  @return a negative value if `this.length < len`, zero if
+   *          `this.length == len`, and a positive value if `this.length > len`
+   */
   override final def lengthCompare(len: Int): Int = Integer.compare(length, len)
 
+  /** Returns the number of elements in this sequence, which is always known
+   *  and equal to `length`.
+   */
   override def knownSize: Int = length
 
+  /** Compares the length of this sequence to the size of another `Iterable`.
+   *
+   *  Delegates to `that.sizeCompare(length)` with the result inverted, so
+   *  `that` is traversed at most `length` elements rather than this sequence
+   *  being traversed.
+   *
+   *  @param that the `Iterable` whose size is compared with this sequence's length
+   *  @return a negative value if `this.length < that.size`, zero if they are
+   *          equal, and a positive value if `this.length > that.size`
+   */
   override final def lengthCompare(that: Iterable[?]^): Int = {
     val res = that.sizeCompare(length)
     // can't just invert the result, because `-Int.MinValue == Int.MinValue`
     if (res == Int.MinValue) 1 else -res
   }
 
+  /** Searches this sorted sequence for a specific element using binary search,
+   *  taking `O(log length)` comparisons.
+   *
+   *  The sequence should be sorted with the same `Ordering` before calling;
+   *  otherwise, the results are undefined.
+   *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
+   *  @param elem the element to find
+   *  @param ord the ordering to be used to compare elements
+   *  @return a `Found` value containing an index at which `elem` appears in
+   *          this sequence (not necessarily the first one), or the
+   *          `InsertionPoint` where `elem` would be inserted if it is not in
+   *          this sequence
+   */
   override def search[B >: A](elem: B)(implicit ord: Ordering[B]): SearchResult =
     binarySearch(elem, 0, length)(using ord)
 
+  /** Searches within an interval in this sorted sequence for a specific element
+   *  using binary search.
+   *
+   *  The sequence should be sorted with the same `Ordering` before calling;
+   *  otherwise, the results are undefined.
+   *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
+   *  @param elem the element to find
+   *  @param from the index where the search starts (treated as `0` if negative,
+   *              but never reduced when it exceeds the length of this sequence)
+   *  @param to the index following where the search ends (reduced to `length` if
+   *            it is greater)
+   *  @param ord the ordering to be used to compare elements
+   *  @return a `Found` value containing an index within the interval at which
+   *          `elem` appears (not necessarily the first one), or the
+   *          `InsertionPoint` where `elem` would be inserted; if the interval is
+   *          empty, an `InsertionPoint` at `from` (at 0 if `from` is negative),
+   *          which may lie beyond the end of this sequence
+   */
   override def search[B >: A](elem: B, from: Int, to: Int)(implicit ord: Ordering[B]): SearchResult =
     binarySearch(elem, from, to)(using ord)
 

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -25,29 +25,121 @@ import scala.annotation.nowarn
  */
 trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A] {
 
+  /** Returns this view itself, since it is already a view. */
   override def view: IndexedSeqView[A]^{this} = this
 
+  /** Returns a view of the elements of this view between index `from`
+   *  (inclusive) and index `until` (exclusive), like `slice`.
+   *
+   *  @param from the index of the first element of the returned view
+   *  @param until the index one past the last element of the returned view
+   *  @return a view of the selected elements
+   */
   @deprecated("Use .view.slice(from, until) instead of .view(from, until)", "2.13.0")
   override def view(from: Int, until: Int): IndexedSeqView[A]^{this} = view.slice(from, until)
 
+  /** Returns an iterator over the elements of this view, produced by indexing
+   *  into it.
+   *
+   *  The iterator's `drop` and `slice` operations adjust indices in constant
+   *  time, without accessing the skipped elements.
+   */
   override def iterator: Iterator[A]^{this} = new IndexedSeqView.IndexedSeqViewIterator(this)
+  /** Returns an iterator over the elements of this view in reverse order,
+   *  from the last element to the first, produced by indexing into this view.
+   */
   override def reverseIterator: Iterator[A]^{this} = new IndexedSeqView.IndexedSeqViewReverseIterator(this)
 
+  /** Returns a view of the elements of this view followed by `elem`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of `A`
+   *  @param elem the element to append
+   */
   override def appended[B >: A](elem: B): IndexedSeqView[B]^{this} = new IndexedSeqView.Appended(this, elem)
+  /** Returns a view of `elem` followed by the elements of this view.
+   *
+   *  @tparam B the element type of the returned view, a supertype of `A`
+   *  @param elem the element to prepend
+   */
   override def prepended[B >: A](elem: B): IndexedSeqView[B]^{this} = new IndexedSeqView.Prepended(elem, this)
+  /** Returns a view of the first `n` elements of this view.
+   *
+   *  @param n the number of elements to take
+   *  @return a view of the first `n` elements of this view, or of all elements
+   *          if this view has fewer than `n`
+   */
   override def take(n: Int): IndexedSeqView[A]^{this} = new IndexedSeqView.Take(this, n)
+  /** Returns a view of the last `n` elements of this view.
+   *
+   *  @param n the number of elements to take
+   *  @return a view of the last `n` elements of this view, or of all elements
+   *          if this view has fewer than `n`
+   */
   override def takeRight(n: Int): IndexedSeqView[A]^{this} = new IndexedSeqView.TakeRight(this, n)
+  /** Returns a view of the elements of this view except the first `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of all elements of this view except the first `n`, empty
+   *          if this view has fewer than `n`
+   */
   override def drop(n: Int): IndexedSeqView[A]^{this} = new IndexedSeqView.Drop(this, n)
+  /** Returns a view of the elements of this view except the last `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of all elements of this view except the last `n`, empty
+   *          if this view has fewer than `n`
+   */
   override def dropRight(n: Int): IndexedSeqView[A]^{this} = new IndexedSeqView.DropRight(this, n)
+  /** Returns a view of the results of applying `f` to each element of this view.
+   *
+   *  `f` is applied lazily, each time an element of the returned view is
+   *  accessed.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param f the function to apply to each element
+   */
   override def map[B](f: A => B): IndexedSeqView[B]^{this, f} = new IndexedSeqView.Map(this, f)
+  /** Returns a view of the elements of this view in reverse order. */
   override def reverse: IndexedSeqView[A]^{this} = new IndexedSeqView.Reverse(this)
+  /** Returns a view of the elements of this view between index `from`
+   *  (inclusive) and index `until` (exclusive), with both bounds clamped to
+   *  the valid range.
+   *
+   *  @param from the index of the first element of the slice
+   *  @param until the index one past the last element of the slice
+   */
   override def slice(from: Int, until: Int): IndexedSeqView[A]^{this} = new IndexedSeqView.Slice(this, from, until)
+  /** Returns a view over the same elements that applies the side-effecting
+   *  function `f` to each element as it is accessed.
+   *
+   *  @tparam U the result type of `f`; the result is discarded
+   *  @param f the function to apply to each element when it is accessed
+   */
   override def tapEach[U](f: A => U): IndexedSeqView[A]^{this, f} = new IndexedSeqView.Map(this, { (a: A) => f(a); a})
 
+  /** Returns a view of the elements of this view followed by the elements of
+   *  `suffix`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of `A`
+   *  @param suffix the indexed sequence to append
+   */
   def concat[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{this, suffix} = new IndexedSeqView.Concat(this, suffix)
+  /** Returns a view of the elements of this view followed by the elements of
+   *  `suffix`. This is the same as `concat`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of `A`
+   *  @param suffix the indexed sequence to append
+   */
   def appendedAll[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{this, suffix} = new IndexedSeqView.Concat(this, suffix)
+  /** Returns a view of the elements of `prefix` followed by the elements of
+   *  this view.
+   *
+   *  @tparam B the element type of the returned view, a supertype of `A`
+   *  @param prefix the indexed sequence to prepend
+   */
   def prependedAll[B >: A](prefix: IndexedSeqView.SomeIndexedSeqOps[B]^): IndexedSeqView[B]^{this, prefix} = new IndexedSeqView.Concat(prefix, this)
 
+  /** The prefix of this view's string representation, `"IndexedSeqView"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "IndexedSeqView"
 }
@@ -126,57 +218,149 @@ object IndexedSeqView {
   /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown. */
   type SomeIndexedSeqOps[A] = IndexedSeqOps[A, AnyConstr, ?]
 
+  /** An identity view of `underlying`, presenting its elements unchanged.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   */
   @SerialVersionUID(3L)
   class Id[+A](underlying: SomeIndexedSeqOps[A]^)
     extends SeqView.Id(underlying) with IndexedSeqView[A]
 
+  /** A view of the elements of `underlying` followed by `elem`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param elem the appended element
+   */
   @SerialVersionUID(3L)
   class Appended[+A](underlying: SomeIndexedSeqOps[A]^, elem: A)
     extends SeqView.Appended(underlying, elem) with IndexedSeqView[A]
 
+  /** A view of `elem` followed by the elements of `underlying`.
+   *
+   *  @tparam A the element type of the view
+   *  @param elem the prepended element
+   *  @param underlying the indexed sequence being viewed
+   */
   @SerialVersionUID(3L)
   class Prepended[+A](elem: A, underlying: SomeIndexedSeqOps[A]^)
     extends SeqView.Prepended(elem, underlying) with IndexedSeqView[A]
 
+  /** A view of the elements of `prefix` followed by the elements of `suffix`.
+   *
+   *  @tparam A the element type of the view
+   *  @param prefix the indexed sequence whose elements come first
+   *  @param suffix the indexed sequence whose elements come last
+   */
   @SerialVersionUID(3L)
   class Concat[A](prefix: SomeIndexedSeqOps[A]^, suffix: SomeIndexedSeqOps[A]^)
     extends SeqView.Concat[A](prefix, suffix) with IndexedSeqView[A]
 
+  /** A view of the first `n` elements of `underlying`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param n the number of elements to take
+   */
   @SerialVersionUID(3L)
   class Take[A](underlying: SomeIndexedSeqOps[A]^, n: Int)
     extends SeqView.Take(underlying, n) with IndexedSeqView[A]
 
+  /** A view of the last `n` elements of `underlying`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param n the number of elements to take
+   */
   @SerialVersionUID(3L)
   class TakeRight[A](underlying: SomeIndexedSeqOps[A]^, n: Int)
     extends SeqView.TakeRight(underlying, n) with IndexedSeqView[A]
 
+  /** A view of the elements of `underlying` except the first `n`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param n the number of elements to drop
+   */
   @SerialVersionUID(3L)
   class Drop[A](underlying: SomeIndexedSeqOps[A]^, n: Int)
     extends SeqView.Drop[A](underlying, n) with IndexedSeqView[A]
 
+  /** A view of the elements of `underlying` except the last `n`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param n the number of elements to drop
+   */
   @SerialVersionUID(3L)
   class DropRight[A](underlying: SomeIndexedSeqOps[A]^, n: Int)
     extends SeqView.DropRight[A](underlying, n) with IndexedSeqView[A]
 
+  /** A view of the results of applying `f` to each element of `underlying`.
+   *
+   *  `f` is applied each time an element is accessed.
+   *
+   *  @tparam A the element type of the underlying sequence
+   *  @tparam B the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param f the function applied to each element that is accessed
+   */
   @SerialVersionUID(3L)
   class Map[A, B](underlying: SomeIndexedSeqOps[A]^, f: A => B)
     extends SeqView.Map(underlying, f) with IndexedSeqView[B]
 
+  /** A view of the elements of `underlying` in reverse order: index `i` of
+   *  the view reads index `length - 1 - i` of the underlying sequence.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   */
   @SerialVersionUID(3L)
   class Reverse[A](underlying: SomeIndexedSeqOps[A]^) extends SeqView.Reverse[A](underlying) with IndexedSeqView[A] {
+    /** Returns the underlying sequence itself when it is an `IndexedSeqView`,
+     *  since reversing a reversed view yields the original view; otherwise
+     *  returns a new view of this view in reverse order.
+     */
     override def reverse: IndexedSeqView[A]^{this} = underlying match {
       case x: IndexedSeqView[A @unchecked] => x
       case _ => super.reverse
     }
   }
 
+  /** A view of the elements of `underlying` between index `from` (inclusive)
+   *  and index `until` (exclusive).
+   *
+   *  A negative `from` is treated as 0 and `until` is clamped to lie between 0
+   *  and the length of `underlying`; the view is empty whenever the resulting
+   *  lower bound is not below the resulting upper bound, so a `from` beyond the
+   *  end of `underlying` yields an empty view rather than an error.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the indexed sequence being viewed
+   *  @param from the index of the first element of the slice
+   *  @param until the index one past the last element of the slice
+   */
   @SerialVersionUID(3L)
   class Slice[A](underlying: SomeIndexedSeqOps[A]^, from: Int, until: Int) extends AbstractIndexedSeqView[A] {
+    /** The inclusive lower bound of the slice within `underlying`: `from`, or 0 if `from` is negative. */
     protected val lo = from max 0
+    /** The exclusive upper bound of the slice within `underlying`: `until` clamped
+     *  to be between 0 and `underlying.length`.
+     */
     protected val hi = (until max 0) min underlying.length
+    /** The number of elements in the slice: `hi - lo`, or 0 if `lo` exceeds `hi`. */
     protected val len = (hi - lo) max 0
+    /** Returns the element at index `i` of this slice, read from the underlying
+     *  sequence at index `lo + i`.
+     *
+     *  @param i the index within the slice
+     *  @return the element of the underlying sequence at index `lo + i`
+     *  @throws IndexOutOfBoundsException if `lo + i` is out of bounds of the underlying sequence
+     */
     @throws[IndexOutOfBoundsException]
     def apply(i: Int): A = underlying(lo + i)
+    /** Returns the number of elements in this slice. */
     def length: Int = len
   }
 }

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -33,13 +33,26 @@ trait Iterable[+A] extends IterableOnce[A]
   with IterableFactoryDefaults[A, Iterable] {
 
   // The collection itself
+  /** Returns this $coll itself.
+   *
+   *  Unlike `toList` or `toSeq`, no elements are copied: for a mutable collection the
+   *  result reflects later mutations of this $coll.
+   */
   @deprecated("toIterable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.7")
   final def toIterable: this.type = this
 
+  /** Returns this $coll itself, fulfilling the `coll` contract of `IterableOps`. */
   final protected def coll: this.type = this
 
+  /** The companion factory object of this $coll, the [[Iterable$ Iterable]] object by
+   *  default; overridden in subclasses to return their own companion.
+   */
   def iterableFactory: IterableFactory[Iterable] = Iterable
 
+  /** Returns this $coll itself. Historically this method converted a parallel collection
+   *  to a sequential one; there are no parallel collections in the standard library
+   *  anymore, so there is nothing to convert.
+   */
   @deprecated("Iterable.seq always returns the iterable itself", "2.13.0")
   def seq: this.type = this
 
@@ -71,6 +84,10 @@ trait Iterable[+A] extends IterableOnce[A]
    */
   private[scala] final def collectionClassName: String = className
 
+  /** The prefix of this $coll's `toString` representation, `"Iterable"` by default.
+   *
+   *  The default implementation of `className` returns this value.
+   */
   @deprecatedOverriding("Override className instead", "2.13.0")
   protected def stringPrefix: String = "Iterable"
 
@@ -152,6 +169,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   @deprecated("toTraversable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.0")
   final def toTraversable: Traversable[A]^{this} = toIterable
 
+  /** Returns `true`: this $coll can be traversed repeatedly. */
   override def isTraversableAgain: Boolean = true
 
   /**
@@ -159,6 +177,9 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   protected def coll: C^{this}
 
+  /** Returns the collection this operates on, as a `C`. Alias for [[coll]], which for an
+   *  adapter such as `IsSeq[String]` is the represented collection rather than the adapter.
+   */
   @deprecated("Use coll instead of repr in a collection implementation, use the collection value itself from the outside", "2.13.0")
   final def repr: C^{this} = coll
 
@@ -180,7 +201,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *       implementations of operations where we use a `View[A]`), it is safe.
    *
    *  @param coll the source collection to convert
-   *  @return a new collection of type `C` containing the elements of `coll`
+   *  @return a collection of type `C` containing the elements of `coll`
    */
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): C^{coll}
 
@@ -412,8 +433,20 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     iterableFactory.from(bs.map(_.result()))
   }
 
+  /** Selects all elements of this $coll which satisfy a predicate.
+   *
+   *  @param pred the predicate used to test elements
+   *  @return a new $coll consisting of all elements of this $coll that satisfy the given
+   *          predicate `pred`. The order of the elements is preserved.
+   */
   def filter(pred: A => Boolean): C^{this, pred} = fromSpecific(new View.Filter(this, pred, isFlipped = false))
 
+  /** Selects all elements of this $coll which do not satisfy a predicate.
+   *
+   *  @param pred the predicate used to test elements
+   *  @return a new $coll consisting of all elements of this $coll that do not satisfy the
+   *          given predicate `pred`. Their order may not be preserved.
+   */
   def filterNot(pred: A => Boolean): C^{this, pred} = fromSpecific(new View.Filter(this, pred, isFlipped = true))
 
   /** Creates a non-strict filter of this $coll.
@@ -450,8 +483,24 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     (fromSpecific(first), fromSpecific(second))
   }
 
+  /** Splits this $coll into a prefix/suffix pair at a given position.
+   *
+   *  Note: `c splitAt n` is equivalent to `(c take n, c drop n)`.
+   *  $orderDependent
+   *
+   *  @param n the position at which to split
+   *  @return a pair of ${coll}s consisting of the first `n` elements of this $coll,
+   *          and the other elements
+   */
   override def splitAt(n: Int): (C^{this}, C^{this}) = (take(n), drop(n))
 
+  /** Selects the first `n` elements.
+   *  $orderDependent
+   *  @param n the number of elements to take from this $coll
+   *  @return a $coll consisting only of the first `n` elements of this $coll,
+   *          or else the whole $coll, if it has less than `n` elements.
+   *          If `n` is negative, returns an empty $coll.
+   */
   def take(n: Int): C^{this} = fromSpecific(new View.Take(this, n))
 
   /** Selects the last *n* elements.
@@ -471,8 +520,25 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def takeWhile(p: A => Boolean): C^{this, p} = fromSpecific(new View.TakeWhile(this, p))
 
+  /** Splits this $coll into a prefix/suffix pair according to a predicate.
+   *
+   *  Note: the default implementation is `(takeWhile(p), dropWhile(p))`, which traverses
+   *  this $coll twice and applies the predicate `p` to each element traversed.
+   *  $orderDependent
+   *
+   *  @param p the test predicate
+   *  @return a pair consisting of the longest prefix of this $coll whose
+   *          elements all satisfy `p`, and the rest of this $coll
+   */
   def span(p: A => Boolean): (C^{this, p}, C^{this, p}) = (takeWhile(p), dropWhile(p))
 
+  /** Selects all elements except the first `n` ones.
+   *  $orderDependent
+   *  @param n the number of elements to drop from this $coll
+   *  @return a $coll consisting of all elements of this $coll except the first `n` ones,
+   *          or else the empty $coll, if this $coll has less than `n` elements.
+   *          If `n` is negative, don't drop any elements.
+   */
   def drop(n: Int): C^{this} = fromSpecific(new View.Drop(this, n))
 
   /** Selects all elements except last *n* ones.
@@ -484,6 +550,17 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def dropRight(n: Int): C^{this} = fromSpecific(new View.DropRight(this, n))
 
+  /** Selects all elements except the longest prefix that satisfies a predicate.
+   *
+   *  The matching prefix starts with the first element of this $coll, and the element
+   *  following the prefix, if any, is the first element that does not satisfy the predicate. The
+   *  matching prefix may be empty, so that this method returns the entire $coll.
+   *  $orderDependent
+   *
+   *  @param p the predicate used to test elements
+   *  @return the longest suffix of this $coll whose first element does not satisfy the
+   *          predicate `p`
+   */
   def dropWhile(p: A => Boolean): C^{this, p} = fromSpecific(new View.DropWhile(this, p))
 
   /** Partitions elements in fixed size ${coll}s.
@@ -553,6 +630,15 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     dropRight(1)
   }
 
+  /** Selects an interval of elements.
+   *  $orderDependent
+   *
+   *  @param from the lowest index to include from this $coll
+   *  @param until the lowest index to EXCLUDE from this $coll
+   *  @return a $coll containing the elements greater than or equal to index `from`
+   *          extending up to (but not including) index `until` of this $coll; a negative
+   *          `from` is treated as `0`, and a non-positive `until` gives an empty result
+   */
   def slice(from: Int, until: Int): C^{this} =
     fromSpecific(new View.Drop(new View.Take(this, until), from))
 
@@ -615,7 +701,13 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
       bldr += f(elem)
     }
     class Result extends runtime.AbstractFunction1[(K, Builder[B, CC[B]]), Unit] {
+      /** The result map accumulated so far. */
       var built = immutable.Map.empty[K, CC[B]]
+      /** Adds to `built` a binding from the key in `kv` to the collection produced by its
+       *  group's builder.
+       *
+       *  @param kv a key paired with the builder collecting that key's group
+       */
       def apply(kv: (K, Builder[B, CC[B]])) =
         built = built.updated(kv._1, kv._2.result())
     }
@@ -670,6 +762,17 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def scan[B >: A](z: B)(op: (B, B) => B): CC[B]^{this, op} = scanLeft(z)(op)
 
+  /** Produces a $ccoll containing cumulative results of applying the operator going left
+   *  to right, including the initial value.
+   *
+   *  $willNotTerminateInf
+   *  $orderDependent
+   *
+   *  @tparam B the type of the elements in the resulting collection
+   *  @param z the initial value
+   *  @param op the binary operator applied to the intermediate result and the element
+   *  @return collection with intermediate results
+   */
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B]^{this, op} = iterableFactory.from(new View.ScanLeft(this, z, op))
 
   /** Produces a collection containing cumulative results of applying the operator going right to left.
@@ -690,8 +793,15 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def scanRight[B](z: B)(op: (A, B) => B): CC[B]^{this, op} = {
     class Scanner extends runtime.AbstractFunction1[A, Unit] {
+      /** The cumulative result so far, initially the value `z`. */
       var acc = z
+      /** The intermediate results produced so far, most recent first; initially just `z`. */
       var scanned = acc :: immutable.Nil
+      /** Combines the element `x` into the cumulative result and prepends the new result
+       *  to `scanned`.
+       *
+       *  @param x the element to combine
+       */
       def apply(x: A) = {
         acc = op(x, acc)
         scanned ::= acc
@@ -702,12 +812,45 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     iterableFactory.from(scanner.scanned)
   }
 
+  /** Builds a new $ccoll by applying a function to all elements of this $coll.
+   *
+   *  @tparam B the element type of the returned $ccoll
+   *  @param f the function to apply to each element
+   *  @return a new $ccoll resulting from applying the given function `f` to each element
+   *          of this $coll and collecting the results
+   */
   def map[B](f: A => B): CC[B]^{this, f} = iterableFactory.from(new View.Map(this, f))
 
+  /** Builds a new $ccoll by applying a function to all elements of this $coll and using
+   *  the elements of the resulting collections.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param f the function to apply to each element
+   *  @return a new $ccoll resulting from applying the given collection-valued function `f`
+   *          to each element of this $coll and concatenating the results
+   */
   def flatMap[B](f: A => IterableOnce[B]^): CC[B]^{this, f} = iterableFactory.from(new View.FlatMap(this, f))
 
+  /** Given that the elements of this collection are themselves iterable collections,
+   *  converts this $coll into a $ccoll comprising the elements of these iterable
+   *  collections.
+   *
+   *  @tparam B the type of the elements of each iterable collection
+   *  @param asIterable an implicit conversion which asserts that the element type of this
+   *         $coll is an `IterableOnce`
+   *  @return a new $ccoll resulting from concatenating all element collections
+   */
   def flatten[B](implicit asIterable: A -> IterableOnce[B]): CC[B]^{this} = flatMap(asIterable)
 
+  /** Builds a new $ccoll by applying a partial function to all elements of this $coll on
+   *  which the function is defined.
+   *
+   *  @tparam B the element type of the returned $ccoll
+   *  @param pf the partial function which filters and maps the $coll
+   *  @return a new $ccoll resulting from applying the given partial function `pf` to each
+   *          element on which it is defined and collecting the results.
+   *          The order of the elements is preserved.
+   */
   def collect[B](pf: PartialFunction[A, B]^): CC[B]^{this, pf} =
     iterableFactory.from(new View.Collect(this, pf))
 
@@ -775,6 +918,11 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     case _ => iterator.zip(that)
   })
 
+  /** Zips this $coll with its indices.
+   *
+   *  @return a new $ccoll containing pairs consisting of all elements of this $coll paired
+   *          with their index. Indices start at `0`.
+   */
   def zipWithIndex: CC[(A @uncheckedVariance, Int)]^{this} = iterableFactory.from(new View.ZipWithIndex(this))
 
   /** Returns a $coll formed from this $coll and another iterable collection
@@ -868,6 +1016,15 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def inits: Iterator[C^{this}]^{this} = iterateUntilEmpty(_.init)
 
+  /** Applies a side-effecting function to each element in this collection.
+   *  Strict collections will apply `f` to their elements immediately, while lazy
+   *  collections like Views and LazyLists will only apply `f` on each element if and when
+   *  that element is evaluated, and each time that element is evaluated.
+   *
+   *  @tparam U the return type of `f`; the value is discarded
+   *  @param f a function to apply to each element in this $coll
+   *  @return the same logical collection as this
+   */
   override def tapEach[U](f: A => U): C^{this, f} = fromSpecific(new View.Map(this, { (a: A) => f(a); a }))
 
   // A helper for tails and inits.
@@ -879,6 +1036,14 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     (it ++ Iterator.single(Iterable.empty: Iterable[A]^{this})).map(fromSpecific)
   }
 
+  /** Returns a new $ccoll containing the elements of `that` followed by the elements of
+   *  this $coll.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `A`
+   *  @param that the collection to prepend
+   *  @return a new $ccoll which contains all elements of `that` followed by all elements
+   *          of this $coll
+   */
   @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
   def ++:[B >: A](that: IterableOnce[B]^): CC[B]^{this, that} = iterableFactory.from(that match {
     case xs: Iterable[B @unchecked] => new View.Concat(xs, this)
@@ -935,17 +1100,47 @@ object IterableOps {
     p: A => Boolean
   ) extends collection.WithFilter[A, CC] with Serializable {
 
+    /** A non-strict view of the elements of `self` that satisfy the predicate `p`. */
     protected def filtered: Iterable[A]^{this} =
       new View.Filter(self, p, isFlipped = false)
 
+    /** Builds a new $coll by applying a function to all elements of the filtered
+     *  collection.
+     *
+     *  @tparam B the element type of the returned collection
+     *  @param f the function to apply to each element
+     *  @return a collection resulting from applying `f` to each element of `self` that
+     *          satisfies the predicate `p` and collecting the results
+     */
     def map[B](f: A => B): CC[B]^{this, f} =
       self.iterableFactory.from(new View.Map(filtered, f))
 
+    /** Builds a new $coll by applying a collection-valued function to all elements of the
+     *  filtered collection and using the elements of the resulting collections.
+     *
+     *  @tparam B the element type of the returned collection
+     *  @param f the function to apply to each element
+     *  @return a collection resulting from applying `f` to each element of `self` that
+     *          satisfies the predicate `p` and concatenating the results
+     */
     def flatMap[B](f: A => IterableOnce[B]^): CC[B]^{this, f} =
       self.iterableFactory.from(new View.FlatMap(filtered, f))
 
+    /** Applies the function `f`, for its side effects, to each element of `self` that
+     *  satisfies the predicate `p`.
+     *
+     *  @tparam U the return type of `f`; the value is discarded
+     *  @param f the function to apply to each element
+     */
     def foreach[U](f: A => U): Unit = filtered.foreach(f)
 
+    /** Further restricts the domain of subsequent `map`, `flatMap`, `foreach`, and
+     *  `withFilter` operations to elements that also satisfy the predicate `q`.
+     *
+     *  @param q the additional predicate used to test elements
+     *  @return a new `WithFilter` whose domain is the elements of `self` that satisfy both
+     *          `p` and `q`
+     */
     def withFilter(q: A => Boolean): WithFilter[A, CC]^{this, q} =
       new WithFilter(self, (a: A) => p(a) && q(a))
 
@@ -956,6 +1151,15 @@ object IterableOps {
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable) {
 
+  /** Returns an `Iterable` whose sole element is `a`.
+   *
+   *  Element access and slicing operations such as `head`, `last`, `take`, and `drop` are
+   *  overridden to constant-time implementations.
+   *
+   *  @tparam A the element type
+   *  @param a the single element of the collection
+   *  @return a collection containing `a` as its only element
+   */
   def single[A](a: A): Iterable[A] = new AbstractIterable[A] {
     override def iterator = Iterator.single(a)
     override def knownSize = 1
@@ -990,10 +1194,18 @@ abstract class AbstractIterable[+A] extends Iterable[A]
  *  @tparam CC the type constructor of the collection
  */
 trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
+  /** Builds a collection of type `CC[A]` containing the elements of the given source
+   *  collection, by delegating to [[iterableFactory]].
+   *
+   *  @param coll the source collection to convert
+   *  @return a collection of type `CC[A]` containing the elements of `coll`
+   */
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): CC[A @uncheckedVariance]^{coll} = iterableFactory.from(coll)
+  /** Returns a new builder for `CC[A]`, obtained from [[iterableFactory]]. */
   protected def newSpecificBuilder: Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = iterableFactory.newBuilder[A]
 
   // overridden for efficiency, since we know CC[A] =:= C
+  /** The empty collection, obtained from [[iterableFactory]]. */
   override def empty: CC[A @uncheckedVariance] = iterableFactory.empty
 }
 
@@ -1009,10 +1221,27 @@ trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends I
  *  @tparam CC the type constructor of the collection
  */
 trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], Ev[_]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
+  /** The factory used to build collections of type `CC`, which requires an evidence value
+   *  of type `Ev` for the element type.
+   */
   protected def evidenceIterableFactory: EvidenceIterableFactory[CC, Ev]
+  /** The evidence value for the element type `A`, required by [[evidenceIterableFactory]]. */
   implicit protected def iterableEvidence: Ev[A @uncheckedVariance]
+  /** Builds a collection of type `CC[A]` containing the elements of the given source
+   *  collection, by delegating to [[evidenceIterableFactory]] with the implicit
+   *  [[iterableEvidence]].
+   *
+   *  @param coll the source collection to convert
+   *  @return a collection of type `CC[A]` containing the elements of `coll`
+   */
   override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): CC[A @uncheckedVariance]^{coll} = evidenceIterableFactory.from(coll)
+  /** Returns a new builder for `CC[A]`, obtained from [[evidenceIterableFactory]] with the
+   *  implicit [[iterableEvidence]].
+   */
   override protected def newSpecificBuilder: Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = evidenceIterableFactory.newBuilder[A]
+  /** The empty collection, obtained from [[evidenceIterableFactory]] with the implicit
+   *  [[iterableEvidence]].
+   */
   override def empty: CC[A @uncheckedVariance] = evidenceIterableFactory.empty
 }
 
@@ -1036,10 +1265,24 @@ trait SortedSetFactoryDefaults[+A,
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] & Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
   self: IterableOps[A, WithFilterCC, CC[A @uncheckedVariance]] =>
 
+  /** Builds a sorted set of type `CC[A]` containing the elements of the given source
+   *  collection, by delegating to `sortedIterableFactory` with this set's `ordering`.
+   *
+   *  @param coll the source collection to convert
+   *  @return a sorted set of type `CC[A]` containing the elements of `coll`
+   */
   override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(using ordering)
+  /** Returns a new builder for `CC[A]`, obtained from `sortedIterableFactory` with this set's `ordering`. */
   override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](using ordering)
+  /** The empty sorted set, obtained from `sortedIterableFactory` with this set's `ordering`. */
   override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(using ordering)
 
+  /** Creates a non-strict filter of this sorted set.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an object whose `map`, `flatMap`, `foreach`, and `withFilter` operations
+   *          apply to those elements of this sorted set that satisfy the predicate `p`
+   */
   override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, WithFilterCC, CC]^{p} =
     new SortedSetOps.WithFilter[A, WithFilterCC, CC](this, p)
 }
@@ -1065,14 +1308,30 @@ trait MapFactoryDefaults[K, +V,
     +CC[x, y] <: IterableOps[(x, y), Iterable, Iterable[(x, y)]],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] & Iterable[x]] extends MapOps[K, V, CC, CC[K, V @uncheckedVariance]] with IterableOps[(K, V), WithFilterCC, CC[K, V @uncheckedVariance]] {
   this: MapFactoryDefaults[K, V, CC, WithFilterCC] =>
+  /** Builds a map of type `CC[K, V]` containing the key-value pairs of the given source
+   *  collection, by delegating to `mapFactory`.
+   *
+   *  @param coll the source collection of key-value pairs to convert
+   *  @return a map of type `CC[K, V]` containing the key-value pairs of `coll`
+   */
   override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]^): CC[K, V @uncheckedVariance]^{coll} = mapFactory.from(coll)
+  /** Returns a new builder for `CC[K, V]`, obtained from `mapFactory`. */
   override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = mapFactory.newBuilder[K, V]
+  /** The empty map, obtained from `mapFactory`; for an [[scala.collection.immutable.TreeSeqMap]]
+   *  the empty map additionally keeps the receiver's ordering mode.
+   */
   override def empty: CC[K, V @uncheckedVariance] = (this: AnyRef) match {
     // Implemented here instead of in TreeSeqMap since overriding empty in TreeSeqMap is not forwards compatible (should be moved)
     case self: immutable.TreeSeqMap[?, ?] => immutable.TreeSeqMap.empty(self.orderedBy).asInstanceOf[CC[K, V]]
     case _ => mapFactory.empty
   }
 
+  /** Creates a non-strict filter of this map.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return an object whose `map`, `flatMap`, `foreach`, and `withFilter` operations
+   *          apply to those key-value pairs of this map that satisfy the predicate `p`
+   */
   override def withFilter(p: ((K, V)) => Boolean): MapOps.WithFilter[K, V, WithFilterCC, CC]^{p} =
     new MapOps.WithFilter[K, V, WithFilterCC, CC](this, p)
 }
@@ -1099,10 +1358,24 @@ trait SortedMapFactoryDefaults[K, +V,
     +UnsortedCC[x, y] <: Map[x, y]] extends SortedMapOps[K, V, CC, CC[K, V @uncheckedVariance]] with MapOps[K, V, UnsortedCC, CC[K, V @uncheckedVariance]] with caps.Pure {
   self: IterableOps[(K, V), WithFilterCC, CC[K, V @uncheckedVariance]] =>
 
+  /** The empty sorted map, obtained from `sortedMapFactory` with this map's `ordering`. */
   override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(using ordering)
+  /** Builds a sorted map of type `CC[K, V]` containing the key-value pairs of the given
+   *  source collection, by delegating to `sortedMapFactory` with this map's `ordering`.
+   *
+   *  @param coll the source collection of key-value pairs to convert
+   *  @return a sorted map of type `CC[K, V]` containing the key-value pairs of `coll`
+   */
   override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]^): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(using ordering)
+  /** Returns a new builder for `CC[K, V]`, obtained from `sortedMapFactory` with this map's `ordering`. */
   override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](using ordering)
 
+  /** Creates a non-strict filter of this sorted map.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return an object whose `map`, `flatMap`, `foreach`, and `withFilter` operations
+   *          apply to those key-value pairs of this sorted map that satisfy the predicate `p`
+   */
   override def withFilter(p: ((K, V)) => Boolean): collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC]^{p} =
     new collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC](this, p)
 }

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -101,70 +101,203 @@ trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
   def knownSize: Int = -1
 }
 
+/** A value class providing the operations of Scala 2.12's `TraversableOnce` as deprecated
+ *  extension methods on [[IterableOnce]], each implemented by delegating to the
+ *  corresponding operation on `it.iterator`.
+ *
+ *  A strict operation traverses the wrapped collection, and consumes it if it can be
+ *  traversed only once. The lazy ones, such as `map`, `flatMap`, `filter` and
+ *  `withFilter`, build an iterator without traversing anything until it is consumed, and
+ *  `toIterator` simply hands back the wrapped iterator.
+ *
+ *  @tparam A the element type of the wrapped collection
+ *  @param it the wrapped collection
+ */
 final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) extends AnyVal {
+  /** Returns an iterator over all elements of the wrapped collection that satisfy the
+   *  predicate `f`.
+   *
+   *  @param f the predicate used to test elements
+   */
   @deprecated("Use .iterator.withFilter(...) instead", "2.13.0")
   def withFilter(f: A => Boolean): Iterator[A]^{f} = it.iterator.withFilter(f)
 
+  /** Optionally applies the binary operator `f` to all elements of the wrapped collection,
+   *  going left to right.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction inside a `Some` if the wrapped collection is
+   *          nonempty, `None` otherwise
+   */
   @deprecated("Use .iterator.reduceLeftOption(...) instead", "2.13.0")
   def reduceLeftOption(f: (A, A) => A): Option[A] = it.iterator.reduceLeftOption(f)
 
+  /** Returns the smallest element of the wrapped collection with respect to the
+   *  ordering `ord`.
+   *
+   *  @param ord the ordering used to compare elements
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.min instead", "2.13.0")
   def min(implicit ord: Ordering[A]): A = it.iterator.min
 
+  /** Returns `true` if the wrapped collection contains at least one element, `false` otherwise. */
   @deprecated("Use .iterator.nonEmpty instead", "2.13.0")
   def nonEmpty: Boolean = it.iterator.nonEmpty
 
+  /** Returns the largest element of the wrapped collection with respect to the
+   *  ordering `ord`.
+   *
+   *  @param ord the ordering used to compare elements
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.max instead", "2.13.0")
   def max(implicit ord: Ordering[A]): A = it.iterator.max
 
+  /** Applies the binary operator `f` to all elements of the wrapped collection, going
+   *  right to left.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.reduceRight(...) instead", "2.13.0")
   def reduceRight(f: (A, A) => A): A = it.iterator.reduceRight(f)
 
+  /** Returns the first element of the wrapped collection with the largest value measured
+   *  by function `f`, with respect to the ordering `cmp`.
+   *
+   *  @tparam B the result type of the measuring function
+   *  @param f the measuring function
+   *  @param cmp the ordering used to compare measured values
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.maxBy(...) instead", "2.13.0")
   def maxBy[B](f: A -> B)(implicit cmp: Ordering[B]): A = it.iterator.maxBy(f)
 
+  /** Applies the binary operator `f` to all elements of the wrapped collection, going
+   *  left to right.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.reduceLeft(...) instead", "2.13.0")
   def reduceLeft(f: (A, A) => A): A = it.iterator.reduceLeft(f)
 
+  /** Returns the sum of all elements of the wrapped collection with respect to the `+`
+   *  operator in `num`.
+   *
+   *  @param num the `Numeric` instance providing the `+` operator and the zero of the sum
+   *  @return the sum of all elements, or `num.zero` if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.sum instead", "2.13.0")
   def sum(implicit num: Numeric[A]): A = it.iterator.sum
 
+  /** Returns the product of all elements of the wrapped collection with respect to the `*`
+   *  operator in `num`.
+   *
+   *  @param num the `Numeric` instance providing the `*` operator and the unit of the product
+   *  @return the product of all elements, or `num.one` if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.product instead", "2.13.0")
   def product(implicit num: Numeric[A]): A = it.iterator.product
 
+  /** Returns the number of elements of the wrapped collection that satisfy the
+   *  predicate `f`.
+   *
+   *  @param f the predicate used to test elements
+   */
   @deprecated("Use .iterator.count(...) instead", "2.13.0")
   def count(f: A => Boolean): Int = it.iterator.count(f)
 
+  /** Optionally reduces the wrapped collection with the binary operator `f`, going left
+   *  to right.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction inside a `Some` if the wrapped collection is
+   *          nonempty, `None` otherwise
+   */
   @deprecated("Use .iterator.reduceOption(...) instead", "2.13.0")
   def reduceOption(f: (A, A) => A): Option[A] = it.iterator.reduceOption(f)
 
+  /** Returns the first element of the wrapped collection with the smallest value measured
+   *  by function `f`, with respect to the ordering `cmp`.
+   *
+   *  @tparam B the result type of the measuring function
+   *  @param f the measuring function
+   *  @param cmp the ordering used to compare measured values
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.minBy(...) instead", "2.13.0")
   def minBy[B](f: A -> B)(implicit cmp: Ordering[B]): A = it.iterator.minBy(f)
 
+  /** Returns the number of elements in the wrapped collection. */
   @deprecated("Use .iterator.size instead", "2.13.0")
   def size: Int = it.iterator.size
 
+  /** Returns `true` if the wrapped collection is empty or the predicate `f` holds for all
+   *  of its elements, `false` otherwise.
+   *
+   *  @param f the predicate used to test elements
+   */
   @deprecated("Use .iterator.forall(...) instead", "2.13.0")
   def forall(f: A => Boolean): Boolean = it.iterator.forall(f)
 
+  /** Finds the first element of the wrapped collection for which the partial function `f`
+   *  is defined, and applies `f` to it.
+   *
+   *  @tparam B the result type of the partial function
+   *  @param f the partial function to test and apply
+   *  @return an option value containing `f` applied to the first element for which it is
+   *          defined, or `None` if none exists
+   */
   @deprecated("Use .iterator.collectFirst(...) instead", "2.13.0")
   def collectFirst[B](f: PartialFunction[A, B]^): Option[B] = it.iterator.collectFirst(f)
 
+  /** Returns an iterator over all elements of the wrapped collection that satisfy the
+   *  predicate `f`.
+   *
+   *  @param f the predicate used to test elements
+   */
   @deprecated("Use .iterator.filter(...) instead", "2.13.0")
   def filter(f: A => Boolean): Iterator[A]^{f} = it.iterator.filter(f)
 
+  /** Returns `true` if the predicate `f` holds for at least one element of the wrapped
+   *  collection, `false` otherwise.
+   *
+   *  @param f the predicate used to test elements
+   */
   @deprecated("Use .iterator.exists(...) instead", "2.13.0")
   def exists(f: A => Boolean): Boolean = it.iterator.exists(f)
 
+  /** Appends all elements of the wrapped collection to the buffer `dest`.
+   *
+   *  @param dest the buffer to which elements are appended
+   */
   @deprecated("Use .iterator.copyToBuffer(...) instead", "2.13.0")
   def copyToBuffer(dest: mutable.Buffer[A]): Unit = it.iterator.copyToBuffer(dest)
 
+  /** Reduces the wrapped collection with the binary operator `f`, going left to right.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction
+   *  @throws UnsupportedOperationException if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.reduce(...) instead", "2.13.0")
   def reduce(f: (A, A) => A): A = it.iterator.reduce(f)
 
+  /** Optionally applies the binary operator `f` to all elements of the wrapped collection,
+   *  going right to left.
+   *
+   *  @param f the binary operator
+   *  @return the result of the reduction inside a `Some` if the wrapped collection is
+   *          nonempty, `None` otherwise
+   */
   @deprecated("Use .iterator.reduceRightOption(...) instead", "2.13.0")
   def reduceRightOption(f: (A, A) => A): Option[A] = it.iterator.reduceRightOption(f)
 
+  /** Returns an immutable `IndexedSeq` containing all elements of the wrapped collection. */
   @deprecated("Use .iterator.toIndexedSeq instead", "2.13.0")
   def toIndexedSeq: IndexedSeq[A] = it.iterator.toIndexedSeq
 
@@ -174,18 +307,34 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
     case _ => it.iterator.foreach(f)
   }
 
+  /** Converts the wrapped collection to a collection of type `C1`.
+   *
+   *  @tparam C1 the target collection type
+   *  @param factory the factory for the target collection type
+   *  @return a new collection of type `C1` containing all elements of the wrapped collection
+   */
   @deprecated("Use .iterator.to(factory) instead", "2.13.0")
   def to[C1](factory: Factory[A, C1]): C1 = factory.fromSpecific(it)
 
+  /** Returns a new mutable `Buffer` (an `ArrayBuffer`) containing all elements of the
+   *  wrapped collection.
+   *
+   *  @tparam B the element type of the result, a supertype of `A`
+   */
   @deprecated("Use .iterator.to(ArrayBuffer) instead", "2.13.0")
   def toBuffer[B >: A]: mutable.Buffer[B] = mutable.ArrayBuffer.from(it)
 
+  /** Returns an array containing all elements of the wrapped collection.
+   *
+   *  @tparam B the element type of the result, a supertype of `A`
+   */
   @deprecated("Use .iterator.toArray", "2.13.0")
   def toArray[B >: A: ClassTag]: Array[B] = it match {
     case it: Iterable[B @unchecked] => it.toArray[B]
     case _ => it.iterator.toArray[B]
   }
 
+  /** Returns a `List` containing all elements of the wrapped collection. */
   @deprecated("Use .iterator.to(List) instead", "2.13.0")
   def toList: immutable.List[A] = immutable.List.from(it)
 
@@ -207,6 +356,16 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
   @deprecated("Use .iterator.to(Vector) instead", "2.13.0")
   @`inline` def toVector: immutable.Vector[A] = immutable.Vector.from(it)
 
+  /** Converts the wrapped collection to an immutable `Map`, given implicit evidence that
+   *  its element type is a key-value pair.
+   *
+   *  @tparam K the key type of the resulting map
+   *  @tparam V the value type of the resulting map
+   *  @param ev implicit evidence that `A` is a subtype of `(K, V)`; never used, but its
+   *            presence proves the element type is a pair
+   *  @return an immutable map containing the elements of the wrapped collection as key-value
+   *          bindings
+   */
   @deprecated("Use .iterator.to(Map) instead", "2.13.0")
   def toMap[K, V](implicit ev: A <:< (K, V)): immutable.Map[K, V] =
     immutable.Map.from(it.asInstanceOf[IterableOnce[(K, V)]])
@@ -214,30 +373,53 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
   @deprecated("Use .iterator instead", "2.13.0")
   @`inline` def toIterator: Iterator[A] = it.iterator
 
+  /** Returns `true` if the wrapped collection contains no elements, `false` otherwise. */
   @deprecated("Use .iterator.isEmpty instead", "2.13.0")
   def isEmpty: Boolean = it match {
     case it: Iterable[A @unchecked] => it.isEmpty
     case _ => it.iterator.isEmpty
   }
 
+  /** Returns a string representation of the wrapped collection that begins with the string
+   *  `start` and ends with the string `end`, with the string representations of all
+   *  elements separated by the string `sep`.
+   *
+   *  @param start the starting string
+   *  @param sep the separator string
+   *  @param end the ending string
+   */
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString(start: String, sep: String, end: String): String = it match {
     case it: Iterable[A @unchecked] => it.mkString(start, sep, end)
     case _ => it.iterator.mkString(start, sep, end)
   }
 
+  /** Returns a string representation of the wrapped collection in which the string
+   *  representations of all elements are separated by the string `sep`.
+   *
+   *  @param sep the separator string
+   */
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString(sep: String): String = it match {
     case it: Iterable[A @unchecked] => it.mkString(sep)
     case _ => it.iterator.mkString(sep)
   }
 
+  /** Returns a string representation of the wrapped collection in which the string
+   *  representations of all elements follow each other without any separator.
+   */
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString: String = it match {
     case it: Iterable[A @unchecked] => it.mkString
     case _ => it.iterator.mkString
   }
 
+  /** Finds the first element of the wrapped collection satisfying the predicate `p`, if any.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an option value containing the first element that satisfies `p`, or `None` if
+   *          none exists
+   */
   @deprecated("Use .iterator.find instead", "2.13.0")
   def find(p: A => Boolean): Option[A] = it.iterator.find(p)
 
@@ -247,6 +429,14 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
   @deprecated("Use .iterator.foldRight instead", "2.13.0")
   @`inline` def foldRight[B](z: B)(op: (A, B) => B): B = it.iterator.foldRight(z)(op)
 
+  /** Folds the elements of the wrapped collection using the binary operator `op`, starting
+   *  with the initial value `z`, going left to right.
+   *
+   *  @tparam A1 the result type of the binary operator, a supertype of `A`
+   *  @param z the initial value
+   *  @param op the binary operator
+   *  @return the result of the fold, or `z` if the wrapped collection is empty
+   */
   @deprecated("Use .iterator.fold instead", "2.13.0")
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = it.iterator.fold(z)(op)
 
@@ -256,23 +446,54 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
   @deprecated("Use .iterator.foldRight instead", "2.13.0")
   @`inline` def :\ [B](z: B)(op: (A, B) => B): B = foldRight[B](z)(op)
 
+  /** Builds a new `IterableOnce` by applying the function `f` to all elements of the
+   *  wrapped collection: an `Iterable` if the wrapped collection is an `Iterable`, an
+   *  iterator otherwise.
+   *
+   *  @tparam B the element type of the result
+   *  @param f the function to apply to each element
+   *  @return a new `IterableOnce` containing the results of applying `f` to each element of
+   *          the wrapped collection
+   */
   @deprecated("Use .iterator.map instead or consider requiring an Iterable", "2.13.0")
   def map[B](f: A => B): IterableOnce[B]^{f} = it match {
     case it: Iterable[A @unchecked]^{f} => it.map(f)
     case _ => it.iterator.map(f)
   }
 
+  /** Builds a new `IterableOnce` by applying the collection-valued function `f` to all
+   *  elements of the wrapped collection and concatenating the results: an `Iterable` if the
+   *  wrapped collection is an `Iterable`, an iterator otherwise.
+   *
+   *  @tparam B the element type of the result
+   *  @param f the collection-valued function to apply to each element
+   *  @return a new `IterableOnce` containing the concatenated results of applying `f` to
+   *          each element of the wrapped collection
+   */
   @deprecated("Use .iterator.flatMap instead or consider requiring an Iterable", "2.13.0")
   def flatMap[B](f: A => IterableOnce[B]^): IterableOnce[B]^{f} = it match {
     case it: Iterable[A @unchecked] => it.flatMap(f)
     case _ => it.iterator.flatMap(f)
   }
 
+  /** Returns `true` if the wrapped collection and `that` contain the same elements in the
+   *  same order, `false` otherwise.
+   *
+   *  @tparam B the element type of `that`, a supertype of `A`
+   *  @param that the collection to compare with
+   */
   @deprecated("Use .iterator.sameElements instead", "2.13.0")
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = it.iterator.sameElements(that)
 }
 
 object IterableOnce {
+  /** Implicit conversion providing the deprecated compatibility operations of
+   *  [[IterableOnceExtensionMethods]] on any `IterableOnce`.
+   *
+   *  @tparam A the element type of the collection
+   *  @param it the collection to wrap
+   *  @return a value class wrapping `it`
+   */
   @inline implicit def iterableOnceExtensionMethods[A](it: IterableOnce[A]): IterableOnceExtensionMethods[A] =
     new IterableOnceExtensionMethods[A](it)
 
@@ -577,7 +798,13 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
    */
   def splitAt(n: Int): (C^{this}, C^{this}) = {
     class Spanner extends runtime.AbstractFunction1[A, Boolean] {
+      /** The number of elements accepted so far. */
       var i = 0
+      /** Returns `true` for the first `n` applications, incrementing the count each time,
+       *  and `false` afterwards.
+       *
+       *  @param a the element under test; never used
+       */
       def apply(a: A) = i < n && { i += 1 ; true }
     }
     val spanner = new Spanner
@@ -1007,6 +1234,11 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
       len
     }
 
+  /** Appends all elements of this $coll to the buffer `dest`.
+   *
+   *  @tparam B the element type of the buffer, a supertype of `A`
+   *  @param dest the buffer to which elements are appended
+   */
   @deprecated("Use `dest ++= coll` instead", "2.13.0")
   @inline final def copyToBuffer[B >: A](dest: mutable.Buffer[B]): Unit = dest ++= this
 
@@ -1512,6 +1744,7 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
    */
   def toIndexedSeq: immutable.IndexedSeq[A] = immutable.IndexedSeq.from(this)
 
+  /** Converts this $coll to a `Stream`. */
   @deprecated("Use .to(LazyList) instead of .toStream", "2.13.0")
   @inline final def toStream: immutable.Stream[A] = to(immutable.Stream)
 
@@ -1539,6 +1772,13 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
     else mutable.ArrayBuilder.make[B].addAll(this).result()
 
   // For internal use
+  /** Returns an `Iterable` containing the elements of this $coll in reverse order of
+   *  traversal.
+   *
+   *  The default implementation eagerly copies all elements into a `List` by prepending
+   *  each one; it is the basis for the default right-to-left operations such as
+   *  `foldRight` and `reduceRight`.
+   */
   protected def reversed: Iterable[A]^{this} = {
     var xs: immutable.List[A] = immutable.Nil
     val it = iterator

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -100,6 +100,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   @throws[NoSuchElementException]
   def next(): A
 
+  /** Returns this iterator, since an iterator is its own iterator.
+   *
+   *  @note Reuse: $preservesIterator
+   */
   @inline final def iterator = this
 
   /** Wraps the value of `next()` in an option.
@@ -276,8 +280,21 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     // fill() returns false if no more sequences can be produced
     private def fill(): Boolean = filled || { filled = self.hasNext && fulfill() ; filled }
 
+    /** Tests whether another segment can be produced, buffering it eagerly
+     *  from the underlying iterator if it is not already buffered.
+     */
     def hasNext = fill()
 
+    /** Returns the next segment, buffering it from the underlying iterator if
+     *  it has not already been buffered by `hasNext`.
+     *
+     *  If sliding with `step < size`, the elements shared with the next
+     *  segment are retained for reuse.
+     *
+     *  @return the next segment, of `size` elements unless it is a partial
+     *          segment permitted by `withPartial`
+     *  @throws NoSuchElementException if no further segment can be produced
+     */
     @throws[NoSuchElementException]
     def next(): immutable.Seq[B] =
       if (!fill()) Iterator.empty.next()
@@ -403,6 +420,19 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   def sliding[B >: A](size: Int, step: Int = 1): GroupedIterator[B]^{this} =
     new GroupedIterator[B](self, size, step)
 
+  /** Produces an iterator containing the cumulative results of applying the
+   *  operator `op` going left to right, starting with the value `z`.
+   *
+   *  The results are computed lazily, as the returned iterator is advanced.
+   *
+   *  @tparam B the element type of the returned iterator
+   *  @param z the initial value, produced first
+   *  @param op the operator applied to the previous cumulative result and the
+   *            next element of this iterator
+   *  @return an iterator producing `z, op(z, x1), op(op(z, x1), x2), ...`
+   *          where `x1, x2, ...` are the elements of this iterator
+   *  @note   Reuse: $consumesAndProducesIterator
+   */
   def scanLeft[B](z: B)(op: (B, A) => B): Iterator[B]^{this, op} = new AbstractIterator[B] {
     // We use an intermediate iterator that iterates through the first element `z`
     // and then that will be modified to iterate through the collection
@@ -434,6 +464,21 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def hasNext: Boolean = current.hasNext
   }
 
+  /** Produces an iterator containing the cumulative results of applying the
+   *  operator `op` going right to left, ending with the value `z`.
+   *
+   *  Unlike most iterator methods, calling this method immediately consumes
+   *  this iterator into an internal buffer, so it must not be called on an
+   *  infinite iterator.
+   *
+   *  @tparam B the element type of the returned iterator
+   *  @param z the initial value, produced last
+   *  @param op the operator applied to an element of this iterator and the
+   *            cumulative result to its right
+   *  @return an iterator producing `..., op(x(n-1), op(xn, z)), op(xn, z), z`
+   *          where `x1, ..., xn` are the elements of this iterator
+   *  @note   Reuse: $consumesAndProducesIterator
+   */
   @deprecated("Call scanRight on an Iterable instead.", "2.13.0")
   def scanRight[B](z: B)(op: (A, B) => B): Iterator[B]^{this, op} = ArrayBuffer.from(this).scanRight(z)(op).iterator
 
@@ -495,13 +540,39 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     -1
   }
 
+  /** Returns the number of elements produced by this iterator, an alias of `size`.
+   *
+   *  Note: will not terminate for infinite iterators.
+   *
+   *  @note Reuse: $consumesIterator
+   */
   @inline final def length: Int = size
 
+  /** Tests whether this iterator is exhausted, i.e. whether `hasNext` is `false`.
+   *
+   *  @note Reuse: $preservesIterator
+   */
   @deprecatedOverriding("isEmpty is defined as !hasNext; override hasNext instead", "2.13.0")
   override def isEmpty: Boolean = !hasNext
 
+  /** Creates an iterator over all the elements of this iterator that
+   *  satisfy the predicate `p`. The order of the elements
+   *  is preserved.
+   *
+   *  @param p the predicate used to test values.
+   *  @return  an iterator which produces those values of this iterator which satisfy the predicate `p`.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def filter(p: A => Boolean): Iterator[A]^{this, p} = filterImpl(p, isFlipped = false)
 
+  /** Creates an iterator over all the elements of this iterator which do not
+   *  satisfy the predicate `p`. The order of the elements
+   *  is preserved.
+   *
+   *  @param p the predicate used to test values.
+   *  @return  an iterator which produces those values of this iterator which do not satisfy the predicate `p`.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def filterNot(p: A => Boolean): Iterator[A]^{this, p} = filterImpl(p, isFlipped = true)
 
   private[collection] def filterImpl(p: A => Boolean, isFlipped: Boolean): Iterator[A]^{this, p} = new AbstractIterator[A] {
@@ -540,6 +611,16 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    */
   def withFilter(p: A => Boolean): Iterator[A]^{this, p} = filter(p)
 
+  /** Creates an iterator by transforming values produced by this iterator with
+   *  a partial function, dropping those values for which the partial function
+   *  is not defined.
+   *
+   *  @tparam B the element type of the returned iterator
+   *  @param pf the partial function which filters and maps the iterator.
+   *  @return   an iterator which yields the value `pf(x)` for each value `x` produced by
+   *            this iterator on which `pf` is defined.
+   *  @note     Reuse: $consumesAndProducesIterator
+   */
   def collect[B](pf: PartialFunction[A, B]^): Iterator[B]^{this, pf} = new AbstractIterator[B] with (A => B) {
     // Manually buffer to avoid extra layer of wrapping with buffered
     private var hd: B = compiletime.uninitialized
@@ -611,12 +692,31 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       }
   }
 
+  /** Creates a new iterator that maps all produced values of this iterator
+   *  to new values using a transformation function.
+   *
+   *  @tparam B the element type of the returned iterator
+   *  @param f the transformation function
+   *  @return  a new iterator which transforms every value produced by this
+   *           iterator by applying the function `f` to it.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def map[B](f: A => B): Iterator[B]^{this, f} = new AbstractIterator[B] {
     override def knownSize = self.knownSize
     def hasNext = self.hasNext
     def next() = f(self.next())
   }
 
+  /** Creates a new iterator by applying a function to all values produced by
+   *  this iterator and concatenating the results.
+   *
+   *  @tparam B the element type of the returned iterator
+   *  @param f the function to apply on each value produced by this iterator
+   *  @return  the iterator resulting from applying the given iterator-valued
+   *           function `f` to each value produced by this iterator and
+   *           concatenating the results.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def flatMap[B](f: A => IterableOnce[B]^): Iterator[B]^{this, f} = new AbstractIterator[B] {
     private var cur: Iterator[B]^{f} = Iterator.empty
     /** Trillium logic boolean: -1 = unknown, 0 = false, 1 = true. */
@@ -652,15 +752,55 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     }
   }
 
+  /** Creates a new iterator by concatenating the elements of the collections
+   *  produced by this iterator.
+   *
+   *  @tparam B the element type of the collections produced by this iterator
+   *  @param ev evidence that each element of this iterator can be treated as
+   *            an `IterableOnce[B]`
+   *  @return   an iterator producing, in order, the elements of each collection
+   *            produced by this iterator.
+   *  @note     Reuse: $consumesAndProducesIterator
+   */
   def flatten[B](implicit ev: A -> IterableOnce[B]): Iterator[B]^{this} =
     flatMap[B](ev)
 
+  /** Concatenates this iterator with the elements of another collection.
+   *
+   *  The by-name argument `xs` is evaluated lazily: not when this method is
+   *  called, but only once the returned iterator has produced all values of
+   *  this iterator and more are demanded. Repeated concatenations are
+   *  efficient because appended collections are kept in a flat queue rather
+   *  than in nested iterators.
+   *
+   *  @tparam B the element type of the returned iterator, a supertype of `A`
+   *  @param xs the collection whose elements follow the values of this iterator
+   *  @return   an iterator producing the values of this iterator, followed by
+   *            the elements of `xs`.
+   *  @note     Reuse: $consumesTwoAndProducesOneIterator
+   */
   def concat[B >: A](xs: => IterableOnce[B]^): Iterator[B]^{this, xs} = new Iterator.ConcatIterator[B](self).concat(xs)
 
   @`inline` final def ++ [B >: A](xs: => IterableOnce[B]^): Iterator[B]^{this, xs} = concat(xs)
 
+  /** Selects the first `n` values of this iterator.
+   *
+   *  @param n the number of values to take
+   *  @return  an iterator producing only the first `n` values of this iterator,
+   *           or else the whole iterator, if it produces fewer than `n` values.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def take(n: Int): Iterator[A]^{this} = sliceIterator(0, n max 0)
 
+  /** Takes the longest prefix of values produced by this iterator that satisfy
+   *  a predicate.
+   *
+   *  @param p the predicate used to test elements.
+   *  @return  an iterator producing the values of this iterator, until
+   *           this iterator produces a value that does not satisfy
+   *           the predicate `p`.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def takeWhile(p: A => Boolean): Iterator[A]^{this, p} = new AbstractIterator[A] {
     private var hd: A = compiletime.uninitialized
     private var hdDefined: Boolean = false
@@ -675,8 +815,27 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = if (hasNext) { hdDefined = false; hd } else Iterator.empty.next()
   }
 
+  /** Selects all values of this iterator except the first `n` ones.
+   *
+   *  The skipped values are not consumed immediately, but only once the
+   *  returned iterator is queried.
+   *
+   *  @param n the number of values to drop
+   *  @return  an iterator producing all values of this iterator except the
+   *           first `n` ones, or else the empty iterator, if this iterator
+   *           produces fewer than `n` values.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def drop(n: Int): Iterator[A]^{this} = sliceIterator(n, -1)
 
+  /** Skips the longest prefix of values produced by this iterator that satisfy
+   *  a predicate.
+   *
+   *  @param p the predicate used to skip values.
+   *  @return  an iterator producing the values of this iterator starting with
+   *           the first value that does not satisfy the predicate `p`.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def dropWhile(p: A => Boolean): Iterator[A]^{this, p} = new AbstractIterator[A] {
     // Magic value: -1 = hasn't dropped, 0 = found first, 1 = defer to parent iterator
     private var status = -1
@@ -738,6 +897,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
         if (lookahead == null) lookahead = new mutable.Queue[A]
         lookahead.nn += a
       }
+      /** Tests whether the prefix has another element, either buffered in the
+       *  lookahead queue or read ahead from the underlying iterator and tested
+       *  against `p`.
+       */
       def hasNext = {
         if (status < 0) (lookahead ne null) && lookahead.nn.nonEmpty
         else if (status > 0) true
@@ -750,6 +913,12 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
           status > 0
         }
       }
+      /** Returns the next element of the prefix, taken from the lookahead
+       *  queue if the underlying iterator has been handed over to the trailing
+       *  iterator.
+       *
+       *  @throws NoSuchElementException if the prefix is exhausted
+       */
       def next() = {
         if (hasNext) {
           if (status == 1) { status = 0; hd }
@@ -757,6 +926,12 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
         }
         else Iterator.empty.next()
       }
+      /** Hands the underlying iterator over to the trailing iterator, reading
+       *  all remaining prefix elements into the lookahead queue.
+       *
+       *  @return `true` if an element failing `p` was found and saved as the
+       *          trailer, `false` if the underlying iterator was exhausted first
+       */
       @tailrec
       def finish(): Boolean = status match {
         case -2 => status = -1 ; true
@@ -774,6 +949,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
           }
           false
       }
+      /** Returns the first element that failed `p`, valid once `finish()` has returned `true`. */
       def trailer: A = hd
     }
 
@@ -816,6 +992,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     (leading, trailing)
   }
 
+  /** Creates an iterator returning an interval of the values produced by this iterator.
+   *
+   *  @param from the index of the first element in this iterator which forms
+   *              part of the slice. If negative, the slice starts at zero.
+   *  @param until the index of the first element following the slice. If
+   *               negative, the slice is empty.
+   *  @return an iterator which advances this iterator past the first `from` elements,
+   *          treating a negative `from` as `0`, and then produces at most as many
+   *          elements as remain up to `until`.
+   *  @note   Reuse: $consumesAndProducesIterator
+   */
   def slice(from: Int, until: Int): Iterator[A]^{this} = sliceIterator(from, until max 0)
 
   /** Creates an optionally bounded slice, unbounded if `until` is negative.
@@ -837,6 +1024,18 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     else new Iterator.SliceIterator(this, lo, rest)
   }
 
+  /** Creates an iterator formed from this iterator and another iterable
+   *  collection by combining corresponding values in pairs. If one of the two
+   *  is longer than the other, its remaining elements are ignored.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection providing the second half of each result pair
+   *  @return a new iterator containing pairs consisting of corresponding
+   *          elements of this iterator and `that`. The number of elements
+   *          produced by the new iterator is the minimum of the number of
+   *          elements produced by this iterator and `that`.
+   *  @note   Reuse: $consumesTwoAndProducesOneIterator
+   */
   def zip[B](that: IterableOnce[B]^): Iterator[(A, B)]^{this, that} = new AbstractIterator[(A, B)] {
     val thatIterator = that.iterator
     override def knownSize = self.knownSize min thatIterator.knownSize
@@ -844,6 +1043,24 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = (self.next(), thatIterator.next())
   }
 
+  /** Creates an iterator formed from this iterator and another iterable
+   *  collection by combining corresponding elements in pairs. If one of the
+   *  two is shorter than the other, placeholder elements are used to extend
+   *  the shorter one to the length of the longer.
+   *
+   *  @tparam A1 the type of the first half of each result pair, a supertype of `A`
+   *  @tparam B the element type of `that`
+   *  @param that the collection providing the second half of each result pair
+   *  @param thisElem the element used to pad the pairs if this iterator is
+   *                  shorter than `that`
+   *  @param thatElem the element used to pad the pairs if `that` is shorter
+   *                  than this iterator
+   *  @return a new iterator containing pairs consisting of corresponding
+   *          values of this iterator and `that`. The number of elements
+   *          produced by the new iterator is the maximum of the number of
+   *          elements produced by this iterator and `that`.
+   *  @note   Reuse: $consumesTwoAndProducesOneIterator
+   */
   def zipAll[A1 >: A, B](that: IterableOnce[B]^, thisElem: A1, thatElem: B): Iterator[(A1, B)]^{this, that} = new AbstractIterator[(A1, B)] {
     val thatIterator = that.iterator
     override def knownSize = {
@@ -861,6 +1078,13 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     }
   }
 
+  /** Creates an iterator that pairs each value produced by this iterator with
+   *  its index, counting from 0.
+   *
+   *  @return a new iterator containing pairs consisting of each value produced
+   *          by this iterator and its index.
+   *  @note   Reuse: $consumesAndProducesIterator
+   */
   def zipWithIndex: Iterator[(A, Int)]^{this} = new AbstractIterator[(A, Int)] {
     var idx = 0
     override def knownSize = self.knownSize
@@ -906,6 +1130,12 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     var ahead: (Iterator[A]^{this}) | Null = null
     class Partner extends AbstractIterator[A] {
       this: Partner^{Iterator.this} =>
+      /** Returns the number of remaining elements if it can be computed, `-1` otherwise.
+       *
+       *  For the partner that is ahead this is the original iterator's
+       *  `knownSize`; for the one that is behind, the buffered elements are
+       *  added to that.
+       */
       override def knownSize: Int = self.synchronized {
         val thisSize = self.knownSize
 
@@ -913,9 +1143,16 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
         else if (thisSize < 0 || gap.knownSize < 0) -1
         else thisSize + gap.knownSize
       }
+      /** Tests whether an element remains, either buffered in the shared queue
+       *  (when this partner is behind the other) or in the original iterator.
+       */
       def hasNext: Boolean = self.synchronized {
         (this ne ahead) && !gap.isEmpty || self.hasNext
       }
+      /** Returns the next element, reading it from the original iterator and
+       *  buffering it for the other partner if this partner is ahead, or
+       *  dequeuing an already buffered element otherwise.
+       */
       def next(): A = self.synchronized {
         if (gap.isEmpty) ahead = this
         if (this eq ahead) {
@@ -927,7 +1164,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       // to verify partnerhood we use reference equality on gap because
       // type testing does not discriminate based on origin.
       private def compareGap(queue: scala.collection.mutable.Queue[A]) = gap eq queue
+      /** Returns the hash code of the queue shared by the two partner iterators, so both partners hash alike. */
       override def hashCode() = gap.hashCode()
+      /** Compares this iterator with `other` for equality.
+       *
+       *  The result is `true` if `other` is a partner iterator created by the
+       *  same `duplicate` call and the shared buffer is empty, that is, the
+       *  two iterators are positioned at the same element. Any other value is
+       *  compared by reference.
+       *
+       *  @param other the value to compare with
+       */
       override def equals(other: Any) = (other: @unchecked) match {
         case x: Partner   => x.compareGap(gap) && gap.isEmpty
         case _            => super.equals(other)
@@ -994,6 +1241,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       }
     }
 
+  /** Applies a side-effecting function to each element as it is produced,
+   *  passing the element through unchanged.
+   *
+   *  The function is invoked lazily: `f` is applied to an element only when,
+   *  and each time, that element is produced by the returned iterator.
+   *
+   *  @tparam U the return type of `f`, which is discarded
+   *  @param f the side-effecting function applied to each element
+   *  @return  an iterator producing the same values as this iterator
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   override def tapEach[U](f: A => U): Iterator[A]^{this, f} = new AbstractIterator[A] {
     override def knownSize = self.knownSize
     override def hasNext = self.hasNext
@@ -1011,6 +1269,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    */
   override def toString() = "<iterator>"
 
+  /** Returns this iterator.
+   *
+   *  @note Reuse: $preservesIterator
+   */
   @deprecated("Iterator.seq always returns the iterator itself", "2.13.0")
   def seq: this.type = this
 }
@@ -1041,6 +1303,12 @@ object Iterator extends IterableFactory[Iterator] {
    */
   @`inline` final def empty[T]: Iterator[T] = _empty
 
+  /** Creates an iterator that produces the single element `a` and is then exhausted.
+   *
+   *  @tparam A the element type of the iterator
+   *  @param a the single element to produce
+   *  @return an iterator that produces `a` once
+   */
   def single[A](a: A): Iterator[A] = new AbstractIterator[A] {
     private var consumed: Boolean = false
     def hasNext = !consumed
@@ -1050,6 +1318,12 @@ object Iterator extends IterableFactory[Iterator] {
       else this
   }
 
+  /** Creates an iterator that produces the given elements, in order.
+   *
+   *  @tparam A the element type of the iterator
+   *  @param xs the elements to produce
+   *  @return an iterator over the elements `xs`
+   */
   override def apply[A](xs: A*): Iterator[A] = xs.iterator
 
   /**

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -79,64 +79,279 @@ import scala.language.implicitConversions
  */
 @deprecated("Use `scala.jdk.CollectionConverters` instead", "2.13.0")
 object JavaConverters extends AsJavaConverters with AsScalaConverters {
+  /** Converts a Scala `Iterator` to a Java `Iterator`.
+   *
+   *  The conversion returns a wrapper, not a copy: advancing the result consumes the underlying
+   *  Scala iterator, and vice versa. An iterator that was itself obtained through `asScala` is
+   *  unwrapped, returning the original Java `Iterator`.
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Scala `Iterator` to convert
+   *  @return a Java `Iterator` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def asJavaIterator[A](i: Iterator[A]): ju.Iterator[A] = asJava(i)
 
+  /** Converts a Scala `Iterable` to a Java `Iterable`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Scala
+   *  collection, so changes to that collection are visible through the Java view. An iterable
+   *  that was itself obtained through `asScala` is unwrapped, returning the original Java
+   *  `Iterable`.
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Scala `Iterable` to convert
+   *  @return a Java `Iterable` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = asJava(i)
 
+  /** Converts a Scala mutable `Buffer` to a Java `List`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A buffer that was itself obtained through `asScala` is
+   *  unwrapped, returning the original Java `List`.
+   *
+   *  @tparam A the element type of the buffer
+   *  @param b the Scala mutable `Buffer` to convert
+   *  @return a Java `List` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = asJava(b)
 
+  /** Converts a Scala mutable `Seq` to a Java `List`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A sequence that was itself obtained through `asScala` is
+   *  unwrapped, returning the original Java `List`.
+   *
+   *  @tparam A the element type of the sequence
+   *  @param s the Scala mutable `Seq` to convert
+   *  @return a Java `List` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def mutableSeqAsJavaList[A](s: mutable.Seq[A]): ju.List[A] = asJava(s)
 
+  /** Converts a Scala `Seq` to a Java `List`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Scala
+   *  sequence, so changes to that sequence are visible through the Java view. A sequence that
+   *  was itself obtained through `asScala` is unwrapped, returning the original Java `List`.
+   *
+   *  @tparam A the element type of the sequence
+   *  @param s the Scala `Seq` to convert
+   *  @return a Java `List` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def seqAsJavaList[A](s: Seq[A]): ju.List[A] = asJava(s)
 
+  /** Converts a Scala mutable `Set` to a Java `Set`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A set that was itself obtained through `asScala` is unwrapped,
+   *  returning the original Java `Set`.
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala mutable `Set` to convert
+   *  @return a Java `Set` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = asJava(s)
 
+  /** Converts a Scala `Set` to a Java `Set`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Scala
+   *  set, so changes to that set are visible through the Java view. A set that was itself
+   *  obtained through `asScala` is unwrapped, returning the original Java `Set`.
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala `Set` to convert
+   *  @return a Java `Set` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def setAsJavaSet[A](s: Set[A]): ju.Set[A] = asJava(s)
 
+  /** Converts a Scala mutable `Map` to a Java `Map`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A map that was itself obtained through `asScala` is unwrapped,
+   *  returning the original Java `Map`.
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to convert
+   *  @return a Java `Map` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def mutableMapAsJavaMap[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = asJava(m)
 
+  /** Converts a Scala `Map` to a Java `Map`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Scala
+   *  map, so changes to that map are visible through the Java view. A map that was itself
+   *  obtained through `asScala` is unwrapped, returning the original Java `Map`.
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `Map` to convert
+   *  @return a Java `Map` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def mapAsJavaMap[K, V](m: Map[K, V]): ju.Map[K, V] = asJava(m)
 
+  /** Converts a Scala `concurrent.Map` to a Java `ConcurrentMap`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A map that was itself obtained through `asScala` is unwrapped,
+   *  returning the original Java `ConcurrentMap`.
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `concurrent.Map` to convert
+   *  @return a Java `ConcurrentMap` view of the argument
+   */
   @deprecated("Use `asJava` instead", "2.13.0")
   def mapAsJavaConcurrentMap[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = asJava(m)
 
 
+  /** Converts a Java `Iterator` to a Scala `Iterator`.
+   *
+   *  The conversion returns a wrapper, not a copy: advancing the result consumes the underlying
+   *  Java iterator, and vice versa. An iterator that was itself obtained through `asJava` is
+   *  unwrapped, returning the original Scala `Iterator`.
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Java `Iterator` to convert
+   *  @return a Scala `Iterator` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def asScalaIterator[A](i: ju.Iterator[A]): Iterator[A] = asScala(i)
 
+  /** Converts a Java `Enumeration` to a Scala `Iterator`.
+   *
+   *  The conversion returns a wrapper, not a copy: advancing the result consumes the underlying
+   *  Java enumeration, and vice versa. An enumeration that was itself obtained through
+   *  `asJavaEnumeration` is unwrapped, returning the original Scala `Iterator`.
+   *
+   *  @tparam A the element type of the enumeration
+   *  @param i the Java `Enumeration` to convert
+   *  @return a Scala `Iterator` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = asScala(i)
 
+  /** Converts a Java `Iterable` to a Scala `Iterable`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Java
+   *  iterable, so changes to it are visible through the Scala view. An iterable that was itself
+   *  obtained through `asJava` is unwrapped, returning the original Scala `Iterable`.
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Java `Iterable` to convert
+   *  @return a Scala `Iterable` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = asScala(i)
 
+  /** Converts a Java `Collection` to a Scala `Iterable`.
+   *
+   *  The conversion returns a wrapper, not a copy: the result is backed by the original Java
+   *  collection, so changes to it are visible through the Scala view. A collection that was
+   *  itself obtained through `asJavaCollection` is unwrapped, returning the original Scala
+   *  `Iterable`.
+   *
+   *  @tparam A the element type of the collection
+   *  @param i the Java `Collection` to convert
+   *  @return a Scala `Iterable` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = asScala(i)
 
+  /** Converts a Java `List` to a Scala mutable `Buffer`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A list that was itself obtained by calling `asJava` on a Scala
+   *  `Buffer` is unwrapped, returning that original `Buffer`.
+   *
+   *  @tparam A the element type of the list
+   *  @param l the Java `List` to convert
+   *  @return a Scala mutable `Buffer` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = asScala(l)
 
+  /** Converts a Java `Set` to a Scala mutable `Set`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A set that was itself obtained by calling `asJava` on a Scala
+   *  mutable `Set` is unwrapped, returning that original `Set`.
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Java `Set` to convert
+   *  @return a Scala mutable `Set` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = asScala(s)
 
+  /** Converts a Java `Map` to a Scala mutable `Map`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A map that was itself obtained by calling `asJava` on a Scala
+   *  mutable `Map` is unwrapped, returning that original `Map`.
+   *
+   *  The wrapper adds no locking of its own. If `m` is a synchronized map, only the
+   *  operations that the underlying map performs atomically remain atomic through the
+   *  wrapper; the caller must synchronize the others.
+   *
+   *  @tparam A the type of the map keys
+   *  @tparam B the type of the map values
+   *  @param m the Java `Map` to convert
+   *  @return a Scala mutable `Map` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = asScala(m)
 
+  /** Converts a Java `ConcurrentMap` to a Scala `concurrent.Map`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A map that was itself obtained through `asJava` is unwrapped,
+   *  returning the original Scala `concurrent.Map`.
+   *
+   *  @tparam A the type of the map keys
+   *  @tparam B the type of the map values
+   *  @param m the Java `ConcurrentMap` to convert
+   *  @return a Scala `concurrent.Map` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = asScala(m)
 
+  /** Converts a Java `Dictionary` to a Scala mutable `Map`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. A dictionary that was itself obtained through
+   *  `asJavaDictionary` is unwrapped, returning the original Scala `Map`.
+   *
+   *  @tparam A the type of the dictionary keys
+   *  @tparam B the type of the dictionary values
+   *  @param p the Java `Dictionary` to convert
+   *  @return a Scala mutable `Map` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = asScala(p)
 
+  /** Converts a Java `Properties` to a Scala mutable `Map[String, String]`.
+   *
+   *  The conversion returns a wrapper, not a copy: changes made through either interface are
+   *  visible through the other. This conversion is one-way; there is no corresponding `asJava`
+   *  conversion to `Properties`, and the result is always a new wrapper.
+   *
+   *  `Properties` extends `Hashtable[Object, Object]` and can hold entries whose key or
+   *  value is not a `String`. The wrapper casts rather than checks, so reading such an
+   *  entry through the returned map throws a `ClassCastException`.
+   *
+   *  @param p the Java `Properties` to convert
+   *  @return a Scala mutable `Map[String, String]` view of the argument
+   */
   @deprecated("Use `asScala` instead", "2.13.0")
   def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = asScala(p)
 

--- a/library/src/scala/collection/LazyZipOps.scala
+++ b/library/src/scala/collection/LazyZipOps.scala
@@ -39,6 +39,23 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
    */
   def lazyZip[B](that: Iterable[B]^): LazyZip3[El1, El2, B, C1]^{this, that} = new LazyZip3(src, coll1, coll2, that)
 
+  /** Builds a collection of the results of applying `f` to corresponding
+   *  elements of the two zipped collections.
+   *
+   *  Traversal is truncated at the end of the shorter collection: excess
+   *  elements of the longer one are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of pairs;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the type of the values returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each pair of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the values of `f` for each pair of corresponding elements
+   */
   def map[B, C](f: (El1, El2) => B)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -52,6 +69,24 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
     })
   }
 
+  /** Builds a collection by applying `f` to corresponding elements of the two
+   *  zipped collections and concatenating the results.
+   *
+   *  Traversal is truncated at the end of the shorter collection: excess
+   *  elements of the longer one are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of pairs;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the element type of the collections returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each pair of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return the concatenation of the collections returned by `f` for each
+   *          pair of corresponding elements
+   */
   def flatMap[B, C](f: (El1, El2) => Iterable[B]^)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -71,6 +106,21 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
     })
   }
 
+  /** Builds a collection of the pairs of corresponding elements of the two
+   *  zipped collections for which `p` holds.
+   *
+   *  Traversal is truncated at the end of the shorter collection: excess
+   *  elements of the longer one are not tested. The elements are zipped
+   *  lazily; whether the result is computed eagerly or on demand is
+   *  determined by `bf` (eagerly for strict collection types such as `List`,
+   *  on demand for lazy ones such as views or `LazyList`).
+   *
+   *  @tparam C the type of the resulting collection
+   *  @param p the predicate applied to each pair of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the pairs of corresponding elements that satisfy `p`
+   */
   def filter[C](p: (El1, El2) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2), C]): C^{this, p} = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2)] {
       def iterator: AbstractIterator[(El1, El2)]^{this, p} = new AbstractIterator[(El1, El2)] {
@@ -99,6 +149,15 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
     })
   }
 
+  /** Returns `true` if `p` holds for at least one pair of corresponding
+   *  elements of the two zipped collections.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the first pair
+   *  satisfying `p`, or at the end of the shorter collection; excess elements
+   *  of the longer one are never tested.
+   *
+   *  @param p the predicate applied to each pair of corresponding elements
+   */
   def exists(p: (El1, El2) => Boolean): Boolean = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -109,8 +168,26 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
     res
   }
 
+  /** Returns `true` if `p` holds for every pair of corresponding elements of
+   *  the two zipped collections.
+   *
+   *  This operation is evaluated eagerly. Only as many pairs as the shorter
+   *  collection provides are tested, so the result is `true` when either
+   *  collection is empty. Iteration stops at the first pair failing `p`.
+   *
+   *  @param p the predicate applied to each pair of corresponding elements
+   */
   def forall(p: (El1, El2) => Boolean): Boolean = !exists((el1, el2) => !p(el1, el2))
 
+  /** Applies `f` to each pair of corresponding elements of the two zipped
+   *  collections, for its side effects.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the end of the
+   *  shorter collection, and the results of `f` are discarded.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each pair of corresponding elements
+   */
   def foreach[U](f: (El1, El2) => U): Unit = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -137,10 +214,25 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
     }
   }
 
+  /** Returns a string of the form `coll1.lazyZip(coll2)`, where `coll1` and
+   *  `coll2` are the string representations of the two zipped collections.
+   */
   override def toString() = s"$coll1.lazyZip($coll2)"
 }
 
 object LazyZip2 {
+  /** Converts a [[LazyZip2]] to a view of pairs of corresponding elements.
+   *
+   *  The elements are zipped lazily: each pair is formed only as the view is
+   *  traversed, and traversal is truncated at the end of the shorter
+   *  collection.
+   *
+   *  @tparam El1 the element type of the first collection
+   *  @tparam El2 the element type of the second collection
+   *  @param zipped2 the lazily zipped pair of collections to convert
+   *  @return a view producing the pairs of corresponding elements of the two
+   *          zipped collections
+   */
   implicit def lazyZip2ToIterable[El1, El2](zipped2: LazyZip2[El1, El2, ?]^): View[(El1, El2)]^{zipped2} = zipped2.toIterable
 }
 
@@ -172,6 +264,23 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
    */
   def lazyZip[B](that: Iterable[B]^): LazyZip4[El1, El2, El3, B, C1]^{this, that} = new LazyZip4(src, coll1, coll2, coll3, that)
 
+  /** Builds a collection of the results of applying `f` to corresponding
+   *  elements of the three zipped collections.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of triples;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the type of the values returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each triple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the values of `f` for each triple of corresponding elements
+   */
   def map[B, C](f: (El1, El2, El3) => B)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -186,6 +295,24 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
     })
   }
 
+  /** Builds a collection by applying `f` to corresponding elements of the
+   *  three zipped collections and concatenating the results.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of triples;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the element type of the collections returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each triple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return the concatenation of the collections returned by `f` for each
+   *          triple of corresponding elements
+   */
   def flatMap[B, C](f: (El1, El2, El3) => Iterable[B]^)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -206,6 +333,21 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
     })
   }
 
+  /** Builds a collection of the triples of corresponding elements of the
+   *  three zipped collections for which `p` holds.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not tested. The elements are zipped
+   *  lazily; whether the result is computed eagerly or on demand is
+   *  determined by `bf` (eagerly for strict collection types such as `List`,
+   *  on demand for lazy ones such as views or `LazyList`).
+   *
+   *  @tparam C the type of the resulting collection
+   *  @param p the predicate applied to each triple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the triples of corresponding elements that satisfy `p`
+   */
   def filter[C](p: (El1, El2, El3) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2, El3), C]): C^{this, p} = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2, El3)] {
       def iterator: AbstractIterator[(El1, El2, El3)]^{this, p} = new AbstractIterator[(El1, El2, El3)] {
@@ -236,6 +378,15 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
     })
   }
 
+  /** Returns `true` if `p` holds for at least one triple of corresponding
+   *  elements of the three zipped collections.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the first triple
+   *  satisfying `p`, or at the end of the shortest collection; excess
+   *  elements of the longer ones are never tested.
+   *
+   *  @param p the predicate applied to each triple of corresponding elements
+   */
   def exists(p: (El1, El2, El3) => Boolean): Boolean = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -248,8 +399,27 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
     res
   }
 
+  /** Returns `true` if `p` holds for every triple of corresponding elements
+   *  of the three zipped collections.
+   *
+   *  This operation is evaluated eagerly. Only as many triples as the
+   *  shortest collection provides are tested, so the result is `true` when
+   *  any of the collections is empty. Iteration stops at the first triple
+   *  failing `p`.
+   *
+   *  @param p the predicate applied to each triple of corresponding elements
+   */
   def forall(p: (El1, El2, El3) => Boolean): Boolean = !exists((el1, el2, el3) => !p(el1, el2, el3))
 
+  /** Applies `f` to each triple of corresponding elements of the three zipped
+   *  collections, for its side effects.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the end of the
+   *  shortest collection, and the results of `f` are discarded.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each triple of corresponding elements
+   */
   def foreach[U](f: (El1, El2, El3) => U): Unit = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -282,10 +452,27 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
     }
   }
 
+  /** Returns a string of the form `coll1.lazyZip(coll2).lazyZip(coll3)`, where
+   *  `coll1`, `coll2` and `coll3` are the string representations of the three
+   *  zipped collections.
+   */
   override def toString() = s"$coll1.lazyZip($coll2).lazyZip($coll3)"
 }
 
 object LazyZip3 {
+  /** Converts a [[LazyZip3]] to a view of triples of corresponding elements.
+   *
+   *  The elements are zipped lazily: each triple is formed only as the view
+   *  is traversed, and traversal is truncated at the end of the shortest
+   *  collection.
+   *
+   *  @tparam El1 the element type of the first collection
+   *  @tparam El2 the element type of the second collection
+   *  @tparam El3 the element type of the third collection
+   *  @param zipped3 the lazily zipped triple of collections to convert
+   *  @return a view producing the triples of corresponding elements of the
+   *          three zipped collections
+   */
   implicit def lazyZip3ToIterable[El1, El2, El3](zipped3: LazyZip3[El1, El2, El3, ?]^): View[(El1, El2, El3)]^{zipped3} = zipped3.toIterable
 }
 
@@ -310,6 +497,23 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
                                                                      coll3: Iterable[El3]^,
                                                                      coll4: Iterable[El4]^) {
 
+  /** Builds a collection of the results of applying `f` to corresponding
+   *  elements of the four zipped collections.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of 4-tuples;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the type of the values returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each 4-tuple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the values of `f` for each 4-tuple of corresponding elements
+   */
   def map[B, C](f: (El1, El2, El3, El4) => B)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -325,6 +529,24 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
     })
   }
 
+  /** Builds a collection by applying `f` to corresponding elements of the
+   *  four zipped collections and concatenating the results.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not passed to `f`. The elements are
+   *  zipped lazily, without creating an intermediate collection of 4-tuples;
+   *  whether the result is computed eagerly or on demand is determined by
+   *  `bf` (eagerly for strict collection types such as `List`, on demand for
+   *  lazy ones such as views or `LazyList`).
+   *
+   *  @tparam B the element type of the collections returned by `f`
+   *  @tparam C the type of the resulting collection
+   *  @param f the function applied to each 4-tuple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return the concatenation of the collections returned by `f` for each
+   *          4-tuple of corresponding elements
+   */
   def flatMap[B, C](f: (El1, El2, El3, El4) => Iterable[B]^)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
     bf.fromSpecific(src)(new AbstractView[B] {
       def iterator: AbstractIterator[B]^{this, f} = new AbstractIterator[B] {
@@ -346,6 +568,21 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
     })
   }
 
+  /** Builds a collection of the 4-tuples of corresponding elements of the
+   *  four zipped collections for which `p` holds.
+   *
+   *  Traversal is truncated at the end of the shortest collection: excess
+   *  elements of the longer ones are not tested. The elements are zipped
+   *  lazily; whether the result is computed eagerly or on demand is
+   *  determined by `bf` (eagerly for strict collection types such as `List`,
+   *  on demand for lazy ones such as views or `LazyList`).
+   *
+   *  @tparam C the type of the resulting collection
+   *  @param p the predicate applied to each 4-tuple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from
+   *            the source collection
+   *  @return a collection of the 4-tuples of corresponding elements that satisfy `p`
+   */
   def filter[C](p: (El1, El2, El3, El4) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2, El3, El4), C]): C^{this, p} = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2, El3, El4)] {
       def iterator: AbstractIterator[(El1, El2, El3, El4)]^{this, p} = new AbstractIterator[(El1, El2, El3, El4)] {
@@ -378,6 +615,15 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
     })
   }
 
+  /** Returns `true` if `p` holds for at least one 4-tuple of corresponding
+   *  elements of the four zipped collections.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the first
+   *  4-tuple satisfying `p`, or at the end of the shortest collection; excess
+   *  elements of the longer ones are never tested.
+   *
+   *  @param p the predicate applied to each 4-tuple of corresponding elements
+   */
   def exists(p: (El1, El2, El3, El4) => Boolean): Boolean = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -391,8 +637,27 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
     res
   }
 
+  /** Returns `true` if `p` holds for every 4-tuple of corresponding elements
+   *  of the four zipped collections.
+   *
+   *  This operation is evaluated eagerly. Only as many 4-tuples as the
+   *  shortest collection provides are tested, so the result is `true` when
+   *  any of the collections is empty. Iteration stops at the first 4-tuple
+   *  failing `p`.
+   *
+   *  @param p the predicate applied to each 4-tuple of corresponding elements
+   */
   def forall(p: (El1, El2, El3, El4) => Boolean): Boolean = !exists((el1, el2, el3, el4) => !p(el1, el2, el3, el4))
 
+  /** Applies `f` to each 4-tuple of corresponding elements of the four zipped
+   *  collections, for its side effects.
+   *
+   *  This operation is evaluated eagerly. Iteration stops at the end of the
+   *  shortest collection, and the results of `f` are discarded.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each 4-tuple of corresponding elements
+   */
   def foreach[U](f: (El1, El2, El3, El4) => U): Unit = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -430,10 +695,28 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
     }
   }
 
+  /** Returns a string of the form `coll1.lazyZip(coll2).lazyZip(coll3).lazyZip(coll4)`,
+   *  where `coll1`, `coll2`, `coll3` and `coll4` are the string
+   *  representations of the four zipped collections.
+   */
   override def toString() = s"$coll1.lazyZip($coll2).lazyZip($coll3).lazyZip($coll4)"
 }
 
 object LazyZip4 {
+  /** Converts a [[LazyZip4]] to a view of 4-tuples of corresponding elements.
+   *
+   *  The elements are zipped lazily: each 4-tuple is formed only as the view
+   *  is traversed, and traversal is truncated at the end of the shortest
+   *  collection.
+   *
+   *  @tparam El1 the element type of the first collection
+   *  @tparam El2 the element type of the second collection
+   *  @tparam El3 the element type of the third collection
+   *  @tparam El4 the element type of the fourth collection
+   *  @param zipped4 the lazily zipped 4-tuple of collections to convert
+   *  @return a view producing the 4-tuples of corresponding elements of the
+   *          four zipped collections
+   */
   implicit def lazyZip4ToIterable[El1, El2, El3, El4](zipped4: LazyZip4[El1, El2, El3, El4, ?]^): View[(El1, El2, El3, El4)]^{zipped4} =
     zipped4.toIterable
 }

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -27,9 +27,11 @@ import scala.annotation.{nowarn, tailrec}
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
   with IterableFactoryDefaults[A, LinearSeq] {
+  /** The prefix used in the string representation of this sequence, `"LinearSeq"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "LinearSeq"
 
+  /** The factory used to build linear sequences, the [[LinearSeq$ `LinearSeq`]] companion object. */
   override def iterableFactory: SeqFactory[LinearSeq] = LinearSeq
 }
 
@@ -63,13 +65,28 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
    */
   def tail: C
 
+  /** Returns the first element of this sequence wrapped in `Some`, or `None`
+   *  if this sequence is empty.
+   */
   override def headOption: Option[A] =
     if (isEmpty) None else Some(head)
 
+  /** Returns an iterator over the elements of this sequence.
+   *
+   *  The iterator steps through the sequence with `head` and `tail`, and does
+   *  not evaluate a tail before the corresponding element is requested, so it
+   *  is lazy enough for sequences such as [[scala.collection.immutable.LazyList]].
+   */
   def iterator: Iterator[A] =
     if (knownSize == 0) Iterator.empty
     else new LinearSeqIterator[A](this)
 
+  /** Returns the number of elements in this sequence.
+   *
+   *  Computed by traversing the sequence with `tail`, so it takes time
+   *  proportional to the number of elements and does not terminate for
+   *  infinite sequences.
+   */
   def length: Int = {
     var these = coll
     var len = 0
@@ -80,6 +97,13 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     len
   }
 
+  /** Returns the last element of this sequence.
+   *
+   *  Found by traversing the whole sequence, so it takes time proportional to
+   *  the number of elements.
+   *
+   *  @throws NoSuchElementException if this sequence is empty
+   */
   override def last: A = {
     if (isEmpty) throw new NoSuchElementException("LinearSeq.last")
     else {
@@ -93,6 +117,16 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     }
   }
 
+  /** Compares the length of this sequence to a test value.
+   *
+   *  Traverses at most `len + 1` elements instead of computing the full
+   *  length, so the running time is `O(length min len)`.
+   *
+   *  @param len the test value that gets compared with the length
+   *  @return a negative value if `this.length < len`, zero if
+   *          `this.length == len`, and a positive value if `this.length > len`
+   *          (in particular, a positive value if `len` is negative)
+   */
   override def lengthCompare(len: Int): Int = {
     @tailrec def loop(i: Int, xs: LinearSeq[A]): Int = {
       if (i == len)
@@ -106,6 +140,17 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     else loop(0, coll)
   }
 
+  /** Compares the length of this sequence to the size of another `Iterable`.
+   *
+   *  If the size of `that` is known, delegates to `lengthCompare(Int)`;
+   *  otherwise both collections are traversed in step and the traversal stops
+   *  as soon as either is exhausted, so the running time is
+   *  `O(this.length min that.size)`.
+   *
+   *  @param that the `Iterable` whose size is compared with this sequence's length
+   *  @return a negative value if `this.length < that.size`, zero if they are
+   *          equal, and a positive value if `this.length > that.size`
+   */
   override def lengthCompare(that: Iterable[?]^): Int = {
     val thatKnownSize = that.knownSize
 
@@ -130,10 +175,29 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     }
   }
 
+  /** Tests whether this sequence contains the given index.
+   *
+   *  Traverses at most `x + 1` elements to make the test, so the full length
+   *  is not computed.
+   *
+   *  @param x the index to test
+   *  @return `true` if `x` is non-negative and less than the length of this
+   *          sequence, `false` otherwise
+   */
   override def isDefinedAt(x: Int): Boolean = x >= 0 && lengthCompare(x) > 0
 
   // `apply` is defined in terms of `drop`, which is in turn defined in
   //  terms of `tail`.
+  /** Returns the element at the specified index.
+   *
+   *  Found by traversing `n` tails from the start of this sequence, so it
+   *  takes time proportional to `n`.
+   *
+   *  @param n the index of the element to retrieve, zero-based
+   *  @return the element at index `n`
+   *  @throws IndexOutOfBoundsException if `n` is negative or greater than or
+   *          equal to the length of this sequence
+   */
   @throws[IndexOutOfBoundsException]
   override def apply(n: Int): A = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
@@ -142,6 +206,14 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     skipped.head
   }
 
+  /** Applies the function `f` to each element of this sequence in order.
+   *
+   *  Traverses with `head` and `tail` directly instead of creating an
+   *  iterator.
+   *
+   *  @tparam U the result type of `f`, ignored
+   *  @param f the function applied to each element for its side effects
+   */
   override def foreach[U](f: A => U): Unit = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
@@ -150,6 +222,15 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     }
   }
 
+  /** Tests whether the predicate `p` holds for all elements of this sequence.
+   *
+   *  Traverses with `head` and `tail` and stops at the first element for
+   *  which `p` is false.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if `p` holds for all elements, or this sequence is empty,
+   *          `false` otherwise
+   */
   override def forall(p: A => Boolean): Boolean = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
@@ -159,6 +240,16 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     true
   }
 
+  /** Tests whether the predicate `p` holds for at least one element of this
+   *  sequence.
+   *
+   *  Traverses with `head` and `tail` and stops at the first element for
+   *  which `p` is true.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if `p` holds for some element of this sequence, `false`
+   *          otherwise
+   */
   override def exists(p: A => Boolean): Boolean = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
@@ -168,6 +259,16 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     false
   }
 
+  /** Tests whether this sequence contains a given value as an element.
+   *
+   *  Traverses with `head` and `tail` and stops at the first element equal to
+   *  `elem`.
+   *
+   *  @tparam A1 the type of the element to test (a supertype of `A`)
+   *  @param elem the element to test
+   *  @return `true` if some element of this sequence is equal (as determined
+   *          by `==`) to `elem`, `false` otherwise
+   */
   override def contains[A1 >: A](elem: A1): Boolean = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
@@ -177,6 +278,15 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     false
   }
 
+  /** Finds the first element of this sequence satisfying a predicate, if any.
+   *
+   *  Traverses with `head` and `tail` and stops at the first element for
+   *  which `p` is true.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an option value containing the first element of this sequence
+   *          that satisfies `p`, or `None` if none exists
+   */
   override def find(p: A => Boolean): Option[A] = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
@@ -186,6 +296,19 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     None
   }
 
+  /** Applies the binary operator `op` between `z` and all elements of this
+   *  sequence, going left to right.
+   *
+   *  Traverses with `head` and `tail` directly instead of creating an
+   *  iterator.
+   *
+   *  @tparam B the result type of the binary operator
+   *  @param z the start value, combined with the first element
+   *  @param op the binary operator
+   *  @return the result of inserting `op` between consecutive elements of
+   *          this sequence, going left to right with the start value `z` on
+   *          the left, or `z` if this sequence is empty
+   */
   override def foldLeft[B](z: B)(op: (B, A) => B): B = {
     var acc = z
     var these: LinearSeq[A] = coll
@@ -196,6 +319,20 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     acc
   }
 
+  /** Checks whether corresponding elements of the given collection compare
+   *  equal (with respect to `==`) to elements of this sequence.
+   *
+   *  When `that` is also a linear sequence, the two are traversed in step
+   *  with `head` and `tail`, and a comparison step succeeds immediately when
+   *  both remainders are the same instance, so shared suffixes are not
+   *  traversed. Otherwise falls back to the default iterator-based
+   *  comparison.
+   *
+   *  @tparam B the type of the elements of `that`
+   *  @param that the collection to compare
+   *  @return `true` if both collections contain equal elements in the same
+   *          order, `false` otherwise
+   */
   override def sameElements[B >: A](that: IterableOnce[B]^): Boolean = {
     @tailrec def linearSeqEq(a: LinearSeq[B], b: LinearSeq[B]): Boolean =
       (a eq b) || {
@@ -213,6 +350,18 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     }
   }
 
+  /** Computes the length of the longest segment that starts from some index
+   *  and whose elements all satisfy some predicate.
+   *
+   *  Traverses with `head` and `tail` and stops at the first element from
+   *  index `from` onwards that does not satisfy `p`. May not terminate for
+   *  infinite sequences.
+   *
+   *  @param p the predicate used to test elements
+   *  @param from the index where the search starts
+   *  @return the length of the longest segment of this sequence starting from
+   *          index `from` such that every element of the segment satisfies `p`
+   */
   override def segmentLength(p: A => Boolean, from: Int): Int = {
     var i = 0
     var seq = drop(from)
@@ -223,6 +372,17 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     i
   }
 
+  /** Finds the index of the first element satisfying some predicate after or
+   *  at some start index.
+   *
+   *  Traverses with `head` and `tail` and stops at the first match. May not
+   *  terminate for infinite sequences.
+   *
+   *  @param p the predicate used to test elements
+   *  @param from the start index (treated as `0` if negative)
+   *  @return the index `>= from` of the first element of this sequence that
+   *          satisfies the predicate `p`, or `-1` if none exists
+   */
   override def indexWhere(p: A => Boolean, from: Int): Int = {
     var i = math.max(from, 0)
     var these: LinearSeq[A] = this drop from
@@ -236,6 +396,18 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     -1
   }
 
+  /** Finds the index of the last element satisfying some predicate before or
+   *  at the given end index.
+   *
+   *  Traverses forwards with `head` and `tail`, remembering the last match,
+   *  and stops after index `end`. Will not terminate for infinite sequences
+   *  if `end` is `Int.MaxValue`.
+   *
+   *  @param p the predicate used to test elements
+   *  @param end the maximum index to consider (inclusive)
+   *  @return the index `<= end` of the last element of this sequence that
+   *          satisfies the predicate `p`, or `-1` if none exists
+   */
   override def lastIndexWhere(p: A => Boolean, end: Int): Int = {
     var i = 0
     var these: LinearSeq[A] = coll
@@ -248,6 +420,15 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     last
   }
 
+  /** Finds the last element of this sequence satisfying a predicate, if any.
+   *
+   *  Traverses the whole sequence with `head` and `tail`, remembering the
+   *  last match; does not terminate for infinite sequences.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an option value containing the last element of this sequence
+   *          that satisfies `p`, or `None` if none exists
+   */
   override def findLast(p: A => Boolean): Option[A] = {
     var these: LinearSeq[A] = coll
     var found = false
@@ -263,6 +444,12 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
     if (found) Some(last) else None
   }
 
+  /** Iterates over the tails of this sequence. The first value is this
+   *  sequence and the final one is an empty sequence, with the intervening
+   *  values the results of successive applications of `tail`.
+   *
+   *  Each tail is obtained directly with `tail`, so no elements are copied.
+   */
   override def tails: Iterator[C] = {
     val end = Iterator.single(empty)
     Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ end
@@ -271,6 +458,12 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
 
 transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] { self =>
   // A more efficient iterator implementation than the default LinearSeqIterator
+  /** Returns an iterator over the elements of this sequence.
+   *
+   *  Steps through the sequence with `head` and `tail` directly. Because this
+   *  trait is for strictly evaluated sequences, no lazy indirection is needed,
+   *  making this more efficient than the default [[LinearSeqOps]] iterator.
+   */
   override def iterator: Iterator[A] = new AbstractIterator[A] {
     private var current = StrictOptimizedLinearSeqOps.this
     def hasNext = !current.isEmpty
@@ -278,6 +471,17 @@ transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: 
   }
 
   // Optimized version of `drop` that avoids copying
+  /** Returns the sequence that remains after the first `n` elements are
+   *  dropped.
+   *
+   *  Applies `tail` up to `n` times instead of copying, so the result shares
+   *  structure with this sequence.
+   *
+   *  @param n the number of elements to drop
+   *  @return the `n`th tail of this sequence, this sequence itself if `n` is
+   *          non-positive, or the empty sequence if `n` is greater than or
+   *          equal to the length
+   */
   override def drop(n: Int): C = {
     @tailrec def loop(n: Int, s: C): C =
       if (n <= 0 || s.isEmpty) s
@@ -285,6 +489,15 @@ transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: 
     loop(n, coll)
   }
 
+  /** Drops the longest prefix of elements that satisfy a predicate.
+   *
+   *  Applies `tail` repeatedly instead of copying, so the result shares
+   *  structure with this sequence.
+   *
+   *  @param p the predicate used to test elements
+   *  @return the longest suffix of this sequence whose first element does not
+   *          satisfy `p`, or the empty sequence if all elements satisfy `p`
+   */
   override def dropWhile(p: A => Boolean): C = {
     @tailrec def loop(s: C): C =
       if (s.nonEmpty && p(s.head)) loop(s.tail)

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -33,8 +33,17 @@ trait Map[K, +V]
     with Equals
     with caps.Pure {
 
+  /** Returns the `Map` companion object as the factory for maps of this kind. */
   def mapFactory: scala.collection.MapFactory[Map] = Map
 
+  /** Tests whether this map can equal the given object.
+   *
+   *  Always `true` here; [[equals]] consults this method so that subclasses can restrict
+   *  equality to specific map types.
+   *
+   *  @param that the value being probed for possible equality; not examined by this implementation
+   *  @return `true`
+   */
   def canEqual(that: Any): Boolean = true
 
   /** Equality of maps is implemented using the lookup method [[get]]. This method returns `true` if
@@ -73,17 +82,39 @@ trait Map[K, +V]
         false
     })
 
+  /** Returns a hash code value consistent with [[equals]]: computed with
+   *  [[scala.util.hashing.MurmurHash3.mapHash]], it does not depend on the order in which
+   *  this map enumerates its bindings.
+   */
   override def hashCode(): Int = MurmurHash3.mapHash(this)
 
   // These two methods are not in MapOps so that MapView is not forced to implement them
+  /** Returns a new map containing all bindings of this map except the one with the given key.
+   *
+   *  @param key the key to remove
+   */
   @deprecated("Use - or removed on an immutable Map", "2.13.0")
   def - (key: K): Map[K, V]
+  /** Returns a new map containing all bindings of this map except those with the given keys.
+   *
+   *  @param key1 the first key to remove
+   *  @param key2 the second key to remove
+   *  @param keys the remaining keys to remove
+   */
   @deprecated("Use -- or removedAll on an immutable Map", "2.13.0")
   def - (key1: K, key2: K, keys: K*): Map[K, V]
 
+  /** Returns `"Map"`, the prefix used by `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "Map"
 
+  /** Returns a string representation of this map, of the form `Map(k1 -> v1, k2 -> v2, ...)`,
+   *  with the prefix taken from `stringPrefix`, so a `SeqMap` or `SortedMap` names itself
+   *  instead.
+   *
+   *  Reinstates `Iterable`'s `toString`, which the `toString` inherited through `Function1`
+   *  would otherwise replace.
+   */
   override def toString(): String = super[Iterable].toString() // Because `Function1` overrides `toString` too
 }
 
@@ -104,6 +135,9 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V] { self: MapOps[K, V, CC, C]^ =>
 
+  /** Returns a [[MapView]] over the key-value pairs of this map; operations on the view are
+   *  evaluated lazily, on access.
+   */
   override def view: MapView[K, V]^{this} = new MapView.Id(this)
 
   /** Returns a [[Stepper]] for the keys of this map. See method [[stepper]].
@@ -225,6 +259,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   /** The implementation class of the set returned by `keySet`. */
   @deprecated("KeySet is no longer used in the .keySet implementation", since = "3.8.0")
   protected class KeySet extends AbstractSet[K] with GenKeySet with DefaultSerializable {
+    /** Returns a new set containing the keys of this set that are not also contained in `that`.
+     *
+     *  @param that the set of keys to exclude
+     */
     def diff(that: Set[K]): Set[K] = fromSpecific(this.view.filterNot(that))
   }
 
@@ -236,10 +274,19 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   protected trait GenKeySet @retains[MapOps.this.type]() {
     this: Set[K] =>
     import caps.unsafe.{unsafeDiscardUses, unsafeAssumePure}
+    /** Returns an iterator over the keys of the underlying map. */
     def iterator: Iterator[K] = unsafeDiscardUses(MapOps.this).keysIterator.unsafeAssumePure
+    /** Tests whether the underlying map contains a binding for the given key.
+     *
+     *  @param key the key to look up
+     *  @return `true` if the underlying map has a binding for `key`, `false` otherwise
+     */
     def contains(key: K): Boolean = unsafeDiscardUses(MapOps.this).contains(key)
+    /** Returns the number of keys, which equals the size of the underlying map. */
     override def size: Int = unsafeDiscardUses(MapOps.this).size
+    /** Returns the size of the underlying map if it can be computed cheaply, -1 otherwise. */
     override def knownSize: Int = unsafeDiscardUses(MapOps.this).knownSize
+    /** Tests whether the underlying map is empty. */
     override def isEmpty: Boolean = unsafeDiscardUses(MapOps.this).isEmpty
   }
 
@@ -406,13 +453,37 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.IterableOnce[(K, V2)]^): CC[K, V2]^{this, xs} = concat(xs)
 
+  /** Appends all bindings of this $coll to a string builder using start, separator, and end
+   *  strings, rendering each binding as `key -> value`.
+   *
+   *  @param sb the string builder to which bindings are appended
+   *  @param start the starting string
+   *  @param sep the separator string
+   *  @param end the ending string
+   *  @return the string builder `sb` to which the bindings were appended
+   */
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
     iterator.map { case (k, v) => s"$k -> $v" }.addString(sb, start, sep, end)
 
+  /** Returns a new $coll containing all bindings of this $coll together with the binding `kv`;
+   *  if this $coll already contains a binding for the key `kv._1`, the new binding replaces it.
+   *
+   *  @tparam V1 the value type of the returned $coll, a supertype of `V`
+   *  @param kv the key-value pair to add
+   */
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat.", "2.13.0")
   def + [V1 >: V](kv: (K, V1)): CC[K, V1]^{this} =
     mapFactory.from(new View.Appended(this, kv))
 
+  /** Returns a new $coll containing all bindings of this $coll together with the given
+   *  key-value pairs; a pair later in the argument list overrides any earlier binding
+   *  with the same key.
+   *
+   *  @tparam V1 the value type of the returned $coll, a supertype of `V`
+   *  @param elem1 the first key-value pair to add
+   *  @param elem2 the second key-value pair to add
+   *  @param elems the remaining key-value pairs to add
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1]^{this} =
     mapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
@@ -423,6 +494,13 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
     fromSpecific(this.view.filterKeys(k => !keysSet.contains(k)))
   }
 
+  /** Returns a new $coll containing the elements of `that` followed by the elements of this
+   *  $coll; if a key has a binding in both, the resulting $coll contains the binding of this
+   *  $coll, whose elements are added last.
+   *
+   *  @tparam V1 the value type of the returned $coll, a supertype of `V`
+   *  @param that the iterable of key-value pairs to prepend
+   */
   @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
   def ++: [V1 >: V](that: IterableOnce[(K,V1)]^): CC[K,V1]^{this, that} = {
     val thatIterable: Iterable[(K, V1)]^{that} = that match {
@@ -445,12 +523,35 @@ object MapOps {
     p: ((K, V)) => Boolean
   ) extends IterableOps.WithFilter[(K, V), IterableCC](self, p) with Serializable {
 
+    /** Builds a new $coll by applying a function to all elements of the filtered outer $coll.
+     *
+     *  @tparam K2 the key type of the returned $coll
+     *  @tparam V2 the value type of the returned $coll
+     *  @param f the function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and collecting the results
+     */
     def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2]^{this, f} =
       self.mapFactory.from(new View.Map(filtered, f))
 
+    /** Builds a new $coll by applying a collection-valued function to all elements of the
+     *  filtered outer $coll and concatenating the results.
+     *
+     *  @tparam K2 the key type of the returned $coll
+     *  @tparam V2 the value type of the returned $coll
+     *  @param f the collection-valued function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and concatenating the results
+     */
     def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^): CC[K2, V2]^{this, f} =
       self.mapFactory.from(new View.FlatMap(filtered, f))
 
+    /** Further refines the filter of this `WithFilter`.
+     *
+     *  @param q the predicate to combine with the existing filter
+     *  @return a new `WithFilter` whose operations apply to the elements of the outer $coll
+     *          that satisfy both the existing predicate and `q`
+     */
     override def withFilter(q: ((K, V)) => Boolean): WithFilter[K, V, IterableCC, CC]^{this, q} =
       new WithFilter[K, V, IterableCC, CC](self, (kv: (K, V)) => p(kv) && q(kv))
 

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -19,10 +19,22 @@ import scala.annotation.nowarn
 import scala.collection.MapView.SomeMapOps
 import scala.collection.mutable.Builder
 
+/** A non-strict view of the key-value pairs of a map.
+ *
+ *  Transformation operations such as `mapValues` and `filterKeys` wrap this
+ *  view without evaluating anything: their function or predicate is applied
+ *  each time an entry is looked up or iterated over. Lookups and iteration
+ *  read the underlying map anew on each access, so changes to it are visible
+ *  through the view.
+ *
+ *  @tparam K the type of keys
+ *  @tparam V the type of values
+ */
 trait MapView[K, +V]
   extends MapOps[K, V, ({ type l[X, Y] = View[(X, Y)] })#l, View[(K, V)]]
     with View[(K, V)] {
 
+  /** Returns this map view itself, since it is already a view. */
   override def view: MapView[K, V]^{this} = this
 
   // Ideally this returns a `View`, but bincompat
@@ -56,22 +68,68 @@ trait MapView[K, +V]
    */
   override def mapValues[W](f: V => W): MapView[K, W]^{this, f} = new MapView.MapValues(this, f)
 
+  /** Returns a map view of the entries of this map that satisfy the predicate
+   *  `pred`.
+   *
+   *  The predicate is evaluated lazily, each time the returned view is
+   *  traversed or a key is looked up in it.
+   *
+   *  @param pred the predicate used to test entries
+   */
   override def filter(pred: ((K, V)) => Boolean): MapView[K, V]^{this, pred} = new MapView.Filter(this, isFlipped = false, pred)
 
+  /** Returns a map view of the entries of this map that do not satisfy the
+   *  predicate `pred`.
+   *
+   *  The predicate is evaluated lazily, each time the returned view is
+   *  traversed or a key is looked up in it.
+   *
+   *  @param pred the predicate used to test entries
+   */
   override def filterNot(pred: ((K, V)) => Boolean): MapView[K, V]^{this, pred} = new MapView.Filter(this, isFlipped = true, pred)
 
+  /** Returns a pair of map views: the first of the entries of this map that
+   *  satisfy `p`, the second of those that do not.
+   *
+   *  Equivalent to `(filter(p), filterNot(p))`: both views are lazy, and `p`
+   *  is evaluated each time either of them is traversed or looked up in.
+   *
+   *  @param p the predicate on which to partition entries
+   */
   override def partition(p: ((K, V)) => Boolean): (MapView[K, V]^{this, p}, MapView[K, V]^{this, p}) = (filter(p), filterNot(p))
 
+  /** Returns a map view over the same entries that applies the side-effecting
+   *  function `f` to each entry as it is accessed.
+   *
+   *  `f` is invoked during iteration over the returned view and on each
+   *  successful lookup in it.
+   *
+   *  @tparam U the result type of `f`; the result is discarded
+   *  @param f the function to apply to each entry when it is accessed
+   */
   override def tapEach[U](f: ((K, V)) => U): MapView[K, V]^{this, f} = new MapView.TapEach(this, f)
 
+  /** Returns the factory used to build map views: the [[MapView]] object. */
   def mapFactory: MapViewFactory = MapView
 
+  /** Returns an empty map view with the same key and value types as this view. */
   override def empty: MapView[K, V] = mapFactory.empty
 
+  /** Creates a non-strict filter of this map view, for use in for-comprehensions.
+   *
+   *  `p` is not evaluated until one of the returned object's operations is
+   *  called, and then once per entry tested.
+   *
+   *  @param p the predicate used to test entries
+   *  @return an object whose `map`, `flatMap`, `foreach`, and `withFilter`
+   *          operations apply only to the entries of this view that satisfy `p`
+   */
   override def withFilter(p: ((K, V)) => Boolean): MapOps.WithFilter[K, V, View, ({ type l[X, Y] = View[(X, Y)] })#l]^{this, p} = new MapOps.WithFilter(this, p)
 
+  /** Returns the string `"MapView(<not computed>)"`; the elements of this view are not evaluated. */
   override def toString(): String = super[View].toString
 
+  /** The prefix of this view's string representation, `"MapView"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "MapView"
 }
@@ -96,11 +154,26 @@ object MapView extends MapViewFactory {
     override def partition(p: ((Any, Nothing)) => Boolean): (MapView[Any, Nothing], MapView[Any, Nothing]) = (this, this)
   }
 
+  /** A map view that does not transform the entries of the underlying map.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param underlying the map being viewed
+   */
   @SerialVersionUID(3L)
   class Id[K, +V](underlying: SomeMapOps[K, V]^) extends AbstractMapView[K, V] {
+    /** Returns the value associated with `key` in the underlying map.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value bound to `key` in the underlying map, or
+     *          `None` if `key` has no binding
+     */
     def get(key: K): Option[V] = underlying.get(key)
+    /** Returns an iterator over the entries of the underlying map. */
     def iterator: Iterator[(K, V)]^{this} = underlying.iterator
+    /** Returns the number of entries in the underlying map, if it can be computed in constant time, otherwise -1. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying map is empty. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
@@ -120,35 +193,124 @@ object MapView extends MapViewFactory {
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A map view that transforms every retrieved value of the underlying map
+   *  with the function `f`.
+   *
+   *  `f` is evaluated each time a value is accessed; results are not cached.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values of the underlying map
+   *  @tparam W the type of values of this view
+   *  @param underlying the map being viewed
+   *  @param f the function applied to each retrieved value
+   */
   @SerialVersionUID(3L)
   class MapValues[K, +V, +W](underlying: SomeMapOps[K, V]^, f: V => W) extends AbstractMapView[K, W] {
+    /** Returns an iterator over the entries of the underlying map, applying `f` to each value as it is retrieved. */
     def iterator: Iterator[(K, W)]^{this} = underlying.iterator.map(kv => (kv._1, f(kv._2)))
+    /** Returns the transformed value associated with `key`.
+     *
+     *  Looks up `key` in the underlying map and applies `f` to the value
+     *  found; `f` is evaluated on each call, and its result is not cached.
+     *
+     *  @param key the key to look up
+     *  @return `Some(f(v))` where `v` is the value bound to `key` in the
+     *          underlying map, or `None` if `key` has no binding
+     */
     def get(key: K): Option[W] = underlying.get(key).map(f)
+    /** Returns the number of entries in the underlying map, if it can be computed in constant time, otherwise -1. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying map is empty, without invoking `f`. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A map view of the entries of the underlying map whose key satisfies the
+   *  predicate `p`.
+   *
+   *  `p` is evaluated each time a key is tested; results are not cached.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param underlying the map being viewed
+   *  @param p the predicate used to test keys
+   */
   @SerialVersionUID(3L)
   class FilterKeys[K, +V](underlying: SomeMapOps[K, V]^, p: K => Boolean) extends AbstractMapView[K, V] {
+    /** Returns an iterator over the entries of the underlying map whose key satisfies `p`, evaluating `p` on each key as iteration proceeds. */
     def iterator: Iterator[(K, V)]^{this} = underlying.iterator.filter { case (k, _) => p(k) }
+    /** Returns the value associated with `key` if `key` satisfies `p`.
+     *
+     *  `p(key)` is evaluated on each call; when it is `false`, the underlying
+     *  map is not consulted.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value bound to `key` if `key` satisfies `p` and
+     *          has a binding in the underlying map, `None` otherwise
+     */
     def get(key: K): Option[V] = if (p(key)) underlying.get(key) else None
+    /** Returns 0 if the underlying map is known to be empty, otherwise -1, since the number of keys satisfying `p` is not known without traversal. */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if no key of the underlying map satisfies `p`, evaluating `p` on the keys until one satisfies it. */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
+  /** A map view of the entries of the underlying map that satisfy the
+   *  predicate `p`, or, if `isFlipped` is `true`, of those that do not.
+   *
+   *  Implements both `filter` and `filterNot` of [[MapView]]; `p` is evaluated
+   *  each time an entry is tested, and results are not cached.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param underlying the map being viewed
+   *  @param isFlipped if `true`, the sense of `p` is inverted
+   *  @param p the predicate used to test entries
+   */
   @SerialVersionUID(3L)
   class Filter[K, +V](underlying: SomeMapOps[K, V]^, isFlipped: Boolean, p: ((K, V)) => Boolean) extends AbstractMapView[K, V] {
+    /** Returns an iterator over the entries of the underlying map that pass the filter, evaluating `p` on each entry as iteration proceeds. */
     def iterator: Iterator[(K, V)]^{this} = underlying.iterator.filterImpl(p, isFlipped)
+    /** Returns the value associated with `key` if the resulting entry passes
+     *  the filter.
+     *
+     *  `p` is evaluated on each call, on the entry `(key, v)` where `v` is the
+     *  value bound to `key`; it is not evaluated when `key` has no binding.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value bound to `key` if the entry passes the
+     *          filter, `None` if it does not or if `key` has no binding
+     */
     def get(key: K): Option[V] = underlying.get(key) match {
       case s @ Some(v) if p((key, v)) != isFlipped => s
       case _ => None
     }
+    /** Returns 0 if the underlying map is known to be empty, otherwise -1, since the number of entries passing the filter is not known without traversal. */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if no entry of the underlying map passes the filter, evaluating `p` on the entries until one passes. */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
+  /** A map view over the entries of the underlying map that applies the
+   *  side-effecting function `f` to each entry as it is accessed.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @tparam U the result type of `f`; the result is discarded
+   *  @param underlying the map being viewed
+   *  @param f the function applied to each accessed entry
+   */
   @SerialVersionUID(3L)
   class TapEach[K, +V, +U](underlying: SomeMapOps[K, V]^, f: ((K, V)) => U) extends AbstractMapView[K, V] {
+    /** Returns the value associated with `key`, applying `f` to the entry for
+     *  its side effect if a value is found.
+     *
+     *  `f` is called with `(key, v)` where `v` is the value bound to `key`;
+     *  it is not called when `key` has no binding.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value bound to `key` in the underlying map, or
+     *          `None` if `key` has no binding
+     */
     override def get(key: K): Option[V] = {
       underlying.get(key) match {
         case s @ Some(v) =>
@@ -157,33 +319,111 @@ object MapView extends MapViewFactory {
         case None => None
       }
     }
+    /** Returns an iterator over the entries of the underlying map, applying `f` to each entry as it is produced. */
     override def iterator: Iterator[(K, V)]^{this} = underlying.iterator.tapEach(f)
+    /** Returns the number of entries in the underlying map, if it can be computed in constant time, otherwise -1. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying map is empty, without invoking `f`. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** Returns a builder for map views.
+   *
+   *  The builder is strict: it collects the added entries into a
+   *  `mutable.HashMap` and returns a view of that map.
+   *
+   *  @tparam X the type of keys
+   *  @tparam Y the type of values
+   */
   override def newBuilder[X, Y]: Builder[(X, Y), MapView[X, Y]] = mutable.HashMap.newBuilder[X, Y].mapResult(_.view)
 
+  /** Returns the empty map view.
+   *
+   *  Every call returns the same instance, cast to the requested key and
+   *  value types.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   */
   override def empty[K, V]: MapView[K, V] = EmptyMapView.asInstanceOf[MapView[K, V]]
 
+  /** Returns a view of the key-value pairs of `it`.
+   *
+   *  Note that the result is a plain `View` of pairs, not a `MapView`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the collection of key-value pairs to view
+   */
   override def from[K, V](it: IterableOnce[(K, V)]^): View[(K, V)]^{it} = View.from(it)
 
+  /** Returns a map view of `it`.
+   *
+   *  If `it` is already a `MapView` it is returned itself; otherwise it is
+   *  wrapped in a [[MapView.Id]].
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the map to view
+   */
   override def from[K, V](it: SomeMapOps[K, V]): MapView[K, V] = it match {
     case mv: MapView[K @unchecked, V @unchecked] => mv
     case other => new MapView.Id(other)
   }
 
+  /** Returns a map view of the given key-value pairs.
+   *
+   *  The pairs are first collected, strictly, into an immutable map, so a
+   *  later pair with the same key as an earlier one overrides it; the result
+   *  is a view of that map.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param elems the key-value pairs
+   */
   override def apply[K, V](elems: (K, V)*): MapView[K, V] = from(elems.toMap)
 }
 
+/** A factory of map views.
+ *
+ *  Adds to [[scala.collection.MapFactory]] operations that produce a
+ *  [[MapView]] rather than a plain view of key-value pairs.
+ */
 trait MapViewFactory extends collection.MapFactory[({ type l[X, Y] = View[(X, Y)]})#l] {
 
+  /** Returns a builder for map views.
+   *
+   *  @tparam X the type of keys
+   *  @tparam Y the type of values
+   *  @return a builder producing a `MapView` of the entries added to it
+   */
   def newBuilder[X, Y]: Builder[(X, Y), MapView[X, Y]]
 
+  /** Returns an empty map view.
+   *
+   *  @tparam X the type of keys
+   *  @tparam Y the type of values
+   */
   def empty[X, Y]: MapView[X, Y]
 
+  /** Returns a map view of `it`.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the map to view
+   */
   def from[K, V](it: SomeMapOps[K, V]): MapView[K, V]
 
+  /** Returns a map view of the given key-value pairs.
+   *
+   *  The pairs are first collected, strictly, into an immutable map, so a
+   *  later pair with the same key as an earlier one overrides it; the result
+   *  is a view of that map.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param elems the key-value pairs
+   */
   override def apply[K, V](elems: (K, V)*): MapView[K, V] = from(elems.toMap)
 }
 

--- a/library/src/scala/collection/Searching.scala
+++ b/library/src/scala/collection/Searching.scala
@@ -41,6 +41,7 @@ object Searching {
     * @param foundIndex the index corresponding to the element searched for in the sequence
     */
   case class Found(foundIndex: Int) extends SearchResult {
+    /** Returns `foundIndex`, the index at which the searched element was found. */
     override def insertionPoint: Int = foundIndex
   }
 
@@ -50,9 +51,26 @@ object Searching {
     */
   case class InsertionPoint(insertionPoint: Int) extends SearchResult
 
+  /** A value class that formerly provided the `search` methods for sequences. The search
+   *  methods are now defined directly on [[SeqOps]], so this class defines no methods of
+   *  its own.
+   *
+   *  @tparam Repr the type of the collection being searched; never used
+   *  @tparam A the element type of the wrapped sequence
+   *  @param coll the wrapped sequence; never used
+   */
   @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
   class SearchImpl[Repr, A](private val coll: SeqOps[A, AnyConstr, ?]) extends AnyVal
 
+  /** Converts a collection to a [[SearchImpl]] over its sequence view.
+   *
+   *  @tparam Repr the type of the collection to convert
+   *  @tparam A never used; the element type of the result is `fr.A`
+   *  @param coll the collection to convert
+   *  @param fr evidence that `Repr` can be viewed as a sequence, determining the
+   *            element type `fr.A`
+   *  @return a `SearchImpl` wrapping the sequence view `fr.conversion(coll)`
+   */
   @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
   implicit def search[Repr, A](coll: Repr)(implicit fr: IsSeq[Repr]): SearchImpl[Repr, fr.A] =
     new SearchImpl(fr.conversion(coll))

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -32,20 +32,54 @@ trait Seq[+A]
     with Equals
     with caps.Pure {
 
+  /** The factory used to build sequences, the [[Seq$ `Seq`]] companion object. */
   override def iterableFactory: SeqFactory[Seq] = Seq
 
+  /** Tests whether `that` can possibly equal this sequence.
+   *
+   *  Any value may be compared with a sequence, so this method always
+   *  returns `true`.
+   *
+   *  @param that the value being probed for possible equality; never used
+   *  @return `true`
+   */
   def canEqual(that: Any): Boolean = true
 
+  /** Tests whether this sequence is equal to another object.
+   *
+   *  Two sequences are equal if they contain equal elements in the same
+   *  order, regardless of their concrete implementations: for example, a
+   *  `List` and a `Vector` with the same elements are equal. Returns `false`
+   *  if `o` is not a sequence, or if `o.canEqual(this)` is `false`.
+   *
+   *  @param o the object to compare with
+   *  @return `true` if `o` is a sequence containing equal elements in the
+   *          same order as this sequence, `false` otherwise
+   */
   override def equals(o: Any): Boolean =
     (this eq o.asInstanceOf[AnyRef]) || (o match {
       case seq: Seq[A @unchecked] if seq.canEqual(this) => sameElements(seq)
       case _ => false
     })
 
+  /** Returns a hash code for this sequence, computed from its elements with
+   *  [[scala.util.hashing.MurmurHash3]]'s sequence hash.
+   *
+   *  Consistent with `equals`: any two equal sequences have the same hash
+   *  code, whatever their concrete implementations.
+   */
   override def hashCode(): Int = MurmurHash3.seqHash(this)
 
+  /** Returns a string representation of this sequence, consisting of the
+   *  `stringPrefix` followed by the elements.
+   *
+   *  Selects the representation inherited from `Iterable` over the
+   *  `<function1>` form that would otherwise be inherited via
+   *  `PartialFunction`.
+   */
   override def toString(): String = super[Iterable].toString()
 
+  /** The prefix used in the string representation of this sequence, `"Seq"`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "Seq"
 }
@@ -80,6 +114,11 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
 transparent trait SeqOps[+A, +CC[_], +C] extends Any
   with IterableOps[A, CC, C] { self: SeqOps[A, CC, C]^ =>
 
+  /** Returns a [[SeqView]] over the elements of this $coll.
+   *
+   *  The view is not evaluated: it reflects any changes to the underlying
+   *  $coll.
+   */
   override def view: SeqView[A]^{this} = new SeqView.Id[A](this)
 
   /** Gets the element at the specified index. This operation is provided for convenience in `Seq`. It should
@@ -182,6 +221,17 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   // Make `concat` an alias for `appendedAll` so that it benefits from performance
   // overrides of this method
+  /** Returns a new $coll containing the elements from this $coll followed by
+   *  the elements from `suffix`.
+   *
+   *  In `Seq` collections, `concat` is an alias for `appendedAll`, so
+   *  performance overrides of `appendedAll` benefit `concat` as well.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param suffix the iterable to append
+   *  @return a new collection of type `CC[B]` which contains all elements
+   *          of this $coll followed by all elements of `suffix`
+   */
   @inline override def concat[B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
@@ -195,6 +245,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   @deprecated("Use `concat` instead", "2.13.0")
   @inline final def union[B >: A](that: Seq[B]): CC[B]^{this} = concat(that)
 
+  /** The size of this $coll, always equal to `length`. */
   final override def size: Int = length
 
   /** Selects all the elements of this $coll ignoring the duplicates.
@@ -517,6 +568,14 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    */
   def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
 
+  /** Builds a new $coll by applying a function to all elements of this $coll
+   *  in reverse order.
+   *
+   *  @tparam B the element type of the returned $coll
+   *  @param f the function to apply to each element
+   *  @return a new $coll consisting of the results of applying `f` to the
+   *          elements of this $coll, from the last to the first
+   */
   @deprecated("Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)", "2.13.0")
   def reverseMap[B](f: A => B): CC[B]^{this, f} = iterableFactory.from(new View.Map(View.fromIteratorProvider(() => reverseIterator), f))
 
@@ -783,6 +842,16 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    */
   def indices: Range = Range(0, length)
 
+  /** Compares the size of this $coll to a test value.
+   *
+   *  Delegates to [[lengthCompare(Int) `lengthCompare(Int)`]], so overrides
+   *  of that method also take effect here.
+   *
+   *  @param otherSize the test value that gets compared with the size
+   *  @return a negative value if `this.size < otherSize`, zero if
+   *          `this.size == otherSize`, and a positive value if
+   *          `this.size > otherSize`
+   */
   override final def sizeCompare(otherSize: Int): Int = lengthCompare(otherSize)
 
   /** Compares the length of this $coll to a test value.
@@ -802,6 +871,16 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    */
   def lengthCompare(len: Int): Int = super.sizeCompare(len)
 
+  /** Compares the size of this $coll to the size of another `Iterable`.
+   *
+   *  Delegates to `lengthCompare(Iterable)`, so overrides of that method
+   *  also take effect here.
+   *
+   *  @param that the `Iterable` whose size is compared with this $coll's size
+   *  @return a negative value if `this.size < that.size`, zero if
+   *          `this.size == that.size`, and a positive value if
+   *          `this.size > that.size`
+   */
   override final def sizeCompare(that: Iterable[?]^): Int = lengthCompare(that)
 
   /** Compares the length of this $coll to the size of another `Iterable`.
@@ -837,6 +916,13 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    */
   @inline final def lengthIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
+  /** Tests whether this $coll is empty.
+   *
+   *  Implemented as `lengthCompare(0) == 0`, so the full length is not
+   *  computed when it is expensive.
+   *
+   *  @return `true` if this $coll contains no elements, `false` otherwise
+   */
   override def isEmpty: Boolean = lengthCompare(0) == 0
 
   /** Checks whether corresponding elements of the given iterable collection
@@ -962,6 +1048,16 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
     iterableFactory.from(new View.Updated(this, index, elem))
   }
 
+  /** Returns a mutable map from each distinct element of `sq` to the number
+   *  of times it occurs in `sq`.
+   *
+   *  Used to implement the multiset operations `diff` and `intersect`.
+   *
+   *  @tparam B the element type of `sq`
+   *  @param sq the sequence whose element occurrences are counted
+   *  @return a mutable map whose keys are the distinct elements of `sq` and
+   *          whose values are their occurrence counts (always positive)
+   */
   protected[collection] def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
     val occ = new mutable.HashMap[B, Int]()
     for (y <- sq) occ.updateWith(y) {

--- a/library/src/scala/collection/SeqMap.scala
+++ b/library/src/scala/collection/SeqMap.scala
@@ -33,9 +33,11 @@ import scala.annotation.nowarn
 trait SeqMap[K, +V] extends Map[K, V]
   with MapOps[K, V, SeqMap, SeqMap[K, V]]
   with MapFactoryDefaults[K, V, SeqMap, Iterable] {
+  /** Returns `"SeqMap"`, the prefix used by `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SeqMap"
 
+  /** Returns the `SeqMap` companion object as the factory for maps of this kind. */
   override def mapFactory: MapFactory[SeqMap] = SeqMap
 }
 

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -21,25 +21,125 @@ import scala.collection.generic.CommonErrors
 import scala.runtime.ScalaRunTime.nullForGC
 
 
+/** A view of a sequence: a [[scala.collection.View]] whose elements additionally can be
+ *  accessed by index via `apply` and counted via `length`.
+ *
+ *  As with all views, transformation operations are non strict: they return other views,
+ *  and elements are evaluated only when the view is traversed or converted to a strict
+ *  collection. The operations that must count from the end - `takeRight`, `dropRight`
+ *  and `sorted` - are an exception in one respect: each computes the length of this view
+ *  as the new view is created, though it still leaves the elements themselves
+ *  unevaluated.
+ *
+ *  @tparam A the element type of the view
+ */
 trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
+  /** Returns this view unchanged: a sequence view is already a view. */
   override def view: SeqView[A]^{this} = this
 
+  /** Returns a view of the results of applying `f` to each element of this view.
+   *
+   *  `f` is applied lazily, each time an element is accessed or traversed, and is
+   *  re-applied on every access.
+   *
+   *  @tparam B the element type of the returned view
+   *  @param f the function to apply to each element
+   *  @return a view producing `f(x)` for each element `x` of this view
+   */
   override def map[B](f: A => B): SeqView[B]^{this, f} = new SeqView.Map(this, f)
+  /** Returns a view of the elements of this view followed by `elem`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of this view's element type
+   *  @param elem the element to append
+   *  @return a view whose last element is `elem`
+   */
   override def appended[B >: A](elem: B): SeqView[B]^{this} = new SeqView.Appended(this, elem)
+  /** Returns a view of `elem` followed by the elements of this view.
+   *
+   *  @tparam B the element type of the returned view, a supertype of this view's element type
+   *  @param elem the element to prepend
+   *  @return a view whose first element is `elem`
+   */
   override def prepended[B >: A](elem: B): SeqView[B]^{this} = new SeqView.Prepended(elem, this)
+  /** Returns a view of the elements of this view in reverse order. */
   override def reverse: SeqView[A]^{this} = new SeqView.Reverse(this)
+  /** Returns a view of the first `n` elements of this view, or of all elements if this
+   *  view has fewer than `n`.
+   *
+   *  @param n the number of elements to take; a negative value is treated as 0
+   *  @return a view of the `n` leading elements, of all of them if there are fewer
+   *          than `n`, or an empty view if `n` is not positive
+   */
   override def take(n: Int): SeqView[A]^{this} = new SeqView.Take(this, n)
+  /** Returns a view of the elements of this view except the first `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of the elements that remain after dropping `n` leading elements
+   */
   override def drop(n: Int): SeqView[A]^{this} = new SeqView.Drop(this, n)
+  /** Returns a view of the last `n` elements of this view, or of all elements if this
+   *  view has fewer than `n`.
+   *
+   *  Creating the returned view computes the size of this view immediately.
+   *
+   *  @param n the number of elements to take; a negative value is treated as 0
+   *  @return a view of the `n` trailing elements, of all of them if there are fewer
+   *          than `n`, or an empty view if `n` is not positive
+   */
   override def takeRight(n: Int): SeqView[A]^{this} = new SeqView.TakeRight(this, n)
+  /** Returns a view of the elements of this view except the last `n`.
+   *
+   *  Creating the returned view computes the size of this view immediately.
+   *
+   *  @param n the number of elements to drop
+   *  @return a view of the elements that remain after dropping `n` trailing elements
+   */
   override def dropRight(n: Int): SeqView[A]^{this} = new SeqView.DropRight(this, n)
+  /** Returns a view of the same elements that additionally applies `f` to each element,
+   *  for its side effect, every time the element is accessed or traversed.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the side-effecting function to apply to each element
+   *  @return a view of the elements of this view, invoking `f` on each element access
+   */
   override def tapEach[U](f: A => U): SeqView[A]^{this, f} = new SeqView.Map(this, { (a: A) => f(a); a })
 
+  /** Returns a view of the elements of this view followed by the elements of `suffix`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of this view's element type
+   *  @param suffix the sequence whose elements follow those of this view
+   *  @return a view of the concatenation of this view and `suffix`
+   */
   def concat[B >: A](suffix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, suffix} = new SeqView.Concat(this, suffix)
+  /** Returns a view of the elements of this view followed by the elements of `suffix`;
+   *  an alias of `concat`.
+   *
+   *  @tparam B the element type of the returned view, a supertype of this view's element type
+   *  @param suffix the sequence whose elements follow those of this view
+   *  @return a view of the concatenation of this view and `suffix`
+   */
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, suffix} = new SeqView.Concat(this, suffix)
+  /** Returns a view of the elements of `prefix` followed by the elements of this view.
+   *
+   *  @tparam B the element type of the returned view, a supertype of this view's element type
+   *  @param prefix the sequence whose elements precede those of this view
+   *  @return a view of the concatenation of `prefix` and this view
+   */
   def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, prefix} = new SeqView.Concat(prefix, this)
 
+  /** Returns a view of the elements of this view in the order given by `ord`.
+   *
+   *  The length of this view is computed immediately, so calling this method on a view
+   *  over an infinite sequence does not terminate. The sort itself is deferred until an
+   *  element of the returned view is first accessed, and its result is then cached.
+   *
+   *  @tparam B the type on which `ord` compares, a supertype of this view's element type
+   *  @param ord the ordering to sort by
+   *  @return a view of the same elements, sorted according to `ord`
+   */
   override def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A]^{this} = new SeqView.Sorted(this, ord)
 
+  /** Returns `"SeqView"`, the prefix used in the string representation of this view. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SeqView"
 }
@@ -52,51 +152,141 @@ object SeqView {
   /** A view that doesn't apply any transformation to an underlying sequence. */
   @SerialVersionUID(3L)
   class Id[+A](underlying: SomeSeqOps[A]^) extends AbstractSeqView[A] {
+    /** Returns the element of the underlying sequence at index `idx`.
+     *
+     *  @param idx the index of the element
+     *  @return the underlying element at `idx`
+     */
     def apply(idx: Int): A = underlying.apply(idx)
+    /** Returns the length of the underlying sequence. */
     def length: Int = underlying.length
+    /** Returns an iterator over the underlying elements, in order. */
     def iterator: Iterator[A]^{this} = underlying.iterator
+    /** Returns the underlying sequence's known size, or -1 if it is not known. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying sequence is empty. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A view that applies a function to each element of an underlying sequence.
+   *
+   *  @tparam A the element type of the underlying sequence
+   *  @tparam B the element type of the view
+   *  @param underlying the sequence providing the elements
+   *  @param f the function applied on demand to each element
+   */
   @SerialVersionUID(3L)
   class Map[+A, +B](underlying: SomeSeqOps[A]^, f: A => B) extends View.Map[A, B](underlying, f) with SeqView[B] {
+    /** Returns the result of applying `f` to the underlying element at index `idx`;
+     *  `f` is re-applied on every access.
+     *
+     *  @param idx the index of the element
+     *  @return `f` applied to the underlying element at `idx`
+     */
     def apply(idx: Int): B = f(underlying(idx))
+    /** Returns the length of the underlying sequence; mapping does not change it. */
     def length: Int = underlying.length
   }
 
+  /** A view of an underlying sequence with one element appended.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence providing all elements but the last
+   *  @param elem the appended element, the last of the view
+   */
   @SerialVersionUID(3L)
   class Appended[+A](underlying: SomeSeqOps[A]^, elem: A) extends View.Appended(underlying, elem) with SeqView[A] {
+    /** Returns `elem` if `idx` equals the length of the underlying sequence, and
+     *  otherwise the underlying element at index `idx`.
+     *
+     *  @param idx the index of the element
+     *  @return the element of this view at `idx`
+     */
     def apply(idx: Int): A = if (idx == underlying.length) elem else underlying(idx)
+    /** Returns the length of the underlying sequence plus 1. */
     def length: Int = underlying.length + 1
   }
 
+  /** A view of an underlying sequence with one element prepended.
+   *
+   *  @tparam A the element type of the view
+   *  @param elem the prepended element, the first of the view
+   *  @param underlying the sequence providing all elements but the first
+   */
   @SerialVersionUID(3L)
   class Prepended[+A](elem: A, underlying: SomeSeqOps[A]^) extends View.Prepended(elem, underlying) with SeqView[A] {
+    /** Returns `elem` if `idx` is 0, and otherwise the underlying element at index
+     *  `idx - 1`.
+     *
+     *  @param idx the index of the element
+     *  @return the element of this view at `idx`
+     */
     def apply(idx: Int): A = if (idx == 0) elem else underlying(idx - 1)
+    /** Returns the length of the underlying sequence plus 1. */
     def length: Int = underlying.length + 1
   }
 
+  /** A view of the concatenation of two sequences.
+   *
+   *  @tparam A the element type of the view
+   *  @param prefix the sequence providing the leading elements
+   *  @param suffix the sequence providing the trailing elements
+   */
   @SerialVersionUID(3L)
   class Concat[A](prefix: SomeSeqOps[A]^, suffix: SomeSeqOps[A]^) extends View.Concat[A](prefix, suffix) with SeqView[A] {
+    /** Returns the prefix element at index `idx` if `idx` is smaller than the prefix
+     *  length, and otherwise the suffix element at `idx` minus the prefix length; the
+     *  prefix length is recomputed on every access.
+     *
+     *  @param idx the index of the element
+     *  @return the element of this view at `idx`
+     */
     def apply(idx: Int): A = {
       val l = prefix.length
       if (idx < l) prefix(idx) else suffix(idx - l)
     }
+    /** Returns the sum of the lengths of the prefix and the suffix. */
     def length: Int = prefix.length + suffix.length
   }
 
+  /** A view of the elements of an underlying sequence in reverse order.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence whose elements are reversed
+   */
   @SerialVersionUID(3L)
   class Reverse[A](underlying: SomeSeqOps[A]^) extends AbstractSeqView[A] {
+    /** Returns the underlying element at index `size - 1 - i`, that is, the element at
+     *  index `i` counting from the end of the underlying sequence.
+     *
+     *  @param i the index of the element in this view
+     */
     def apply(i: Int) = underlying.apply(size - 1 - i)
+    /** Returns the size of the underlying sequence; reversing does not change it. */
     def length = underlying.size
+    /** Returns an iterator over the underlying elements in reverse order. */
     def iterator: Iterator[A]^{this} = underlying.reverseIterator
+    /** Returns the underlying sequence's known size, or -1 if it is not known. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying sequence is empty. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A view of the first `n` elements of an underlying sequence.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence whose leading elements are taken
+   *  @param n the number of elements to take
+   */
   @SerialVersionUID(3L)
   class Take[+A](underlying: SomeSeqOps[A]^, n: Int) extends View.Take(underlying, n) with SeqView[A] {
+    /** Returns the underlying element at index `idx`.
+     *
+     *  @param idx the index of the element
+     *  @return the element of this view at `idx`
+     *  @throws IndexOutOfBoundsException if `idx` is negative, at least `n`, or beyond
+     *          the end of the underlying sequence
+     */
     def apply(idx: Int): A = if (idx < n) {
       underlying(idx)
     } else {
@@ -105,33 +295,100 @@ object SeqView {
         else CommonErrors.indexOutOfBounds(index = idx)
       )
     }
+    /** Returns the smaller of the underlying sequence's length and the take count. */
     def length: Int = underlying.length min normN
   }
 
+  /** A view of the last `n` elements of an underlying sequence.
+   *
+   *  The size of the underlying sequence is computed eagerly, when this view is created.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence whose trailing elements are taken
+   *  @param n the number of elements to take
+   */
   @SerialVersionUID(3L)
   class TakeRight[+A](underlying: SomeSeqOps[A]^, n: Int) extends View.TakeRight(underlying, n) with SeqView[A] {
     private val delta = (underlying.size - (n max 0)) max 0
+    /** Returns the underlying sequence's size minus the number of leading elements that
+     *  were excluded when this view was created: the smaller of that size and the take
+     *  count, if the underlying sequence has not changed size since.
+     */
     def length = underlying.size - delta
+    /** Returns the underlying element at index `i` plus the offset of the first taken
+     *  element; bounds are checked only by the underlying sequence, not against the
+     *  length of this view.
+     *
+     *  @param i the index of the element in this view
+     */
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + delta)
   }
 
+  /** A view of the elements of an underlying sequence except the first `n`.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence whose leading elements are dropped
+   *  @param n the number of elements to drop
+   */
   @SerialVersionUID(3L)
   class Drop[A](underlying: SomeSeqOps[A]^, n: Int) extends View.Drop[A](underlying, n) with SeqView[A] {
+    /** Returns the underlying sequence's size minus the drop count, or 0 if the drop
+     *  count is larger.
+     */
     def length = (underlying.size - normN) max 0
+    /** Returns the underlying element at index `i` plus the drop count; bounds are
+     *  checked only by the underlying sequence, not against the length of this view.
+     *
+     *  @param i the index of the element in this view
+     */
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + normN)
+    /** Returns a view that drops `n` more elements of the underlying sequence, fusing
+     *  this drop and the new one into a single `Drop` whose drop count is the sum of
+     *  the two, before that sum is clamped to be non-negative. A negative count on
+     *  either side therefore offsets the other rather than being ignored on its own.
+     *
+     *  @param n the number of additional elements to drop
+     *  @return a view of the underlying elements except the first `this.n + n`, or of
+     *          all of them if that sum is not positive
+     */
     override def drop(n: Int): SeqView[A]^{this} = new Drop(underlying, this.n + n)
   }
 
+  /** A view of the elements of an underlying sequence except the last `n`.
+   *
+   *  The size of the underlying sequence is computed eagerly, when this view is created.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the sequence whose trailing elements are dropped
+   *  @param n the number of elements to drop
+   */
   @SerialVersionUID(3L)
   class DropRight[A](underlying: SomeSeqOps[A]^, n: Int) extends View.DropRight[A](underlying, n) with SeqView[A] {
     private val len = (underlying.size - (n max 0)) max 0
+    /** Returns the underlying sequence's size minus the drop count (at least 0), as
+     *  computed when this view was created.
+     */
     def length = len
+    /** Returns the underlying element at index `i`; bounds are checked only by the
+     *  underlying sequence, not against the shortened length of this view.
+     *
+     *  @param i the index of the element
+     */
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i)
   }
 
+  /** A view of the elements of an underlying sequence in sorted order.
+   *
+   *  Creating the view computes the length of the underlying sequence eagerly. The sort
+   *  itself is deferred until an element is first accessed; its result is then cached,
+   *  and the reference to the underlying sequence released.
+   *
+   *  @tparam A the element type of the view
+   *  @tparam B the type on which the ordering compares, a supertype of the element type
+   */
   @SerialVersionUID(3L)
   class Sorted[A, B >: A] private (underlying_ : SomeSeqOps[A]^,
                                    private val len: Int,
@@ -143,6 +400,12 @@ object SeqView {
 
     // force evaluation immediately by calling `length` so infinite collections
     // hang on `sorted`/`sortWith`/`sortBy` rather than on arbitrary method calls
+    /** Creates a sorted view of `underlying`, eagerly computing its length; on a view
+     *  over an infinite sequence, this constructor does not terminate.
+     *
+     *  @param underlying the sequence whose elements are sorted
+     *  @param ord the ordering to sort by
+     */
     def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]) = this(underlying, underlying.length, ord)
 
     @SerialVersionUID(3L)
@@ -196,17 +459,45 @@ object SeqView {
       if (evaluated) _sorted else underlying
     }
 
+    /** Returns the element at index `i` in sorted order, forcing the sort on the first
+     *  element access; later accesses read the cached result.
+     *
+     *  @param i the index of the element
+     *  @return the element of this view at `i`
+     */
     def apply(i: Int): A = _sorted.apply(i)
+    /** Returns the length, computed when this view was created; does not force the sort. */
     def length: Int = len
+    /** Returns an iterator over the elements in sorted order; the sort is deferred until
+     *  the iterator is first queried.
+     */
     def iterator: Iterator[A]^{this} = Iterator.empty ++ _sorted.iterator // very lazy
+    /** Returns the length, computed when this view was created; does not force the sort. */
     override def knownSize: Int = len
+    /** Returns `true` if the length is 0; does not force the sort. */
     override def isEmpty: Boolean = len == 0
+    /** Returns a collection containing the elements in sorted order, forcing the sort.
+     *
+     *  @tparam C1 the type of the collection to build
+     *  @param factory the factory that builds the result
+     *  @return a collection of the elements in sorted order
+     */
     override def to[C1](factory: Factory[A, C1]): C1 = _sorted.to(factory)
+    /** Returns a view of the elements in reverse sorted order; does not force the sort. */
     override def reverse: SeqView[A]^{this} = new ReverseSorted
+    /** Returns a view of the elements in reverse sorted order; does not force the sort. */
     // we know `_sorted` is either tiny or has efficient random access,
     //  so this is acceptable for `reversed`
     override protected def reversed: Iterable[A]^{this} = new ReverseSorted
 
+    /** Returns this view if `ord1` equals the ordering it was sorted by, a reverse-order
+     *  view if `ord1` is the reverse of that ordering, and otherwise a new sorted view,
+     *  reusing the cached sorted elements when the sort has already been performed.
+     *
+     *  @tparam B1 the type on which `ord1` compares
+     *  @param ord1 the ordering to sort by
+     *  @return a view of the same elements, sorted according to `ord1`
+     */
     override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
       if (ord1 == this.ord) this
       else if (ord1.isReverseOf(this.ord)) reverse

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -32,6 +32,13 @@ trait Set[A]
     with IterableFactoryDefaults[A, Set]
     with caps.Pure {
 
+  /** Tests whether this set can equal the given object.
+   *
+   *  Always `true` here; [[equals]] consults this method so that subclasses can restrict
+   *  equality to specific set types.
+   *
+   *  @param that the value being probed for possible equality; not examined by this implementation
+   */
   def canEqual(that: Any) = true
 
   /** Equality of sets is implemented using the lookup method [[contains]]. This method returns `true` if
@@ -70,13 +77,25 @@ trait Set[A]
         false
     })
 
+  /** Returns a hash code value consistent with [[equals]]: computed with
+   *  [[scala.util.hashing.MurmurHash3.setHash]], it does not depend on the order in which
+   *  this set enumerates its elements.
+   */
   override def hashCode(): Int = MurmurHash3.setHash(this)
 
+  /** Returns the `Set` companion object as the factory for sets of this kind. */
   override def iterableFactory: IterableFactory[Set] = Set
 
+  /** Returns `"Set"`, the prefix used by `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "Set"
 
+  /** Returns a string representation of this set, of the form `Set(elem1, elem2, ...)`,
+   *  with the prefix taken from `stringPrefix`, so a `SortedSet` names itself instead.
+   *
+   *  Reinstates `Iterable`'s `toString`, which the `toString` inherited through `Function1`
+   *  would otherwise replace.
+   */
   override def toString(): String = super[Iterable].toString() // Because `Function1` overrides `toString` too
 }
 
@@ -94,6 +113,11 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
      with (A => Boolean)
      with caps.Pure {
 
+  /** Tests whether this set contains a given element.
+   *
+   *  @param elem the element to test for membership
+   *  @return `true` if `elem` is contained in this set, `false` otherwise
+   */
   def contains(elem: A): Boolean
 
   /** Tests if some element is contained in this set.
@@ -211,15 +235,30 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
+  /** Returns a new $coll containing the elements of this $coll that are not also contained
+   *  in the given collection `that`.
+   *
+   *  @param that the collection of elements to exclude
+   */
   @deprecated("Consider requiring an immutable Set", "2.13.0")
   def -- (that: IterableOnce[A]^): C = {
     val toRemove = that.iterator.to(immutable.Set)
     fromSpecific(view.filterNot(toRemove))
   }
 
+  /** Returns a new $coll containing all elements of this $coll except `elem`.
+   *
+   *  @param elem the element to remove
+   */
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
   def - (elem: A): C = diff(Set(elem))
 
+  /** Returns a new $coll containing all elements of this $coll except the given elements.
+   *
+   *  @param elem1 the first element to remove
+   *  @param elem2 the second element to remove
+   *  @param elems the remaining elements to remove
+   */
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
@@ -247,9 +286,20 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     })
   }
 
+  /** Returns a new $coll containing all elements of this $coll together with `elem`.
+   *
+   *  @param elem the element to add
+   */
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
   def + (elem: A): C = fromSpecific(new View.Appended(this, elem))
 
+  /** Returns a new $coll containing all elements of this $coll together with the given
+   *  elements.
+   *
+   *  @param elem1 the first element to add
+   *  @param elem2 the second element to add
+   *  @param elems the remaining elements to add
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -28,13 +28,26 @@ trait SortedMap[K, +V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
     with SortedMapFactoryDefaults[K, V, SortedMap, Iterable, Map]{
 
+  /** Returns this map itself, statically typed as an unsorted `Map`; no copy is made. */
   def unsorted: Map[K, V] = this
 
+  /** Returns the `SortedMap` companion object as the factory for sorted maps of this kind. */
   def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
+  /** Returns `"SortedMap"`, the prefix used by `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SortedMap"
 
+  /** Tests whether this sorted map equals the given object.
+   *
+   *  If `that` is a sorted map whose ordering equals this map's ordering, the two are compared
+   *  by iterating both in order and testing that corresponding keys are equivalent under that
+   *  ordering and corresponding values are equal (after checking `canEqual` and equal sizes).
+   *  Otherwise falls back to the unordered `Map` equality, which compares by key lookup.
+   *
+   *  @param that the object to compare this sorted map with
+   *  @return `true` if the two maps are equal according to the description
+   */
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
     case sm: SortedMap[K @unchecked, ?] if sm.ordering == this.ordering =>
@@ -80,6 +93,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    */
   @`inline` protected final def sortedMapFromIterable[K2, V2](it: Iterable[(K2, V2)]^)(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFactory.from(it)
 
+  /** Widens the type of this map to its unsorted counterpart. */
   def unsorted: Map[K, V]
 
   /** Creates an iterator over all the key/value pairs
@@ -118,7 +132,15 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    */
   def valuesIteratorFrom(start: K): Iterator[V] = iteratorFrom(start).map(_._2)
 
+  /** Returns the first key of this map, the smallest under its ordering.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   def firstKey: K = head._1
+  /** Returns the last key of this map, the largest under its ordering.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   def lastKey: K = last._1
 
   /** Finds the element with smallest key larger than or equal to a given key.
@@ -133,6 +155,11 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    */
   def maxBefore(key: K): Option[(K, V)] = rangeUntil(key).lastOption
 
+  /** Creates a ranged projection of this collection with no lower-bound.
+   *
+   *  @param to The upper-bound (inclusive) of the ranged projection.
+   *  @return a ranged projection of this collection containing only entries with keys less than or equal to `to`
+   */
   def rangeTo(to: K): C = {
     val i = keySet.rangeFrom(to).iterator
     if (i.isEmpty) return coll
@@ -144,6 +171,11 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
       rangeUntil(next)
   }
 
+  /** Returns a sorted set of the keys of this map, sorted by this map's ordering.
+   *
+   *  The set is a view backed by this map: it holds a reference to the map and reflects its
+   *  current contents rather than copying the keys.
+   */
   override def keySet: SortedSet[K] = new LazyKeySortedSet
 
   /** The implementation class of the set returned by `keySet`. */
@@ -161,7 +193,19 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   /** The old implementation class of the set returned by `keySet`. */
   @deprecated("KeySortedSet is no longer used in the .keySet implementation", since = "3.8.0")
   protected class KeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
+    /** Returns a new sorted set containing the keys of this set that are not also contained
+     *  in `that`.
+     *
+     *  @param that the set of keys to exclude
+     */
     def diff(that: Set[K]): SortedSet[K] = fromSpecific(view.filterNot(that))
+    /** Creates a ranged projection of this key set, backed by the corresponding ranged
+     *  projection of the underlying map.
+     *
+     *  @param from the lower-bound (inclusive) of the projection, `None` if there is no lower bound
+     *  @param until the upper-bound (exclusive) of the projection, `None` if there is no upper bound
+     *  @return the key set of the underlying map restricted to the given range
+     */
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
       val map = SortedMapOps.this.rangeImpl(from, until)
       new map.KeySortedSet
@@ -171,7 +215,14 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   /** A generic trait that is reused by sorted keyset implementations. */
   @deprecated("GenKeySortedSet is no longer used in .keySet implementations", since = "3.8.0")
   protected trait GenKeySortedSet extends GenKeySet { this: SortedSet[K] =>
+    /** The ordering of the underlying map, by which the keys of this set are sorted. */
     implicit def ordering: Ordering[K] = SortedMapOps.this.ordering
+    /** Returns an iterator over the keys of the underlying map that are greater than or equal
+     *  to `start` under the map's ordering.
+     *
+     *  @param start the lower bound (inclusive) on the keys to be returned
+     *  @return an iterator over all keys greater than or equal to `start`
+     */
     def iteratorFrom(start: K): Iterator[K] = SortedMapOps.this.keysIteratorFrom(start)
   }
 
@@ -215,6 +266,14 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^)(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.Collect(this, pf))
 
+  /** Returns a new $coll containing the bindings of this $coll and those of `suffix`, with
+   *  keys sorted by this $coll's ordering. The result is built through the sorted map
+   *  factory, so where two keys compare equal under that ordering only the later binding
+   *  survives.
+   *
+   *  @tparam V2 the value type of the returned sorted map, a supertype of `V`
+   *  @param suffix the collection of key-value pairs to append
+   */
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): CC[K, V2] = sortedMapFactory.from(suffix match {
     case it: Iterable[(K, V2) @unchecked] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
@@ -227,9 +286,24 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CC[K, V2] = concat(xs)
 
+  /** Returns a new $coll containing all bindings of this $coll together with the binding `kv`;
+   *  if this $coll already contains a binding for the key `kv._1`, the new binding replaces it.
+   *
+   *  @tparam V1 the value type of the returned sorted map, a supertype of `V`
+   *  @param kv the key-value pair to add
+   */
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(using ordering)
 
+  /** Returns a new $coll containing all bindings of this $coll together with the given
+   *  key-value pairs; a pair later in the argument list overrides any earlier binding
+   *  with the same key.
+   *
+   *  @tparam V1 the value type of the returned sorted map, a supertype of `V`
+   *  @param elem1 the first key-value pair to add
+   *  @param elem2 the second key-value pair to add
+   *  @param elems the remaining key-value pairs to add
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(using ordering)
 }
@@ -252,12 +326,35 @@ object SortedMapOps {
     p: ((K, V)) => Boolean
   ) extends MapOps.WithFilter[K, V, IterableCC, MapCC](self, p) {
 
+    /** Builds a new $coll by applying a function to all elements of the filtered outer $coll.
+     *
+     *  @tparam K2 the key type of the returned $coll, which must have an implicit `Ordering`
+     *  @tparam V2 the value type of the returned $coll
+     *  @param f the function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and collecting the results
+     */
     def map[K2 : Ordering, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] =
       self.sortedMapFactory.from(new View.Map(filtered, f))
 
+    /** Builds a new $coll by applying a collection-valued function to all elements of the
+     *  filtered outer $coll and concatenating the results.
+     *
+     *  @tparam K2 the key type of the returned $coll, which must have an implicit `Ordering`
+     *  @tparam V2 the value type of the returned $coll
+     *  @param f the collection-valued function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and concatenating the results
+     */
     def flatMap[K2 : Ordering, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^): CC[K2, V2] =
       self.sortedMapFactory.from(new View.FlatMap(filtered, f))
 
+    /** Further refines the filter of this `WithFilter`.
+     *
+     *  @param q the predicate to combine with the existing filter
+     *  @return a new `WithFilter` whose operations apply to the elements of the outer $coll
+     *          that satisfy both the existing predicate and `q`
+     */
     override def withFilter(q: ((K, V)) => Boolean): WithFilter[K, V, IterableCC, MapCC, CC]^{this, q} =
       new WithFilter[K, V, IterableCC, MapCC, CC](self, (kv: (K, V)) => p(kv) && q(kv))
 

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -22,6 +22,9 @@ import language.experimental.captureChecking
  */
 transparent trait SortedOps[A, +C] {
 
+  /** The ordering by which the elements of this collection are sorted, and by which its
+   *  range operations select them.
+   */
   def ordering: Ordering[A]
 
   /** Returns the first key of the collection. */

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -26,13 +26,26 @@ trait SortedSet[A] extends Set[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
     with SortedSetFactoryDefaults[A, SortedSet, Set] {
 
+  /** Returns this set itself, statically typed as an unsorted `Set`; no copy is made. */
   def unsorted: Set[A] = this
 
+  /** Returns the `SortedSet` companion object as the factory for sorted sets of this kind. */
   def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
 
+  /** Returns `"SortedSet"`, the prefix used by `toString`. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SortedSet"
 
+  /** Tests whether this sorted set equals the given object.
+   *
+   *  If `that` is a sorted set whose ordering equals this set's ordering, the two are compared
+   *  by iterating both in order and testing that corresponding elements are equivalent under
+   *  that ordering (after checking `canEqual` and equal sizes). Otherwise falls back to the
+   *  unordered `Set` equality, which compares by membership.
+   *
+   *  @param that the object to compare this sorted set with
+   *  @return `true` if the two sets are equal according to the description
+   */
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
     case ss: SortedSet[A @unchecked] if ss.ordering == this.ordering =>
@@ -81,7 +94,15 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   @deprecated("Use `iteratorFrom` instead.", "2.13.0")
   @`inline` def keysIteratorFrom(start: A): Iterator[A] = iteratorFrom(start)
 
+  /** Returns the first element of this collection, the smallest under its ordering.
+   *
+   *  @throws NoSuchElementException if this collection is empty
+   */
   def firstKey: A = head
+  /** Returns the last element of this collection, the largest under its ordering.
+   *
+   *  @throws NoSuchElementException if this collection is empty
+   */
   def lastKey: A = last
 
   /** Finds the smallest element larger than or equal to a given key.
@@ -96,18 +117,43 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
    */
   def maxBefore(key: A): Option[A] = rangeUntil(key).lastOption
 
+  /** Returns the smallest element of this collection with respect to `ord`.
+   *
+   *  When `ord` equals this collection's ordering, the first element is returned; when it is
+   *  the reverse of that ordering, the last. Any other ordering falls back to examining every
+   *  element.
+   *
+   *  @tparam B the type over which the ordering is defined, a supertype of `A`
+   *  @param ord the ordering used to compare elements
+   *  @throws UnsupportedOperationException if this collection is empty
+   */
   override def min[B >: A](implicit ord: Ordering[B]): A =
     if (isEmpty) throw new UnsupportedOperationException("empty.min")
     else if (ord == ordering) head
     else if (ord isReverseOf ordering) last
     else super.min[B] // need the type annotation for it to infer the correct implicit
 
+  /** Returns the largest element of this collection with respect to `ord`.
+   *
+   *  When `ord` equals this collection's ordering, the last element is returned; when it is
+   *  the reverse of that ordering, the first. Any other ordering falls back to examining every
+   *  element.
+   *
+   *  @tparam B the type over which the ordering is defined, a supertype of `A`
+   *  @param ord the ordering used to compare elements
+   *  @throws UnsupportedOperationException if this collection is empty
+   */
   override def max[B >: A](implicit ord: Ordering[B]): A =
     if (isEmpty) throw new UnsupportedOperationException("empty.max")
     else if (ord == ordering) last
     else if (ord isReverseOf ordering) head
     else super.max[B] // need the type annotation for it to infer the correct implicit
 
+  /** Creates a ranged projection of this collection with no lower-bound.
+   *
+   *  @param to The upper-bound (inclusive) of the ranged projection.
+   *  @return a ranged projection of this collection containing only elements less than or equal to `to`
+   */
   def rangeTo(to: A): C = {
     val i = rangeFrom(to).iterator
     if (i.isEmpty) return coll
@@ -189,12 +235,33 @@ object SortedSetOps {
     p: A => Boolean
   ) extends IterableOps.WithFilter[A, IterableCC](self, p) {
 
+    /** Builds a new $coll by applying a function to all elements of the filtered outer $coll.
+     *
+     *  @tparam B the element type of the returned $coll, which must have an implicit `Ordering`
+     *  @param f the function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and collecting the results
+     */
     def map[B : Ordering](f: A => B): CC[B] =
       self.sortedIterableFactory.from(new View.Map(filtered, f))
 
+    /** Builds a new $coll by applying a collection-valued function to all elements of the
+     *  filtered outer $coll and concatenating the results.
+     *
+     *  @tparam B the element type of the returned $coll, which must have an implicit `Ordering`
+     *  @param f the collection-valued function to apply to each element
+     *  @return a new $coll resulting from applying `f` to each element of the filtered outer
+     *          $coll and concatenating the results
+     */
     def flatMap[B : Ordering](f: A => IterableOnce[B]^): CC[B] =
       self.sortedIterableFactory.from(new View.FlatMap(filtered, f))
 
+    /** Further refines the filter of this `WithFilter`.
+     *
+     *  @param q the predicate to combine with the existing filter
+     *  @return a new `WithFilter` whose operations apply to the elements of the outer $coll
+     *          that satisfy both the existing predicate and `q`
+     */
     override def withFilter(q: A => Boolean): WithFilter[A, IterableCC, CC]^{this, q} =
       new WithFilter[A, IterableCC, CC](self, (a: A) => p(a) && q(a))
   }

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -197,10 +197,25 @@ object Stepper {
  *  @tparam A the element type of the stepper
  */
 trait AnyStepper[+A] extends Stepper[A] {
+  /** Splits this stepper, if applicable. See [[Stepper.trySplit]].
+   *
+   *  @return a new `AnyStepper` containing a portion of the elements, or `null` if this stepper cannot be split
+   */
   def trySplit(): AnyStepper[A]^{this} | Null
 
+  /** Returns a [[java.util.Spliterator]] over the remaining elements of this stepper.
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a `Spliterator` whose advancing, splitting, size estimate and characteristics
+   *          all delegate to this stepper
+   */
   def spliterator[B >: A]: Spliterator[B]^{this} = new AnyStepper.AnyStepperSpliterator(this)
 
+  /** Returns a Java [[java.util.Iterator]] over the remaining elements of this stepper.
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a Java `Iterator` whose `hasNext` and `next()` delegate to `hasStep` and `nextStep()`
+   */
   def javaIterator[B >: A]: JIterator[B]^{this} = new JIterator[B] {
     def hasNext: Boolean = hasStep
     def next(): B = nextStep()
@@ -208,27 +223,82 @@ trait AnyStepper[+A] extends Stepper[A] {
 }
 
 object AnyStepper {
+  /** A [[java.util.Spliterator]] backed by an [[AnyStepper]]; every operation delegates
+   *  to the underlying stepper.
+   *
+   *  @tparam A the element type
+   *  @param s the stepper providing the elements
+   */
   class AnyStepperSpliterator[A](s: AnyStepper[A]^) extends Spliterator[A] {
+    /** If the underlying stepper has another element, passes it to the given action
+     *  and advances past it.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     def tryAdvance(c: Consumer[? >: A]): Boolean =
       if (s.hasStep) { c.accept(s.nextStep()); true } else false
+    /** Splits the underlying stepper and returns a `Spliterator` over the split-off
+     *  elements, or `null` if the underlying stepper cannot be split.
+     */
     def trySplit(): Spliterator[A]^{this} | Null = {
       val sp = s.trySplit()
       if (sp == null) null else sp.spliterator
     }
+    /** Returns the size estimate of the underlying stepper. */
     def estimateSize(): Long = s.estimateSize
+    /** Returns the characteristics of the underlying stepper. */
     def characteristics(): Int = s.characteristics
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper,
+     *  implemented directly with `hasStep` and `nextStep()` for efficiency.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: Consumer[? >: A]): Unit =
       while (s.hasStep) { c.accept(s.nextStep()) }
   }
 
+  /** Returns an `AnyStepper[Double]` that boxes the elements of the given `DoubleStepper`.
+   *
+   *  @param st the primitive stepper to wrap
+   *  @return a stepper yielding the same elements as `st`, boxed
+   */
   def ofSeqDoubleStepper(st: DoubleStepper): AnyStepper[Double] = new BoxedDoubleStepper(st)
+  /** Returns an `AnyStepper[Double]` that boxes the elements of the given `DoubleStepper`,
+   *  retaining the [[Stepper.EfficientSplit]] marker.
+   *
+   *  @param st the primitive stepper to wrap, supporting efficient splitting
+   *  @return a stepper yielding the same elements as `st`, boxed, with `EfficientSplit`
+   */
   def ofParDoubleStepper(st: DoubleStepper & EfficientSplit): AnyStepper[Double] & EfficientSplit = new BoxedDoubleStepper(st) with EfficientSplit
 
+  /** Returns an `AnyStepper[Int]` that boxes the elements of the given `IntStepper`.
+   *
+   *  @param st the primitive stepper to wrap
+   *  @return a stepper yielding the same elements as `st`, boxed
+   */
   def ofSeqIntStepper(st: IntStepper): AnyStepper[Int] = new BoxedIntStepper(st)
+  /** Returns an `AnyStepper[Int]` that boxes the elements of the given `IntStepper`,
+   *  retaining the [[Stepper.EfficientSplit]] marker.
+   *
+   *  @param st the primitive stepper to wrap, supporting efficient splitting
+   *  @return a stepper yielding the same elements as `st`, boxed, with `EfficientSplit`
+   */
   def ofParIntStepper(st: IntStepper & EfficientSplit): AnyStepper[Int] & EfficientSplit = new BoxedIntStepper(st) with EfficientSplit
 
+  /** Returns an `AnyStepper[Long]` that boxes the elements of the given `LongStepper`.
+   *
+   *  @param st the primitive stepper to wrap
+   *  @return a stepper yielding the same elements as `st`, boxed
+   */
   def ofSeqLongStepper(st: LongStepper): AnyStepper[Long] = new BoxedLongStepper(st)
+  /** Returns an `AnyStepper[Long]` that boxes the elements of the given `LongStepper`,
+   *  retaining the [[Stepper.EfficientSplit]] marker.
+   *
+   *  @param st the primitive stepper to wrap, supporting efficient splitting
+   *  @return a stepper yielding the same elements as `st`, boxed, with `EfficientSplit`
+   */
   def ofParLongStepper(st: LongStepper & EfficientSplit): AnyStepper[Long] & EfficientSplit = new BoxedLongStepper(st) with EfficientSplit
 
   private[collection] class BoxedDoubleStepper(st: DoubleStepper) extends AnyStepper[Double] {
@@ -267,35 +337,85 @@ object AnyStepper {
 
 /** A `Stepper` for `Int`s. See [[Stepper]]. */
 trait IntStepper extends Stepper[Int] {
+  /** Splits this stepper, if applicable. See [[Stepper.trySplit]].
+   *
+   *  @return a new `IntStepper` containing a portion of the elements, or `null` if this stepper cannot be split
+   */
   def trySplit(): IntStepper^{this} | Null
 
+  /** Returns a primitive [[java.util.Spliterator.OfInt]] over the remaining elements of
+   *  this stepper, which yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Int`; never used, the result is always a `Spliterator.OfInt`
+   *  @return a `Spliterator.OfInt` whose operations delegate to this stepper
+   */
   def spliterator[B >: Int]: Spliterator.OfInt^{this} = new IntStepper.IntStepperSpliterator(this)
 
+  /** Returns a primitive [[java.util.PrimitiveIterator.OfInt]] over the remaining elements
+   *  of this stepper, whose `nextInt()` yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Int`; never used, the result is always a `PrimitiveIterator.OfInt`
+   *  @return a `PrimitiveIterator.OfInt` whose `hasNext` and `nextInt()` delegate to `hasStep` and `nextStep()`
+   */
   def javaIterator[B >: Int]: PrimitiveIterator.OfInt^{this} = new PrimitiveIterator.OfInt {
     def hasNext: Boolean = hasStep
     def nextInt(): Int = nextStep()
   }
 }
 object IntStepper {
+  /** A primitive [[java.util.Spliterator.OfInt]] backed by an [[IntStepper]]; every
+   *  operation delegates to the underlying stepper.
+   *
+   *  @param s the stepper providing the elements
+   */
   class IntStepperSpliterator(s: IntStepper^) extends Spliterator.OfInt {
+    /** If the underlying stepper has another element, passes it to the given action
+     *  without boxing and advances past it.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     def tryAdvance(c: IntConsumer): Boolean =
       if (s.hasStep) { c.accept(s.nextStep()); true } else false
     // Override for efficiency: don't wrap the function and call the `tryAdvance` overload
+    /** If the underlying stepper has another element, passes it to the given action
+     *  and advances past it. If `c` is an `IntConsumer`, the element is passed without
+     *  boxing; otherwise it is boxed to `java.lang.Integer`.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     override def tryAdvance(c: Consumer[? >: jl.Integer]): Boolean = (c: AnyRef) match {
       case ic: IntConsumer => tryAdvance(ic)
       case _ => if (s.hasStep) { c.accept(jl.Integer.valueOf(s.nextStep())); true } else false
     }
     // override required for dotty#6152
+    /** Splits the underlying stepper and returns a `Spliterator.OfInt` over the split-off
+     *  elements, or `null` if the underlying stepper cannot be split.
+     */
     override def trySplit(): Spliterator.OfInt^{this} | Null = {
       val sp = s.trySplit()
       if (sp == null) null else sp.spliterator
     }
+    /** Returns the size estimate of the underlying stepper. */
     def estimateSize(): Long = s.estimateSize
+    /** Returns the characteristics of the underlying stepper. */
     def characteristics(): Int = s.characteristics
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper
+     *  without boxing, implemented directly with `hasStep` and `nextStep()` for efficiency.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: IntConsumer): Unit =
       while (s.hasStep) { c.accept(s.nextStep()) }
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper.
+     *  If `c` is an `IntConsumer`, the elements are passed without boxing; otherwise
+     *  each element is boxed to `java.lang.Integer`.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: Consumer[? >: jl.Integer]): Unit = (c: AnyRef) match {
       case ic: IntConsumer => forEachRemaining(ic)
       case _ => while (s.hasStep) { c.accept(jl.Integer.valueOf(s.nextStep())) }
@@ -305,10 +425,26 @@ object IntStepper {
 
 /** A `Stepper` for `Double`s. See [[Stepper]]. */
 trait DoubleStepper extends Stepper[Double] {
+  /** Splits this stepper, if applicable. See [[Stepper.trySplit]].
+   *
+   *  @return a new `DoubleStepper` containing a portion of the elements, or `null` if this stepper cannot be split
+   */
   def trySplit(): DoubleStepper^{this} | Null
 
+  /** Returns a primitive [[java.util.Spliterator.OfDouble]] over the remaining elements of
+   *  this stepper, which yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Double`; never used, the result is always a `Spliterator.OfDouble`
+   *  @return a `Spliterator.OfDouble` whose operations delegate to this stepper
+   */
   def spliterator[B >: Double]: Spliterator.OfDouble^{this} = new DoubleStepper.DoubleStepperSpliterator(this)
 
+  /** Returns a primitive [[java.util.PrimitiveIterator.OfDouble]] over the remaining elements
+   *  of this stepper, whose `nextDouble()` yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Double`; never used, the result is always a `PrimitiveIterator.OfDouble`
+   *  @return a `PrimitiveIterator.OfDouble` whose `hasNext` and `nextDouble()` delegate to `hasStep` and `nextStep()`
+   */
   def javaIterator[B >: Double]: PrimitiveIterator.OfDouble^{this} = new PrimitiveIterator.OfDouble {
     def hasNext: Boolean = hasStep
     def nextDouble(): Double = nextStep()
@@ -316,25 +452,59 @@ trait DoubleStepper extends Stepper[Double] {
 }
 
 object DoubleStepper {
+  /** A primitive [[java.util.Spliterator.OfDouble]] backed by a [[DoubleStepper]]; every
+   *  operation delegates to the underlying stepper.
+   *
+   *  @param s the stepper providing the elements
+   */
   class DoubleStepperSpliterator(s: DoubleStepper^) extends Spliterator.OfDouble {
+    /** If the underlying stepper has another element, passes it to the given action
+     *  without boxing and advances past it.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     def tryAdvance(c: DoubleConsumer): Boolean =
       if (s.hasStep) { c.accept(s.nextStep()); true } else false
     // Override for efficiency: don't wrap the function and call the `tryAdvance` overload
+    /** If the underlying stepper has another element, passes it to the given action
+     *  and advances past it. If `c` is a `DoubleConsumer`, the element is passed without
+     *  boxing; otherwise it is boxed to `java.lang.Double`.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     override def tryAdvance(c: Consumer[? >: jl.Double]): Boolean = (c: AnyRef) match {
       case ic: DoubleConsumer => tryAdvance(ic)
       case _ => if (s.hasStep) { c.accept(java.lang.Double.valueOf(s.nextStep())); true } else false
     }
     // override required for dotty#6152
+    /** Splits the underlying stepper and returns a `Spliterator.OfDouble` over the split-off
+     *  elements, or `null` if the underlying stepper cannot be split.
+     */
     override def trySplit(): Spliterator.OfDouble^{this} | Null = {
       val sp = s.trySplit()
       if (sp == null) null else sp.spliterator
     }
+    /** Returns the size estimate of the underlying stepper. */
     def estimateSize(): Long = s.estimateSize
+    /** Returns the characteristics of the underlying stepper. */
     def characteristics(): Int = s.characteristics
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper
+     *  without boxing, implemented directly with `hasStep` and `nextStep()` for efficiency.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: DoubleConsumer): Unit =
       while (s.hasStep) { c.accept(s.nextStep()) }
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper.
+     *  If `c` is a `DoubleConsumer`, the elements are passed without boxing; otherwise
+     *  each element is boxed to `java.lang.Double`.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: Consumer[? >: jl.Double]): Unit = (c: AnyRef) match {
       case ic: DoubleConsumer => forEachRemaining(ic)
       case _ => while (s.hasStep) { c.accept(jl.Double.valueOf(s.nextStep())) }
@@ -344,10 +514,26 @@ object DoubleStepper {
 
 /** A `Stepper` for `Long`s. See [[Stepper]]. */
 trait LongStepper extends Stepper[Long] {
+  /** Splits this stepper, if applicable. See [[Stepper.trySplit]].
+   *
+   *  @return a new `LongStepper` containing a portion of the elements, or `null` if this stepper cannot be split
+   */
   def trySplit(): LongStepper^{this} | Null
 
+  /** Returns a primitive [[java.util.Spliterator.OfLong]] over the remaining elements of
+   *  this stepper, which yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Long`; never used, the result is always a `Spliterator.OfLong`
+   *  @return a `Spliterator.OfLong` whose operations delegate to this stepper
+   */
   def spliterator[B >: Long]: Spliterator.OfLong^{this} = new LongStepper.LongStepperSpliterator(this)
 
+  /** Returns a primitive [[java.util.PrimitiveIterator.OfLong]] over the remaining elements
+   *  of this stepper, whose `nextLong()` yields the elements without boxing.
+   *
+   *  @tparam B a supertype of `Long`; never used, the result is always a `PrimitiveIterator.OfLong`
+   *  @return a `PrimitiveIterator.OfLong` whose `hasNext` and `nextLong()` delegate to `hasStep` and `nextStep()`
+   */
   def javaIterator[B >: Long]: PrimitiveIterator.OfLong^{this} = new PrimitiveIterator.OfLong {
     def hasNext: Boolean = hasStep
     def nextLong(): Long = nextStep()
@@ -355,25 +541,59 @@ trait LongStepper extends Stepper[Long] {
 }
 
 object LongStepper {
+  /** A primitive [[java.util.Spliterator.OfLong]] backed by a [[LongStepper]]; every
+   *  operation delegates to the underlying stepper.
+   *
+   *  @param s the stepper providing the elements
+   */
   class LongStepperSpliterator(s: LongStepper^) extends Spliterator.OfLong {
+    /** If the underlying stepper has another element, passes it to the given action
+     *  without boxing and advances past it.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     def tryAdvance(c: LongConsumer): Boolean =
       if (s.hasStep) { c.accept(s.nextStep()); true } else false
     // Override for efficiency: don't wrap the function and call the `tryAdvance` overload
+    /** If the underlying stepper has another element, passes it to the given action
+     *  and advances past it. If `c` is a `LongConsumer`, the element is passed without
+     *  boxing; otherwise it is boxed to `java.lang.Long`.
+     *
+     *  @param c the action to perform on the next element
+     *  @return `true` if an element existed and `c` was applied to it, `false` otherwise
+     */
     override def tryAdvance(c: Consumer[? >: jl.Long]): Boolean = (c: AnyRef) match {
       case ic: LongConsumer => tryAdvance(ic)
       case _ => if (s.hasStep) { c.accept(java.lang.Long.valueOf(s.nextStep())); true } else false
     }
     // override required for dotty#6152
+    /** Splits the underlying stepper and returns a `Spliterator.OfLong` over the split-off
+     *  elements, or `null` if the underlying stepper cannot be split.
+     */
     override def trySplit(): Spliterator.OfLong^{this} | Null = {
       val sp = s.trySplit()
       if (sp == null) null else sp.spliterator
     }
+    /** Returns the size estimate of the underlying stepper. */
     def estimateSize(): Long = s.estimateSize
+    /** Returns the characteristics of the underlying stepper. */
     def characteristics(): Int = s.characteristics
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper
+     *  without boxing, implemented directly with `hasStep` and `nextStep()` for efficiency.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: LongConsumer): Unit =
       while (s.hasStep) { c.accept(s.nextStep()) }
     // Override for efficiency: implement with hasStep / nextStep instead of tryAdvance
+    /** Applies the given action to each remaining element of the underlying stepper.
+     *  If `c` is a `LongConsumer`, the elements are passed without boxing; otherwise
+     *  each element is boxed to `java.lang.Long`.
+     *
+     *  @param c the action to perform on each remaining element
+     */
     override def forEachRemaining(c: Consumer[? >: jl.Long]): Unit = (c: AnyRef) match {
       case ic: LongConsumer => forEachRemaining(ic)
       case _ => while (s.hasStep) { c.accept(jl.Long.valueOf(s.nextStep())) }

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -47,79 +47,168 @@ sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
 }
 
 object StepperShape extends StepperShapeLowPriority1 {
+  /** A value class enumerating the possible shapes of a [[StepperShape]]. The values are
+   *  the constants defined in this companion object, [[ReferenceShape]] through [[FloatShape]].
+   */
   class Shape private[StepperShape] (private val s: Int) extends AnyVal
 
   // reference
+  /** The shape for reference (boxed) element types, stepped over with an [[AnyStepper]]. */
   val ReferenceShape = new Shape(0)
 
   // primitive
+  /** The shape for `Int` elements, stepped over with an [[IntStepper]]. */
   val IntShape    = new Shape(1)
+  /** The shape for `Long` elements, stepped over with a [[LongStepper]]. */
   val LongShape   = new Shape(2)
+  /** The shape for `Double` elements, stepped over with a [[DoubleStepper]]. */
   val DoubleShape = new Shape(3)
 
   // widening
+  /** The shape for `Byte` elements, widened to `Int` and stepped over with an [[IntStepper]]. */
   val ByteShape  = new Shape(4)
+  /** The shape for `Short` elements, widened to `Int` and stepped over with an [[IntStepper]]. */
   val ShortShape = new Shape(5)
+  /** The shape for `Char` elements, widened to `Int` and stepped over with an [[IntStepper]]. */
   val CharShape  = new Shape(6)
+  /** The shape for `Float` elements, widened to `Double` and stepped over with a [[DoubleStepper]]. */
   val FloatShape = new Shape(7)
 
+  /** The `StepperShape` for `Int` elements, selecting [[IntStepper]]. */
   implicit val intStepperShape: StepperShape[Int, IntStepper] = new StepperShape[Int, IntStepper] {
     def shape = IntShape
     def seqUnbox(st: AnyStepper[Int]^): IntStepper^{st} = new Stepper.UnboxingIntStepper(st)
     def parUnbox(st: (AnyStepper[Int] & EfficientSplit)^): (IntStepper & EfficientSplit)^{st} = new Stepper.UnboxingIntStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Integer` elements, selecting [[IntStepper]]; the same
+   *  instance as [[intStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jIntegerStepperShape: StepperShape[jl.Integer, IntStepper] = intStepperShape.asInstanceOf[StepperShape[jl.Integer, IntStepper]]
 
+  /** The `StepperShape` for `Long` elements, selecting [[LongStepper]]. */
   implicit val longStepperShape: StepperShape[Long, LongStepper] = new StepperShape[Long, LongStepper] {
     def shape = LongShape
     def seqUnbox(st: AnyStepper[Long]^): LongStepper^{st} = new Stepper.UnboxingLongStepper(st)
     def parUnbox(st: (AnyStepper[Long] & EfficientSplit)^): (LongStepper & EfficientSplit)^{st} = new Stepper.UnboxingLongStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Long` elements, selecting [[LongStepper]]; the same
+   *  instance as [[longStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jLongStepperShape: StepperShape[jl.Long, LongStepper] = longStepperShape.asInstanceOf[StepperShape[jl.Long, LongStepper]]
 
+  /** The `StepperShape` for `Double` elements, selecting [[DoubleStepper]]. */
   implicit val doubleStepperShape: StepperShape[Double, DoubleStepper] = new StepperShape[Double, DoubleStepper] {
     def shape = DoubleShape
     def seqUnbox(st: AnyStepper[Double]^): DoubleStepper^{st} = new Stepper.UnboxingDoubleStepper(st)
     def parUnbox(st: (AnyStepper[Double] & EfficientSplit)^): (DoubleStepper & EfficientSplit)^{st} = new Stepper.UnboxingDoubleStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Double` elements, selecting [[DoubleStepper]]; the same
+   *  instance as [[doubleStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jDoubleStepperShape: StepperShape[jl.Double, DoubleStepper] = doubleStepperShape.asInstanceOf[StepperShape[jl.Double, DoubleStepper]]
 
+  /** The `StepperShape` for `Byte` elements, selecting [[IntStepper]]; the elements are
+   *  widened to `Int`.
+   */
   implicit val byteStepperShape: StepperShape[Byte, IntStepper] = new StepperShape[Byte, IntStepper] {
     def shape = ByteShape
     def seqUnbox(st: AnyStepper[Byte]^): IntStepper^{st} = new Stepper.UnboxingByteStepper(st)
     def parUnbox(st: (AnyStepper[Byte] & EfficientSplit)^): (IntStepper & EfficientSplit)^{st} = new Stepper.UnboxingByteStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Byte` elements, selecting [[IntStepper]]; the same
+   *  instance as [[byteStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jByteStepperShape: StepperShape[jl.Byte, IntStepper] = byteStepperShape.asInstanceOf[StepperShape[jl.Byte, IntStepper]]
 
+  /** The `StepperShape` for `Short` elements, selecting [[IntStepper]]; the elements are
+   *  widened to `Int`.
+   */
   implicit val shortStepperShape: StepperShape[Short, IntStepper] = new StepperShape[Short, IntStepper] {
     def shape = ShortShape
     def seqUnbox(st: AnyStepper[Short]^): IntStepper^{st} = new Stepper.UnboxingShortStepper(st)
     def parUnbox(st: (AnyStepper[Short] & EfficientSplit)^): (IntStepper & EfficientSplit)^{st} = new Stepper.UnboxingShortStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Short` elements, selecting [[IntStepper]]; the same
+   *  instance as [[shortStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jShortStepperShape: StepperShape[jl.Short, IntStepper] = shortStepperShape.asInstanceOf[StepperShape[jl.Short, IntStepper]]
 
+  /** The `StepperShape` for `Char` elements, selecting [[IntStepper]]; the elements are
+   *  widened to `Int`.
+   */
   implicit val charStepperShape: StepperShape[Char, IntStepper] = new StepperShape[Char, IntStepper] {
     def shape = CharShape
     def seqUnbox(st: AnyStepper[Char]^): IntStepper^{st} = new Stepper.UnboxingCharStepper(st)
     def parUnbox(st: (AnyStepper[Char] & EfficientSplit)^): (IntStepper & EfficientSplit)^{st} = new Stepper.UnboxingCharStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Character` elements, selecting [[IntStepper]]; the same
+   *  instance as [[charStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jCharacterStepperShape: StepperShape[jl.Character, IntStepper] = charStepperShape.asInstanceOf[StepperShape[jl.Character, IntStepper]]
 
+  /** The `StepperShape` for `Float` elements, selecting [[DoubleStepper]]; the elements are
+   *  widened to `Double`.
+   */
   implicit val floatStepperShape: StepperShape[Float, DoubleStepper] = new StepperShape[Float, DoubleStepper] {
     def shape = FloatShape
     def seqUnbox(st: AnyStepper[Float]^): DoubleStepper^{st} = new Stepper.UnboxingFloatStepper(st)
     def parUnbox(st: (AnyStepper[Float] & EfficientSplit)^): (DoubleStepper & EfficientSplit)^{st} = new Stepper.UnboxingFloatStepper(st) with EfficientSplit
   }
+  /** The `StepperShape` for `java.lang.Float` elements, selecting [[DoubleStepper]]; the same
+   *  instance as [[floatStepperShape]].
+   *
+   *  The stepper it selects unboxes each element, so a `null` element throws a
+   *  `NullPointerException` when it is stepped over.
+   */
   implicit val jFloatStepperShape: StepperShape[jl.Float, DoubleStepper] = floatStepperShape.asInstanceOf[StepperShape[jl.Float, DoubleStepper]]
 }
 
+/** Low-priority implicit `StepperShape` instances, tried after the specialized primitive
+ *  instances defined in the [[StepperShape]] companion object.
+ */
 trait StepperShapeLowPriority1 extends StepperShapeLowPriority2 {
+  /** Returns the `StepperShape` for an arbitrary element type `T`, selecting `AnyStepper[T]`
+   *  with [[StepperShape.ReferenceShape]].
+   *
+   *  @tparam T the element type
+   *  @return the reference-shape instance [[StepperShapeLowPriority2.anyStepperShapePrototype]], cast to `StepperShape[T, AnyStepper[T]]`
+   */
   implicit def anyStepperShape[T]: StepperShape[T, AnyStepper[T]] = anyStepperShapePrototype.asInstanceOf[StepperShape[T, AnyStepper[T]]]
 }
 
+/** Lowest-priority implicit `StepperShape` instances, tried after those in
+ *  [[StepperShapeLowPriority1]].
+ */
 trait StepperShapeLowPriority2 {
+  /** Returns the `StepperShape` for an arbitrary element type `T`, selecting the base type
+   *  `Stepper[T]` with [[StepperShape.ReferenceShape]].
+   *
+   *  @tparam T the element type
+   *  @return the reference-shape instance [[anyStepperShapePrototype]], cast to `StepperShape[T, Stepper[T]]`
+   */
   implicit def baseStepperShape[T]: StepperShape[T, Stepper[T]] = anyStepperShapePrototype.asInstanceOf[StepperShape[T, Stepper[T]]]
 
+  /** The single reference-shape instance underlying [[anyStepperShape]] and
+   *  [[baseStepperShape]]; its `seqUnbox` and `parUnbox` return the given stepper unchanged.
+   */
   protected val anyStepperShapePrototype: StepperShape[AnyRef, Stepper[AnyRef]] = new StepperShape[AnyRef, Stepper[AnyRef]] {
     def shape = StepperShape.ReferenceShape
     def seqUnbox(st: AnyStepper[AnyRef]^): Stepper[AnyRef]^{st} = st

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -31,12 +31,33 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     with IterableOps[A, CC, C] {
 
   // Optimized, push-based version of `partition`
+  /** Returns a pair holding, first, all elements that satisfy predicate `p` and,
+   *  second, all elements that do not.
+   *
+   *  Overrides the default implementation to build both results with strict
+   *  builders in a single traversal of this collection, instead of one
+   *  traversal each for `filter` and `filterNot`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of collections: the first containing all elements that
+   *          satisfy `p`, the second containing those that do not
+   */
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder
     iterator.foreach(x => (if (p(x)) l else r) += x)
     (l.result(), r.result())
   }
 
+  /** Splits this collection into a prefix/suffix pair according to a predicate.
+   *
+   *  Overrides the default implementation to build both results with strict
+   *  builders in a single traversal of this collection, instead of one
+   *  traversal each for `takeWhile` and `dropWhile`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair consisting of the longest prefix of this collection whose
+   *          elements all satisfy `p`, and the rest of this collection
+   */
   override def span(p: A => Boolean): (C, C) = {
     val first = newSpecificBuilder
     val second = newSpecificBuilder
@@ -57,6 +78,18 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     (first.result(), second.result())
   }
 
+  /** Converts this collection of pairs into two collections of the first and
+   *  second half of each pair.
+   *
+   *  Overrides the default implementation to fill two strict builders in a
+   *  single traversal of this collection.
+   *
+   *  @tparam A1 the type of the first half of the element pairs
+   *  @tparam A2 the type of the second half of the element pairs
+   *  @param asPair evidence that this collection's element type is a pair `(A1, A2)`
+   *  @return a pair of collections containing, respectively, the first and
+   *          second half of each element pair of this collection
+   */
   override def unzip[A1, A2](implicit asPair: A -> (A1, A2)): (CC[A1], CC[A2]) = {
     val first = iterableFactory.newBuilder[A1]
     val second = iterableFactory.newBuilder[A2]
@@ -68,6 +101,19 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     (first.result(), second.result())
   }
 
+  /** Converts this collection of triples into three collections of the first,
+   *  second, and third element of each triple.
+   *
+   *  Overrides the default implementation to fill three strict builders in a
+   *  single traversal of this collection.
+   *
+   *  @tparam A1 the type of the first member of the element triples
+   *  @tparam A2 the type of the second member of the element triples
+   *  @tparam A3 the type of the third member of the element triples
+   *  @param asTriple evidence that this collection's element type is a triple `(A1, A2, A3)`
+   *  @return a triple of collections containing, respectively, the first,
+   *          second, and third member of each element triple of this collection
+   */
   override def unzip3[A1, A2, A3](implicit asTriple: A -> (A1, A2, A3)): (CC[A1], CC[A2], CC[A3]) = {
     val b1 = iterableFactory.newBuilder[A1]
     val b2 = iterableFactory.newBuilder[A2]
@@ -86,6 +132,17 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   // the view-based implementations, but they turn out to be slightly faster because
   // a couple of indirection levels are removed
 
+  /** Builds a new collection by applying a function to all elements of this
+   *  collection.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param f the function to apply to each element
+   *  @return a new collection containing the results of applying `f` to every
+   *          element of this collection
+   */
   override def map[B](f: A => B): CC[B] =
     strictOptimizedMap(iterableFactory.newBuilder, f)
 
@@ -104,6 +161,17 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Builds a new collection by applying a function to all elements of this
+   *  collection and concatenating the results.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param f the function to apply to each element
+   *  @return a new collection containing the concatenated results of applying
+   *          `f` to every element of this collection
+   */
   override def flatMap[B](f: A => IterableOnce[B]^): CC[B] =
     strictOptimizedFlatMap(iterableFactory.newBuilder, f)
 
@@ -135,6 +203,18 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Builds a new collection by applying a partial function to all elements of
+   *  this collection on which the function is defined.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, using a single `applyOrElse` call per element to test
+   *  definedness and transform the element at the same time.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param pf the partial function to apply to each element
+   *  @return a new collection containing the results of applying `pf` to every
+   *          element of this collection on which it is defined
+   */
   override def collect[B](pf: PartialFunction[A, B]^): CC[B] =
     strictOptimizedCollect(iterableFactory.newBuilder, pf)
 
@@ -156,6 +236,18 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Converts this collection of collections into a collection formed by the
+   *  elements of the nested collections.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the nested collections
+   *  @param toIterableOnce evidence that this collection's element type can be
+   *                        seen as an `IterableOnce[B]`
+   *  @return a new collection containing the concatenated elements of the
+   *          nested collections, in order
+   */
   override def flatten[B](implicit toIterableOnce: A -> IterableOnce[B]): CC[B] =
     strictOptimizedFlatten(iterableFactory.newBuilder)
 
@@ -174,6 +266,20 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Returns a new collection of pairs formed from this collection and another
+   *  iterable collection by combining corresponding elements.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster. As with the default implementation,
+   *  if one of the two collections is longer than the other, its remaining
+   *  elements are ignored.
+   *
+   *  @tparam B the type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
+   *  @return a new collection containing pairs consisting of corresponding
+   *          elements of this collection and `that`, whose length is the
+   *          minimum of the lengths of the two collections
+   */
   override def zip[B](that: IterableOnce[B]^): CC[(A @uncheckedVariance, B)] =
     strictOptimizedZip(that, iterableFactory.newBuilder[(A, B)])
 
@@ -193,6 +299,10 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Returns a collection of pairs of each element of this collection with its index,
+   *  counting from 0, filling a strict builder in a single traversal instead of going
+   *  through a view.
+   */
   override def zipWithIndex: CC[(A @uncheckedVariance, Int)] = {
     val b = iterableFactory.newBuilder[(A, Int)]
     var i = 0
@@ -204,6 +314,20 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Produces a collection containing the cumulative results of applying the
+   *  operator going left to right, including the initial value.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param z the initial value
+   *  @param op the binary operator applied to the intermediate result and the element
+   *  @return a new collection containing the intermediate results of inserting
+   *          `op` between consecutive elements of this collection, going left
+   *          to right with the start value `z` on the left, so one element
+   *          longer than this collection
+   */
   override def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b.sizeHint(this, delta = 0)
@@ -217,10 +341,39 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  /** Selects all elements of this collection that satisfy a predicate.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, via [[filterImpl]].
+   *
+   *  @param pred the predicate used to test elements
+   *  @return a new collection containing all elements of this collection that
+   *          satisfy `pred`, in the order they appear in this collection
+   */
   override def filter(pred: A => Boolean): C = filterImpl(pred, isFlipped = false)
 
+  /** Selects all elements of this collection that do not satisfy a predicate.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, via [[filterImpl]].
+   *
+   *  @param pred the predicate used to test elements
+   *  @return a new collection containing all elements of this collection that
+   *          do not satisfy `pred`, in the order they appear in this collection
+   */
   override def filterNot(pred: A => Boolean): C = filterImpl(pred, isFlipped = true)
 
+  /** Shared strict implementation of [[filter]] and [[filterNot]]: builds a
+   *  new collection from the elements whose `pred` result differs from
+   *  `isFlipped`.
+   *
+   *  @param pred the predicate used to test elements
+   *  @param isFlipped if `false`, keeps the elements that satisfy `pred`
+   *                   (`filter`); if `true`, keeps those that do not
+   *                   (`filterNot`)
+   *  @return a new collection containing the selected elements, in the order
+   *          they appear in this collection
+   */
   protected[collection] def filterImpl(pred: A => Boolean, isFlipped: Boolean): C = {
     val b = newSpecificBuilder
     val it = iterator
@@ -234,6 +387,19 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   }
 
   // Optimized, push-based version of `partitionMap`
+  /** Applies a function returning an `Either` to each element of this
+   *  collection and collects the `Left` and `Right` results into two separate
+   *  collections.
+   *
+   *  Overrides the default implementation to fill two strict builders in a
+   *  single traversal of this collection, applying `f` once per element.
+   *
+   *  @tparam A1 the element type of the first resulting collection
+   *  @tparam A2 the element type of the second resulting collection
+   *  @param f the function mapping each element to a `Left(_)` or a `Right(_)`
+   *  @return a pair of collections: the first containing the values wrapped in
+   *          `Left`, the second containing the values wrapped in `Right`
+   */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
     val l = iterableFactory.newBuilder[A1]
     val r = iterableFactory.newBuilder[A2]
@@ -247,6 +413,17 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   }
 
   // Optimization avoids creation of second collection
+  /** Applies a side-effecting function to each element of this collection and
+   *  returns this collection itself.
+   *
+   *  Overrides the default implementation to call `f` eagerly on every element
+   *  and return this collection unchanged, instead of creating a second,
+   *  mapped collection.
+   *
+   *  @tparam U the return type of `f`, ignored
+   *  @param f the side-effecting function to apply to each element
+   *  @return this collection, unchanged
+   */
   override def tapEach[U](f: A => U): C^{this}  = {
     foreach(f)
     coll

--- a/library/src/scala/collection/StrictOptimizedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedMapOps.scala
@@ -26,18 +26,77 @@ transparent trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyCo
   extends MapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {
 
+  /** Builds a new map by applying a function to all entries of this map.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param f the function to apply to each entry
+   *  @return a new map resulting from applying `f` to each entry of this map
+   */
   override def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] =
     strictOptimizedMap(mapFactory.newBuilder, f)
 
+  /** Builds a new map by applying a function to all entries of this map and
+   *  concatenating the resulting collections of entries.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param f the function to apply to each entry
+   *  @return a new map resulting from applying `f` to each entry of this map
+   *          and adding all resulting entries
+   */
   override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^): CC[K2, V2] =
     strictOptimizedFlatMap(mapFactory.newBuilder, f)
 
+  /** Returns a new map containing the entries of this map followed by the
+   *  entries of `suffix`.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly. As with the default implementation, if a key occurs in both
+   *  maps, the entry from `suffix` wins.
+   *
+   *  @tparam V2 the value type of the returned map
+   *  @param suffix the entries to add
+   *  @return a new map containing all entries of this map and of `suffix`
+   */
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): CC[K, V2] =
     strictOptimizedConcat(suffix, mapFactory.newBuilder)
 
+  /** Builds a new map by applying a partial function to all entries of this
+   *  map on which the function is defined.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, using a single `applyOrElse` call per entry to test definedness
+   *  and transform the entry at the same time.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param pf the partial function to apply to each entry
+   *  @return a new map containing the results of applying `pf` to every entry
+   *          of this map on which it is defined
+   */
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^): CC[K2, V2] =
     strictOptimizedCollect(mapFactory.newBuilder, pf)
 
+  /** Returns a new map containing the entries of this map together with two or
+   *  more additional entries.
+   *
+   *  Overrides the default implementation to fill a strict builder directly.
+   *  As with the default implementation, a later entry for a key overrides an
+   *  earlier one.
+   *
+   *  @tparam V1 the value type of the returned map
+   *  @param elem1 the first entry to add
+   *  @param elem2 the second entry to add
+   *  @param elems the remaining entries to add
+   *  @return a new map containing all entries of this map plus the given entries
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = {
     val b = mapFactory.newBuilder[K, V1]

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -25,6 +25,19 @@ import language.experimental.captureChecking
 transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
   extends Any with SeqOps[A, CC, C] with StrictOptimizedIterableOps[A, CC, C] with caps.Pure {
 
+  /** Selects all the elements of this sequence ignoring duplicates as
+   *  determined by `==` after applying the transforming function `f`.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  in a single traversal, keeping the first of each group of elements on
+   *  which `f` agrees.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f the transforming function whose result is used to determine the
+   *           uniqueness of each element
+   *  @return a new sequence consisting of all the elements of this sequence
+   *          without duplicates
+   */
   override def distinctBy[B](f: A -> B): C = {
     val builder = newSpecificBuilder
     val seen = mutable.HashSet.empty[B]
@@ -36,6 +49,17 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
     builder.result()
   }
 
+  /** Returns a new sequence consisting of `elem` followed by the elements of
+   *  this sequence.
+   *
+   *  Overrides the default view-based implementation to fill a size-hinted
+   *  strict builder directly.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param elem the prepended element
+   *  @return a new sequence consisting of `elem` followed by all elements of
+   *          this sequence
+   */
   override def prepended[B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b.sizeHint(this, delta = 1)
@@ -44,6 +68,17 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Returns a new sequence consisting of the elements of this sequence
+   *  followed by `elem`.
+   *
+   *  Overrides the default view-based implementation to fill a size-hinted
+   *  strict builder directly.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param elem the appended element
+   *  @return a new sequence consisting of all elements of this sequence
+   *          followed by `elem`
+   */
   override def appended[B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b.sizeHint(this, delta = 1)
@@ -52,9 +87,31 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Returns a new sequence consisting of the elements of this sequence
+   *  followed by the elements of `suffix`.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param suffix the iterable to append
+   *  @return a new sequence consisting of all elements of this sequence
+   *          followed by all elements of `suffix`
+   */
   override def appendedAll[B >: A](suffix: IterableOnce[B]^): CC[B] =
     strictOptimizedConcat(suffix, iterableFactory.newBuilder)
 
+  /** Returns a new sequence consisting of the elements of `prefix` followed by
+   *  the elements of this sequence.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param prefix the iterable to prepend
+   *  @return a new sequence consisting of all elements of `prefix` followed by
+   *          all elements of this sequence
+   */
   override def prependedAll[B >: A](prefix: IterableOnce[B]^): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b ++= prefix
@@ -62,6 +119,20 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Returns a copy of this sequence padded at the end with `elem` up to
+   *  length `len`.
+   *
+   *  Overrides the default view-based implementation to fill a size-hinted
+   *  strict builder directly.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param len the target length of the returned sequence
+   *  @param elem the padding value
+   *  @return a new sequence consisting of all elements of this sequence
+   *          followed by the minimal number of occurrences of `elem` so that
+   *          the resulting sequence has length at least `len`; if this
+   *          sequence already has at least `len` elements, no padding is added
+   */
   override def padTo[B >: A](len: Int, elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     val L = size
@@ -75,6 +146,20 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Computes the multiset difference between this sequence and another
+   *  sequence.
+   *
+   *  Overrides the default implementation to fill a strict builder in a single
+   *  traversal of this sequence, using a map of occurrence counts of `that`.
+   *  If either sequence is empty, this sequence is returned as is, without
+   *  building a copy.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the sequence of elements to remove
+   *  @return a sequence containing all elements of this sequence except that
+   *          each occurrence of an element in `that` cancels out one
+   *          occurrence of an equal element of this sequence
+   */
   override def diff[B >: A](that: Seq[B]): C =
     if (isEmpty || that.isEmpty) coll
     else {
@@ -93,6 +178,21 @@ transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
       b.result()
     }
 
+  /** Computes the multiset intersection between this sequence and another
+   *  sequence.
+   *
+   *  Overrides the default implementation to fill a strict builder in a single
+   *  traversal of this sequence, using a map of occurrence counts of `that`.
+   *  If either sequence is empty, the empty sequence is returned directly,
+   *  without building.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the sequence of elements to intersect with
+   *  @return a sequence containing the elements of this sequence that also
+   *          occur in `that`, where each occurrence in `that` accounts for at
+   *          most one equal element of this sequence, in the order they appear
+   *          in this sequence
+   */
   override def intersect[B >: A](that: Seq[B]): C =
     if (isEmpty || that.isEmpty) empty
     else {

--- a/library/src/scala/collection/StrictOptimizedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSetOps.scala
@@ -25,6 +25,15 @@ transparent trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends SetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 
+  /** Returns a new set containing the elements of this set followed by the
+   *  elements of `that`.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @param that the elements to add
+   *  @return a new set containing all elements of this set and of `that`
+   */
   override def concat(that: IterableOnce[A]^): C =
     strictOptimizedConcat(that, newSpecificBuilder)
 

--- a/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -28,18 +28,82 @@ transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & So
   extends SortedMapOps[K, V, CC, C]
     with StrictOptimizedMapOps[K, V, Map, C] {
 
+  /** Builds a new sorted map by applying a function to all entries of this map.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param f the function to apply to each entry
+   *  @param ordering the ordering of the resulting map's keys
+   *  @return a new sorted map resulting from applying `f` to each entry of
+   *          this map
+   */
   override def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedMap(sortedMapFactory.newBuilder, f)
 
+  /** Builds a new sorted map by applying a function to all entries of this map
+   *  and concatenating the resulting collections of entries.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param f the function to apply to each entry
+   *  @param ordering the ordering of the resulting map's keys
+   *  @return a new sorted map resulting from applying `f` to each entry of
+   *          this map and adding all resulting entries
+   */
   override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^)(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedFlatMap(sortedMapFactory.newBuilder, f)
 
+  /** Returns a new sorted map containing the entries of this map followed by
+   *  the entries of `xs`, using this map's key ordering.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly. As with the default implementation, if a key occurs in both
+   *  maps, the entry from `xs` wins.
+   *
+   *  @tparam V2 the value type of the returned map
+   *  @param xs the entries to add
+   *  @return a new sorted map containing all entries of this map and of `xs`
+   */
   override def concat[V2 >: V](xs: IterableOnce[(K, V2)]^): CC[K, V2] =
     strictOptimizedConcat(xs, sortedMapFactory.newBuilder(using ordering))
 
+  /** Builds a new sorted map by applying a partial function to all entries of
+   *  this map on which the function is defined.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, using a single `applyOrElse` call per entry to test definedness
+   *  and transform the entry at the same time.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param pf the partial function to apply to each entry
+   *  @param ordering the ordering of the resulting map's keys
+   *  @return a new sorted map containing the results of applying `pf` to every
+   *          entry of this map on which it is defined
+   */
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^)(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedCollect(sortedMapFactory.newBuilder, pf)
 
+  /** Returns a new sorted map containing the entries of this map together with
+   *  two or more additional entries, using this map's key ordering.
+   *
+   *  Adds `elem1` and `elem2` with single-entry `+` calls, then concatenates
+   *  `elems` only if it is non-empty. A later entry for a key overrides an
+   *  earlier one.
+   *
+   *  @tparam V1 the value type of the returned map
+   *  @param elem1 the first entry to add
+   *  @param elem2 the second entry to add
+   *  @param elems the remaining entries to add
+   *  @return a new sorted map containing all entries of this map plus the
+   *          given entries
+   */
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = {
     val m = ((this + elem1).asInstanceOf[Map[K, V]] + elem2).asInstanceOf[CC[K, V1]]

--- a/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -29,15 +29,65 @@ transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: S
   extends SortedSetOps[A, CC, C]
     with StrictOptimizedSetOps[A, Set, C] {
 
+  /** Builds a new sorted set by applying a function to all elements of this
+   *  set.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering of the resulting set's elements
+   *  @return a new sorted set containing the results of applying `f` to every
+   *          element of this set
+   */
   override def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     strictOptimizedMap(sortedIterableFactory.newBuilder, f)
 
+  /** Builds a new sorted set by applying a function to all elements of this
+   *  set and concatenating the results.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, which is slightly faster.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering of the resulting set's elements
+   *  @return a new sorted set containing the concatenated results of applying
+   *          `f` to every element of this set
+   */
   override def flatMap[B](f: A => IterableOnce[B]^)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     strictOptimizedFlatMap(sortedIterableFactory.newBuilder, f)
 
+  /** Returns a new sorted set of pairs formed from this set and another
+   *  iterable collection by combining corresponding elements.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly. As with the default implementation, if one of the two
+   *  collections is longer than the other, its remaining elements are ignored.
+   *
+   *  @tparam B the type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
+   *  @param ev the ordering of the resulting set's pair elements
+   *  @return a new sorted set containing pairs consisting of corresponding
+   *          elements of this set and `that`
+   */
   override def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] =
     strictOptimizedZip(that, sortedIterableFactory.newBuilder[(A, B)])
 
+  /** Builds a new sorted set by applying a partial function to all elements of
+   *  this set on which the function is defined.
+   *
+   *  Overrides the default view-based implementation to fill a strict builder
+   *  directly, using a single `applyOrElse` call per element to test
+   *  definedness and transform the element at the same time.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param pf the partial function to apply to each element
+   *  @param ev the ordering of the resulting set's elements
+   *  @return a new sorted set containing the results of applying `pf` to every
+   *          element of this set on which it is defined
+   */
   override def collect[B](pf: PartialFunction[A, B]^)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     strictOptimizedCollect(sortedIterableFactory.newBuilder, pf)
 

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -196,10 +196,13 @@ object StringOps {
 final class StringOps(private val s: String) extends AnyVal { self =>
   import StringOps._
 
+  /** Returns a [[scala.collection.StringView]] over the chars of this string. */
   @inline def view: StringView = new StringView(s)
 
+  /** Returns the length of this string. */
   @inline def size: Int = s.length
 
+  /** Returns the length of this string, which is always known. */
   @inline def knownSize: Int = s.length
 
   /** Gets the char at the specified index.
@@ -209,12 +212,46 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    */
   @inline def apply(i: Int): Char = s.charAt(i)
 
+  /** Compares the length of this string to a test value.
+   *
+   *  @param otherSize the test value that gets compared with the length
+   *  @return a value `x` where
+   *  ```
+   *       x <  0       if this.length <  otherSize
+   *       x == 0       if this.length == otherSize
+   *       x >  0       if this.length >  otherSize
+   *  ```
+   */
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
 
+  /** Compares the length of this string to a test value.
+   *
+   *  @param len the test value that gets compared with the length
+   *  @return a value `x` where
+   *  ```
+   *       x <  0       if this.length <  len
+   *       x == 0       if this.length == len
+   *       x >  0       if this.length >  len
+   *  ```
+   */
   def lengthCompare(len: Int): Int = Integer.compare(s.length, len)
 
+  /** Returns the length of this string.
+   *
+   *  On general collections, `sizeIs` supports comparing the size to a test
+   *  value without computing the full size; a string always knows its length,
+   *  so this simply returns it, and the comparison operators of `Int` provide
+   *  the same syntax.
+   */
   def sizeIs: Int = s.length
 
+  /** Returns the length of this string.
+   *
+   *  On general collections, `lengthIs` supports comparing the length to a
+   *  test value without computing the full length; a string always knows its
+   *  length, so this simply returns it, and the comparison operators of `Int`
+   *  provide the same syntax.
+   */
   def lengthIs: Int = s.length
 
   /** Builds a new collection by applying a function to all chars of this string.
@@ -967,6 +1004,19 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     }
   }
 
+  /** Splits this string around occurrences of any of the separator characters.
+   *
+   *  Builds a regular expression character class from the (escaped) separator
+   *  characters and calls `String.split` with it, so, as described there,
+   *  trailing empty substrings are not included in the result.
+   *
+   *  @param separators the characters used as delimiters
+   *  @return an array of strings computed by splitting this string around
+   *          occurrences of any of the separator characters
+   *  @throws java.util.regex.PatternSyntaxException if the character class
+   *          built from `separators` is not a valid regular expression, for
+   *          example when `separators` is empty
+   */
   @throws(classOf[java.util.regex.PatternSyntaxException])
   def split(separators: Array[Char]): Array[String] = {
     val re = separators.foldLeft("[")(_+escape(_)) + "]"
@@ -1097,6 +1147,14 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     else if (s.equalsIgnoreCase("false")) false
     else throw new IllegalArgumentException("For input string: \""+s+"\"")
 
+  /** Returns a new array containing the chars of this string.
+   *
+   *  @tparam B the element type of the returned array
+   *  @param tag the class tag for the element type `B`, required to create the
+   *             result array; when it is `ClassTag.Char`, the result is a
+   *             plain `char` array
+   *  @return a new array of length `this.length` containing the chars of this string
+   */
   def toArray[B >: Char](implicit tag: ClassTag[B]): Array[B] =
     if (tag == ClassTag.Char) s.toCharArray.asInstanceOf[Array[B]]
     else new WrappedString(s).toArray[B]
@@ -1142,6 +1200,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def formatLocal(l: java.util.Locale, args: Any*): String =
     java.lang.String.format(l, s, args.map(unwrapArg)*)
 
+  /** Compares this string to `that` lexicographically by char values, as
+   *  `String.compareTo`.
+   *
+   *  @param that the string to compare against
+   *  @return a negative value if this string sorts before `that`, a positive
+   *          value if it sorts after, and `0` if the two strings are equal
+   */
   def compare(that: String): Int = s.compareTo(that)
 
   /** Returns true if `this` is less than `that`.
@@ -1836,12 +1901,23 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def permutations: Iterator[String] = new WrappedString(s).permutations.map(_.unwrap)
 }
 
+/** An indexed view over the chars of a string.
+ *
+ *  @param s the underlying string
+ */
 final case class StringView(s: String) extends AbstractIndexedSeqView[Char] {
+  /** Returns the length of the underlying string. */
   def length = s.length
+  /** Returns the char of the underlying string at index `n`.
+   *
+   *  @param n the index of the char to return
+   */
   @throws[StringIndexOutOfBoundsException]
   def apply(n: Int) = s.charAt(n)
+  /** Returns a string of the form `StringView(...)` containing the underlying string. */
   override def toString(): String = s"StringView($s)"
 }
 
 object StringView extends scala.runtime.AbstractFunction1[String, StringView]:
+  /** Returns the string `"StringView"`. */
   override def toString(): String = "StringView"

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -31,14 +31,22 @@ import caps.unsafe.unsafeAssumePure
  */
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with IterableFactoryDefaults[A, View] with Serializable {
 
+  /** Returns this view unchanged: a view is already a view. */
   override def view: View[A]^{this} = this
 
+  /** Returns the companion object `View`, used as the factory for views of any element type. */
   override def iterableFactory: IterableFactory[View] = View
 
+  /** Returns an empty view. */
   override def empty: scala.collection.View[A] = iterableFactory.empty
 
+  /** Returns a string consisting of this view's class name followed by `(<not computed>)`.
+   *
+   *  The elements of this view are never evaluated by `toString`.
+   */
   override def toString(): String  = className + "(<not computed>)"
 
+  /** Returns `"View"`, the prefix used in the string representation of this view. */
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "View"
 
@@ -80,57 +88,93 @@ object View extends IterableFactory[View] {
     case _                      => LazyList.from(it).view
   }
 
+  /** Returns the empty view, [[View.Empty]].
+   *
+   *  @tparam A the element type of the view; no elements are ever produced
+   */
   def empty[A]: View[A] = Empty
 
+  /** Returns a new builder for a view.
+   *
+   *  The builder is strict: elements added to it are buffered eagerly, and
+   *  `result()` returns a view over the buffered elements.
+   *
+   *  @tparam A the element type of the view to build
+   *  @return a builder that buffers the added elements and returns a view of them
+   */
   def newBuilder[A]: Builder[A, View[A]] = ArrayBuffer.newBuilder[A].mapResult(from)
 
+  /** Returns a view of the given elements.
+   *
+   *  @tparam A the element type of the view
+   *  @param xs the elements of the view
+   *  @return a view iterating over `xs`
+   */
   override def apply[A](xs: A*): View[A] = new Elems(xs*)
 
   /** The empty view. */
   @SerialVersionUID(3L)
   case object Empty extends AbstractView[Nothing] {
+    /** Returns the empty iterator. */
     def iterator = Iterator.empty
+    /** Returns 0: this view never has elements. */
     override def knownSize = 0
+    /** Returns `true`: this view is always empty. */
     override def isEmpty: Boolean = true
   }
 
   /** A view with exactly one element. */
   @SerialVersionUID(3L)
   class Single[A](a: A) extends AbstractView[A] {
+    /** Returns an iterator producing the single element `a`. */
     def iterator: Iterator[A] = Iterator.single(a)
+    /** Returns 1: this view always has exactly one element. */
     override def knownSize: Int = 1
+    /** Returns `false`: this view always has one element. */
     override def isEmpty: Boolean = false
   }
 
   /** A view with given elements. */
   @SerialVersionUID(3L)
   class Elems[A](xs: A*) extends AbstractView[A] {
+    /** Returns an iterator over the given elements. */
     def iterator = xs.iterator
+    /** Returns the number of given elements, or -1 if the argument sequence does not know its size. */
     override def knownSize = xs.knownSize
+    /** Returns `true` if no elements were given. */
     override def isEmpty: Boolean = xs.isEmpty
   }
 
   /** A view containing the results of some element computation a number of times. */
   @SerialVersionUID(3L)
   class Fill[A](n: Int)(elem: => A) extends AbstractView[A] {
+    /** Returns an iterator that evaluates `elem` anew for each of the `n` elements it produces. */
     def iterator = Iterator.fill(n)(elem)
+    /** Returns `n`, or 0 if `n` is negative. */
     override def knownSize: Int = 0 max n
+    /** Returns `true` if `n <= 0`; `elem` is not evaluated. */
     override def isEmpty: Boolean = n <= 0
   }
 
   /** A view containing values of a given function over a range of integer values starting from 0. */
   @SerialVersionUID(3L)
   class Tabulate[A](n: Int)(f: Int => A) extends AbstractView[A] {
+    /** Returns an iterator that applies `f` on demand to each index from 0 until `n`. */
     def iterator: Iterator[A]^{f} = Iterator.tabulate(n)(f)
+    /** Returns `n`, or 0 if `n` is negative. */
     override def knownSize: Int = 0 max n
+    /** Returns `true` if `n <= 0`; `f` is not called. */
     override def isEmpty: Boolean = n <= 0
   }
 
   /** A view containing repeated applications of a function to a start value. */
   @SerialVersionUID(3L)
   class Iterate[A](start: A, len: Int)(f: A => A) extends AbstractView[A] {
+    /** Returns an iterator producing on demand `start`, `f(start)`, `f(f(start))`, ..., limited to `len` elements. */
     def iterator: Iterator[A]^{f} = Iterator.iterate(start)(f).take(len)
+    /** Returns `len`, or 0 if `len` is negative. */
     override def knownSize: Int = 0 max len
+    /** Returns `true` if `len <= 0`; `f` is not called. */
     override def isEmpty: Boolean = len <= 0
   }
 
@@ -139,6 +183,9 @@ object View extends IterableFactory[View] {
    */
   @SerialVersionUID(3L)
   class Unfold[A, S](initial: S)(f: S => Option[(A, S)]) extends AbstractView[A] {
+    /** Returns an iterator that, on demand, applies `f` to the current state, yielding the
+     *  element and next state of each `Some` result and ending when `f` returns `None`.
+     */
     def iterator: Iterator[A]^{f} = Iterator.unfold(initial)(f)
   }
 
@@ -148,12 +195,34 @@ object View extends IterableFactory[View] {
   /** A view that filters an underlying collection. */
   @SerialVersionUID(3L)
   class Filter[A](val underlying: SomeIterableOps[A]^, val p: A => Boolean, val isFlipped: Boolean) extends AbstractView[A] {
+    /** Returns an iterator that evaluates `p` on demand and produces the underlying elements
+     *  that satisfy `p`, or that fail `p` if `isFlipped` is `true`.
+     */
     def iterator = underlying.iterator.filterImpl(p, isFlipped)
+    /** Returns 0 if the underlying collection is known to be empty, -1 otherwise
+     *  (how many elements pass the filter cannot be known without evaluating `p`).
+     */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if no underlying element passes the filter, that is, if none
+     *  satisfies `p`, or, when `isFlipped` is set, if all of them do. `p` is evaluated
+     *  on the underlying elements only until a first match is found.
+     */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   object Filter {
+    /** Returns a view that filters `underlying` with `p`.
+     *
+     *  If `underlying` is itself a `Filter` with the same `isFlipped` polarity, the two
+     *  predicates are combined by conjunction into a single `Filter` over the original
+     *  collection instead of stacking two view layers.
+     *
+     *  @tparam A the element type of the view
+     *  @param underlying the collection to filter
+     *  @param p the predicate to apply to each element
+     *  @param isFlipped if `true`, keeps the elements that fail `p` instead of those that satisfy it
+     *  @return a view of the underlying elements selected by `p` and `isFlipped`
+     */
     def apply[A](underlying: Iterable[A]^, p: A => Boolean, isFlipped: Boolean): Filter[A]^{underlying, p} =
       (underlying: @unchecked) match {
         case filter : Filter[A] if filter.isFlipped == isFlipped => {
@@ -168,13 +237,32 @@ object View extends IterableFactory[View] {
   /** A view that removes the duplicated elements as determined by the transformation function `f`. */
   @SerialVersionUID(3L)
   class DistinctBy[A, B](underlying: SomeIterableOps[A]^, f: A -> B) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements, skipping any element whose image
+     *  under `f` equals that of an already produced element.
+     */
     def iterator: Iterator[A]^{underlying} = underlying.iterator.distinctBy(f)
+    /** Returns 0 if the underlying collection is known to be empty, -1 otherwise
+     *  (the number of distinct elements cannot be known without evaluating `f`).
+     */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if the underlying collection is empty; `f` is not called. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A view of the `Left` values produced by applying `f` to the elements of an
+   *  underlying collection; elements for which `f` yields a `Right` are skipped.
+   *
+   *  @tparam A the element type of the underlying collection
+   *  @tparam A1 the `Left` type of the results of `f`, and the element type of this view
+   *  @tparam A2 the `Right` type of the results of `f`; values of this type are discarded
+   *  @param underlying the collection whose elements are partitioned
+   *  @param f the function applied on demand to each underlying element
+   */
   @SerialVersionUID(3L)
   class LeftPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A]^, f: A => Either[A1, A2]) extends AbstractView[A1] {
+    /** Returns an iterator that applies `f` on demand to the underlying elements and
+     *  produces the value inside each `Left` result, skipping `Right` results.
+     */
     def iterator: AbstractIterator[A1]^{this} = new AbstractIterator[A1] {
       private val self = underlying.iterator
       private var hd: A1 = compiletime.uninitialized
@@ -198,8 +286,20 @@ object View extends IterableFactory[View] {
     }
   }
 
+  /** A view of the `Right` values produced by applying `f` to the elements of an
+   *  underlying collection; elements for which `f` yields a `Left` are skipped.
+   *
+   *  @tparam A the element type of the underlying collection
+   *  @tparam A1 the `Left` type of the results of `f`; values of this type are discarded
+   *  @tparam A2 the `Right` type of the results of `f`, and the element type of this view
+   *  @param underlying the collection whose elements are partitioned
+   *  @param f the function applied on demand to each underlying element
+   */
   @SerialVersionUID(3L)
   class RightPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A]^, f: A => Either[A1, A2]) extends AbstractView[A2] {
+      /** Returns an iterator that applies `f` on demand to the underlying elements and
+       *  produces the value inside each `Right` result, skipping `Left` results.
+       */
       def iterator: AbstractIterator[A2]^{this} = new AbstractIterator[A2] {
         private val self = underlying.iterator
         private var hd: A2 = compiletime.uninitialized
@@ -226,98 +326,206 @@ object View extends IterableFactory[View] {
   /** A view that drops leading elements of the underlying collection. */
   @SerialVersionUID(3L)
   class Drop[A](underlying: SomeIterableOps[A]^, n: Int) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements, skipping the first `n` of them. */
     def iterator = underlying.iterator.drop(n)
+    /** The number of elements to drop, clamped to be non-negative. */
     protected val normN = n max 0
+    /** Returns the underlying collection's known size minus the drop count (at least 0),
+     *  or -1 if the underlying size is not known.
+     */
     override def knownSize = {
       val size = underlying.knownSize
       if (size >= 0) (size - normN) max 0 else -1
     }
+    /** Returns `true` if no element remains after the drop, determined by iterating
+     *  past the dropped prefix.
+     */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   /** A view that drops trailing elements of the underlying collection. */
   @SerialVersionUID(3L)
   class DropRight[A](underlying: SomeIterableOps[A]^, n: Int) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements except the last `n`, or over
+     *  all of them if `n` is not positive.
+     *
+     *  If `n` is positive and the underlying size is not known, the iterator maintains
+     *  an `n`-element lookahead buffer, so it reads `n` elements ahead of the one it
+     *  produces.
+     */
     def iterator = dropRightIterator(underlying.iterator, n)
+    /** The number of elements to drop, clamped to be non-negative. */
     protected val normN = n max 0
+    /** Returns the underlying collection's known size minus the drop count (at least 0),
+     *  or -1 if the underlying size is not known.
+     */
     override def knownSize = {
       val size = underlying.knownSize
       if (size >= 0) (size - normN) max 0 else -1
     }
+    /** Returns `true` if this view has no elements, using `knownSize` when available and
+     *  otherwise asking the iterator, which reads up to `normN + 1` underlying elements.
+     */
     override def isEmpty: Boolean =
       if(knownSize >= 0) knownSize == 0
       else iterator.isEmpty
   }
 
+  /** A view of the elements of an underlying collection that follow its longest prefix
+   *  of elements satisfying a predicate.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the collection whose leading elements are dropped
+   *  @param p the predicate that selects the prefix to drop, evaluated on demand
+   */
   @SerialVersionUID(3L)
   class DropWhile[A](underlying: SomeIterableOps[A]^, p: A => Boolean) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements, skipping the longest prefix
+     *  whose elements all satisfy `p`.
+     */
     def iterator = underlying.iterator.dropWhile(p)
+    /** Returns 0 if the underlying collection is known to be empty, -1 otherwise
+     *  (the length of the dropped prefix cannot be known without evaluating `p`).
+     */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if every underlying element satisfies `p`, determined by iterating
+     *  past the dropped prefix.
+     */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   /** A view that takes leading elements of the underlying collection. */
   @SerialVersionUID(3L)
   class Take[+A](underlying: SomeIterableOps[A]^, n: Int) extends AbstractView[A] {
+    /** Returns an iterator over the first `n` underlying elements, or all of them
+     *  if there are fewer than `n`.
+     */
     def iterator = underlying.iterator.take(n)
+    /** The number of elements to take, clamped to be non-negative. */
     protected val normN = n max 0
+    /** Returns the smaller of the underlying collection's known size and the take count,
+     *  or -1 if the underlying size is not known.
+     */
     override def knownSize = {
       val size = underlying.knownSize
       if (size >= 0) size min normN else -1
     }
+    /** Returns `true` if this view has no elements, determined by iterating. */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   /** A view that takes trailing elements of the underlying collection. */
   @SerialVersionUID(3L)
   class TakeRight[+A](underlying: SomeIterableOps[A]^, n: Int) extends AbstractView[A] {
+    /** Returns an iterator over the last `n` underlying elements, or all of them
+     *  if there are fewer than `n`. The iterator is empty if `n` is not positive, and
+     *  is the underlying iterator itself if `n` is `Int.MaxValue`.
+     *
+     *  Otherwise, if the underlying size is not known, the first query of the iterator
+     *  consumes the entire underlying iterator, buffering at most `n` elements.
+     */
     def iterator = takeRightIterator(underlying.iterator, n)
+    /** The number of elements to take, clamped to be non-negative. */
     protected val normN = n max 0
+    /** Returns the smaller of the underlying collection's known size and the take count,
+     *  or -1 if the underlying size is not known.
+     */
     override def knownSize = {
       val size = underlying.knownSize
       if (size >= 0) size min normN else -1
     }
+    /** Returns `true` if this view has no elements, using `knownSize` when available and
+     *  otherwise asking the iterator, which traverses the whole underlying collection
+     *  unless `normN` is 0 or `n` is `Int.MaxValue`.
+     */
     override def isEmpty: Boolean =
       if(knownSize >= 0) knownSize == 0
       else iterator.isEmpty
   }
 
+  /** A view of the longest prefix of an underlying collection whose elements all
+   *  satisfy a predicate.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the collection whose prefix is taken
+   *  @param p the predicate that selects the prefix, evaluated on demand
+   */
   @SerialVersionUID(3L)
   class TakeWhile[A](underlying: SomeIterableOps[A]^, p: A => Boolean) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements that stops before the first
+     *  element failing `p`.
+     */
     def iterator = underlying.iterator.takeWhile(p)
+    /** Returns 0 if the underlying collection is known to be empty, -1 otherwise
+     *  (the length of the prefix cannot be known without evaluating `p`).
+     */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if the underlying collection is empty or its first element fails `p`. */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
+  /** A view of the cumulative results of applying an operator going left to right over
+   *  an underlying collection, starting with an initial value.
+   *
+   *  @tparam A the element type of the underlying collection
+   *  @tparam B the element type of the view
+   *  @param underlying the collection to scan
+   *  @param z the initial value, the first element of the view
+   *  @param op the operator applied on demand to the previous result and the next underlying element
+   */
   @SerialVersionUID(3L)
   class ScanLeft[+A, +B](underlying: SomeIterableOps[A]^, z: B, op: (B, A) => B) extends AbstractView[B] {
+    /** Returns an iterator producing `z`, then on demand each successive result of
+     *  applying `op` to the previous result and the next underlying element.
+     */
     def iterator = underlying.iterator.scanLeft(z)(op)
+    /** Returns the underlying collection's known size plus 1 (for the initial value `z`),
+     *  or -1 if the underlying size is not known.
+     */
     override def knownSize: Int = {
       val size = underlying.knownSize
       if (size >= 0) size + 1 else -1
     }
+    /** Returns `false`: this view always contains at least the initial value `z`. */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   /** A view that maps elements of the underlying collection. */
   @SerialVersionUID(3L)
   class Map[+A, +B](underlying: SomeIterableOps[A]^, f: A => B) extends AbstractView[B] {
+    /** Returns an iterator that applies `f` on demand to each underlying element. */
     def iterator = underlying.iterator.map(f)
+    /** Returns the underlying collection's known size, or -1 if it is not known;
+     *  mapping does not change the number of elements.
+     */
     override def knownSize = underlying.knownSize
+    /** Returns `true` if the underlying collection is empty; `f` is not called. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
   /** A view that flatmaps elements of the underlying collection. */
   @SerialVersionUID(3L)
   class FlatMap[A, B](underlying: SomeIterableOps[A]^, f: A => IterableOnce[B]^) extends AbstractView[B] {
+    /** Returns an iterator that applies `f` on demand to each underlying element and
+     *  produces the elements of each result in turn.
+     */
     def iterator = underlying.iterator.flatMap(f)
+    /** Returns 0 if the underlying collection is known to be empty, -1 otherwise
+     *  (the total number of elements cannot be known without evaluating `f`).
+     */
     override def knownSize: Int = if (underlying.knownSize == 0) 0 else super.knownSize
+    /** Returns `true` if `f` yields an empty collection for every underlying element,
+     *  evaluating `f` on the underlying elements until a first non-empty result.
+     */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
   /** A view that collects elements of the underlying collection. */
   @SerialVersionUID(3L)
   class Collect[+A, B](underlying: SomeIterableOps[A]^, pf: PartialFunction[A, B]^) extends AbstractView[B] {
+    /** Returns an iterator that, on demand, applies `pf` to each underlying element on
+     *  which it is defined, skipping the elements on which it is not.
+     */
     def iterator = underlying.iterator.collect(pf)
   }
 
@@ -326,7 +534,9 @@ object View extends IterableFactory[View] {
    */
   @SerialVersionUID(3L)
   class Concat[A](prefix: SomeIterableOps[A]^, suffix: SomeIterableOps[A]^) extends AbstractView[A] {
+    /** Returns an iterator over the prefix elements followed by the suffix elements. */
     def iterator = prefix.iterator ++ suffix.iterator
+    /** Returns the sum of the two known sizes, or -1 if either is not known. */
     override def knownSize = {
       val prefixSize = prefix.knownSize
       if (prefixSize >= 0) {
@@ -336,6 +546,7 @@ object View extends IterableFactory[View] {
       }
       else -1
     }
+    /** Returns `true` if both the prefix and the suffix are empty. */
     override def isEmpty: Boolean = prefix.isEmpty && suffix.isEmpty
   }
 
@@ -344,7 +555,13 @@ object View extends IterableFactory[View] {
    */
   @SerialVersionUID(3L)
   class Zip[A, B](underlying: SomeIterableOps[A]^, other: Iterable[B]^) extends AbstractView[(A, B)] {
+    /** Returns an iterator producing pairs of corresponding elements, ending when either
+     *  collection runs out of elements.
+     */
     def iterator = underlying.iterator.zip(other)
+    /** Returns the smaller of the two known sizes; 0 if either collection is known to be
+     *  empty, and -1 if neither is known to be empty and either size is not known.
+     */
     override def knownSize = {
       val s1 = underlying.knownSize
       if (s1 == 0) 0 else {
@@ -352,6 +569,7 @@ object View extends IterableFactory[View] {
         if (s2 == 0) 0 else s1 min s2
       }
     }
+    /** Returns `true` if either collection is empty. */
     override def isEmpty: Boolean = underlying.isEmpty || other.isEmpty
   }
 
@@ -361,7 +579,11 @@ object View extends IterableFactory[View] {
    */
   @SerialVersionUID(3L)
   class ZipAll[A, B](underlying: SomeIterableOps[A]^, other: Iterable[B]^, thisElem: A, thatElem: B) extends AbstractView[(A, B)] {
+    /** Returns an iterator producing pairs of corresponding elements, substituting
+     *  `thisElem` or `thatElem` once the shorter collection runs out of elements.
+     */
     def iterator = underlying.iterator.zipAll(other, thisElem, thatElem)
+    /** Returns the larger of the two known sizes, or -1 if either is not known. */
     override def knownSize = {
       val s1 = underlying.knownSize
       if(s1 == -1) -1 else {
@@ -369,33 +591,58 @@ object View extends IterableFactory[View] {
         if(s2 == -1) -1 else s1 max s2
       }
     }
+    /** Returns `true` if both collections are empty. */
     override def isEmpty: Boolean = underlying.isEmpty && other.isEmpty
   }
 
   /** A view that appends an element to its elements. */
   @SerialVersionUID(3L)
   class Appended[+A](underlying: SomeIterableOps[A]^, elem: A) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements followed by `elem`. */
     def iterator = new Concat(underlying, new View.Single(elem)).iterator
+    /** Returns the underlying collection's known size plus 1, or -1 if it is not known. */
     override def knownSize: Int = {
       val size = underlying.knownSize
       if (size >= 0) size + 1 else -1
     }
+    /** Returns `false`: this view always contains at least the appended element. */
     override def isEmpty: Boolean = false
   }
 
   /** A view that prepends an element to its elements. */
   @SerialVersionUID(3L)
   class Prepended[+A](elem: A, underlying: SomeIterableOps[A]^) extends AbstractView[A] {
+    /** Returns an iterator producing `elem` followed by the underlying elements. */
     def iterator = new Concat(new View.Single(elem), underlying).iterator
+    /** Returns the underlying collection's known size plus 1, or -1 if it is not known. */
     override def knownSize: Int = {
       val size = underlying.knownSize
       if (size >= 0) size + 1 else -1
     }
+    /** Returns `false`: this view always contains at least the prepended element. */
     override def isEmpty: Boolean = false
   }
 
+  /** A view of the elements of an underlying collection with the element at one position
+   *  replaced by another value.
+   *
+   *  If `index` is greater than or equal to the number of underlying elements, iterating
+   *  past the end throws an `IndexOutOfBoundsException`; if `index` is negative, no
+   *  element is replaced and the view contains the underlying elements unchanged.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the collection providing the elements
+   *  @param index the position at which to substitute `elem`
+   *  @param elem the replacement element
+   */
   @SerialVersionUID(3L)
   class Updated[A](underlying: SomeIterableOps[A]^, index: Int, elem: A) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements that produces `elem` instead of
+     *  the element at position `index`.
+     *
+     *  @throws IndexOutOfBoundsException if the underlying collection is exhausted
+     *          before position `index` is reached
+     */
     def iterator: Iterator[A]^{underlying} = new AbstractIterator[A] {
       private val it = underlying.iterator
       private var i = 0
@@ -409,7 +656,16 @@ object View extends IterableFactory[View] {
         else if(index >= i) throw new IndexOutOfBoundsException(index.toString)
         else false
     }
+    /** Returns the underlying collection's known size, or -1 if it is not known;
+     *  updating does not change the number of elements.
+     */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `false` if the underlying collection has elements, determined by iterating.
+     *
+     *  @throws IndexOutOfBoundsException if the underlying collection is empty and
+     *          `index` is non-negative; `true` is returned only for a negative `index`
+     *          on an empty underlying collection
+     */
     override def isEmpty: Boolean = iterator.isEmpty
   }
 
@@ -426,21 +682,49 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = if (knownSize == 0) true else iterator.isEmpty
   }
 
+  /** A view that pairs each element of an underlying collection with its index,
+   *  counting from 0.
+   *
+   *  @tparam A the element type of the underlying collection
+   *  @param underlying the collection whose elements are paired with their indices
+   */
   @SerialVersionUID(3L)
   class ZipWithIndex[A](underlying: SomeIterableOps[A]^) extends AbstractView[(A, Int)] {
+    /** Returns an iterator producing each underlying element paired with its index,
+     *  starting from `(firstElem, 0)`.
+     */
     def iterator: Iterator[(A, Int)]^{this} = underlying.iterator.zipWithIndex
+    /** Returns the underlying collection's known size, or -1 if it is not known. */
     override def knownSize: Int = underlying.knownSize
+    /** Returns `true` if the underlying collection is empty. */
     override def isEmpty: Boolean = underlying.isEmpty
   }
 
+  /** A view of the elements of an underlying collection, followed by as many copies of a
+   *  padding element as are needed to reach a given length.
+   *
+   *  If the underlying collection already has `len` or more elements, no padding is added.
+   *
+   *  @tparam A the element type of the view
+   *  @param underlying the collection providing the leading elements
+   *  @param len the minimum length of the view
+   *  @param elem the padding element
+   */
   @SerialVersionUID(3L)
   class PadTo[A](underlying: SomeIterableOps[A]^, len: Int, elem: A) extends AbstractView[A] {
+    /** Returns an iterator over the underlying elements, then over copies of `elem` until
+     *  `len` elements in total have been produced.
+     */
     def iterator: Iterator[A]^{this} = underlying.iterator.padTo(len, elem)
 
+    /** Returns the larger of the underlying collection's known size and `len`, or -1 if
+     *  the underlying size is not known.
+     */
     override def knownSize: Int = {
       val size = underlying.knownSize
       if (size >= 0) size max len else -1
     }
+    /** Returns `true` if the underlying collection is empty and `len <= 0`. */
     override def isEmpty: Boolean = underlying.isEmpty && len <= 0
   }
 

--- a/library/src/scala/collection/package.scala
+++ b/library/src/scala/collection/package.scala
@@ -18,10 +18,16 @@ import language.experimental.captureChecking
 package object collection {
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   type Traversable[+X] = Iterable[X]
+  /** Alias for the [[Iterable]] companion object, kept so that code written against
+   *  the old name can still call factory methods such as `Traversable(1, 2, 3)`.
+   */
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
   @deprecated("Use IterableOnce instead of TraversableOnce", "2.13.0")
   type TraversableOnce[+X] = IterableOnce[X]
+  /** Alias for the [[IterableOnce]] companion object, kept so that code written
+   *  against the old name still resolves.
+   */
   @deprecated("Use IterableOnce instead of TraversableOnce", "2.13.0")
   val TraversableOnce = IterableOnce
   @deprecated("Use SeqOps instead of SeqLike", "2.13.0")
@@ -31,26 +37,44 @@ package object collection {
 
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenTraversableOnce[+X] = IterableOnce[X]
+  /** Alias for the [[IterableOnce]] companion object, standing in for the removed
+   *  `GenTraversableOnce` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenTraversableOnce = IterableOnce
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenTraversable[+X] = Iterable[X]
+  /** Alias for the [[Iterable]] companion object, standing in for the removed
+   *  `GenTraversable` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenTraversable = Iterable
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenIterable[+X] = Iterable[X]
+  /** Alias for the [[Iterable]] companion object, standing in for the removed
+   *  `GenIterable` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenIterable = Iterable
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenSeq[+X] = Seq[X]
+  /** Alias for the [[Seq]] companion object, standing in for the removed
+   *  `GenSeq` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenSeq = Seq
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenSet[X] = Set[X]
+  /** Alias for the [[Set]] companion object, standing in for the removed
+   *  `GenSet` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenSet = Set
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenMap[K, +V] = Map[K, V]
+  /** Alias for the [[Map]] companion object, standing in for the removed
+   *  `GenMap` companion.
+   */
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenMap = Map
 


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for the root of `scala.collection` that is completely missing any Scaladoc documentation. It covers the `Iterable`, `Seq`, `Set` and `Map` hierarchies and their `Ops` traits, the views, the steppers and stepper shapes, and the factory and build-from machinery. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet.  We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.