### PR TITLE
collection, immutable, Vector, HashMap, ArraySeq (11): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -50,6 +50,13 @@ sealed abstract class ArraySeq[+A]
    */
   protected def elemTag: ClassTag[?]
 
+  /** Returns the companion factory in its untagged form, which requires no `ClassTag`.
+   *
+   *  Because no element type is known, the immutable arrays this factory constructs
+   *  are backed by an `Array[AnyRef]` and store primitive values boxed. Its `from`
+   *  constructs nothing when the source is already an `ArraySeq`, returning it with
+   *  whatever backing array it has.
+   */
   override def iterableFactory: SeqFactory[ArraySeq] = ArraySeq.untagged
 
   /** The wrapped mutable `Array` that backs this `ArraySeq`. Any changes to this array will break
@@ -59,14 +66,52 @@ sealed abstract class ArraySeq[+A]
    */
   def unsafeArray: Array[?]
 
+  /** Returns the `ArraySeq` companion object, the `ClassTag`-based factory used by the
+   *  default implementations of `fromSpecific`, `newSpecificBuilder`, and `empty`.
+   */
   protected def evidenceIterableFactory: ArraySeq.type = ArraySeq
+  /** Returns this immutable array's `elemTag` viewed as a `ClassTag[A]`, the evidence
+   *  passed to `evidenceIterableFactory` when building collections of the same element
+   *  type.
+   */
   protected def iterableEvidence: ClassTag[A @uncheckedVariance] = elemTag.asInstanceOf[ClassTag[A]]
 
+  /** Returns a stepper for the elements of this immutable array.
+   *
+   *  Steppers enable creating a Java stream to operate on the elements. Where the
+   *  element type is a primitive with a value-shaped stepper - that is, any except
+   *  `Boolean` and `Unit` - the stepper steps over unboxed values unless a
+   *  reference-shaped stepper is explicitly requested.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape implicit evidence selecting the stepper type for the element type `A`
+   *  @return a stepper over the elements, supporting efficient splitting for parallel
+   *          processing
+   */
   def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit
 
+  /** Returns the element at the given index of the underlying array.
+   *
+   *  @param i the zero-based index of the element
+   *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+   *          `length`
+   */
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A
 
+  /** Returns a new immutable array with the element at `index` replaced by `elem`.
+   *
+   *  The elements are copied into a new boxed array, so the result is backed by an
+   *  `Array[AnyRef]` even when this immutable array has a primitive representation;
+   *  the specialized subclasses override this to keep the primitive representation
+   *  when `elem` fits it.
+   *
+   *  @tparam B the element type of the returned immutable array, a supertype of `A`
+   *  @param index the zero-based index of the element to replace
+   *  @param elem the value to store at `index`
+   *  @return a new immutable array, identical to this one except at `index`
+   *  @throws IndexOutOfBoundsException if `index` is negative or not less than `length`
+   */
   override def updated[B >: A](index: Int, elem: B): ArraySeq[B] = {
     val dest = new Array[Any](length)
     Array.copy(unsafeArray, 0, dest, 0, length)
@@ -74,6 +119,16 @@ sealed abstract class ArraySeq[+A]
     ArraySeq.unsafeWrapArray(dest).asInstanceOf[ArraySeq[B]]
   }
 
+  /** Returns a new immutable array resulting from applying `f` to each element of
+   *  this immutable array.
+   *
+   *  The results are collected into a new boxed array, so the returned collection is
+   *  backed by an `Array[AnyRef]` regardless of `B`.
+   *
+   *  @tparam B the element type of the returned immutable array
+   *  @param f the function to apply to each element
+   *  @return a new immutable array containing the results in the same order
+   */
   override def map[B](f: A => B): ArraySeq[B] = {
     val a = new Array[Any](size)
     var i = 0
@@ -84,9 +139,31 @@ sealed abstract class ArraySeq[+A]
     ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[B]]
   }
 
+  /** Returns a new immutable array with `elem` prepended before all elements of this
+   *  immutable array.
+   *
+   *  The elements are copied into a new boxed array, so the result is backed by an
+   *  `Array[AnyRef]`; the specialized subclasses override this to keep a primitive
+   *  representation when `elem` fits it.
+   *
+   *  @tparam B the element type of the returned immutable array, a supertype of `A`
+   *  @param elem the element to prepend
+   *  @return a new immutable array with `elem` as its first element
+   */
   override def prepended[B >: A](elem: B): ArraySeq[B] =
     ArraySeq.unsafeWrapArray(unsafeArray.prepended[Any](elem)).asInstanceOf[ArraySeq[B]]
 
+  /** Returns a new immutable array with `elem` appended after all elements of this
+   *  immutable array.
+   *
+   *  The elements are copied into a new boxed array, so the result is backed by an
+   *  `Array[AnyRef]`; the specialized subclasses override this to keep a primitive
+   *  representation when `elem` fits it.
+   *
+   *  @tparam B the element type of the returned immutable array, a supertype of `A`
+   *  @param elem the element to append
+   *  @return a new immutable array with `elem` as its last element
+   */
   override def appended[B >: A](elem: B): ArraySeq[B] =
     ArraySeq.unsafeWrapArray(unsafeArray.appended[Any](elem)).asInstanceOf[ArraySeq[B]]
 
@@ -132,6 +209,25 @@ sealed abstract class ArraySeq[+A]
     }
   }
 
+  /** Returns a new immutable array containing the elements of this immutable array
+   *  followed by the elements of `suffix`.
+   *
+   *  When `suffix` is also an `ArraySeq`, an empty operand results in the other
+   *  operand being returned unchanged, and two operands backed by the same kind of
+   *  array (both object arrays, or both primitive arrays of the same element type)
+   *  are concatenated directly, a primitive representation being preserved. In all
+   *  other cases the elements are copied into a new boxed array, so the result is
+   *  backed by an `Array[AnyRef]`; if `suffix` is known to be empty, this immutable
+   *  array is returned unchanged.
+   *
+   *  @tparam B the element type of the returned immutable array, a supertype of `A`
+   *  @param suffix the elements to append
+   *  @return the concatenated immutable array
+   *  @throws ArrayStoreException if this immutable array and `suffix` are both backed
+   *          by primitive arrays but of different element types, as in
+   *          `ArraySeq(1) ++ ArraySeq(1L)`: the direct path then writes the elements
+   *          of `suffix` into an array of this immutable array's element type
+   */
   override def appendedAll[B >: A](suffix: collection.IterableOnce[B]^): ArraySeq[B] = {
     def genericResult = {
       val k = suffix.knownSize
@@ -155,6 +251,25 @@ sealed abstract class ArraySeq[+A]
     }
   }
 
+  /** Returns a new immutable array containing the elements of `prefix` followed by
+   *  the elements of this immutable array.
+   *
+   *  When `prefix` is also an `ArraySeq`, an empty operand results in the other
+   *  operand being returned unchanged, and two operands backed by the same kind of
+   *  array (both object arrays, or both primitive arrays of the same element type)
+   *  are concatenated directly, a primitive representation being preserved. In all
+   *  other cases the elements are copied into a new boxed array, so the result is
+   *  backed by an `Array[AnyRef]`; if `prefix` is known to be empty, this immutable
+   *  array is returned unchanged.
+   *
+   *  @tparam B the element type of the returned immutable array, a supertype of `A`
+   *  @param prefix the elements to prepend
+   *  @return the concatenated immutable array
+   *  @throws ArrayStoreException if `prefix` and this immutable array are both backed
+   *          by primitive arrays but of different element types, as in
+   *          `ArraySeq(1L).prependedAll(ArraySeq(1))`: the direct path then writes the
+   *          elements of this immutable array into an array of `prefix`'s element type
+   */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): ArraySeq[B] = {
     def genericResult = {
       val k = prefix.knownSize
@@ -179,6 +294,15 @@ sealed abstract class ArraySeq[+A]
     }
   }
 
+  /** Returns a new immutable array of pairs formed from the elements of this
+   *  immutable array and the corresponding elements of `that`.
+   *
+   *  The result is truncated to the length of the shorter operand, and is backed by
+   *  an array of tuples.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection providing the second half of each pair
+   */
   override def zip[B](that: collection.IterableOnce[B]^): ArraySeq[(A, B)] =
     that match {
       case bs: ArraySeq[B] =>
@@ -189,36 +313,92 @@ sealed abstract class ArraySeq[+A]
         strictOptimizedZip[B, ArraySeq[(A, B)]](that, iterableFactory.newBuilder)
     }
 
+  /** Returns an immutable array containing the first `n` elements of this immutable
+   *  array.
+   *
+   *  @param n the number of elements to take
+   *  @return this immutable array itself if `n >= length`, otherwise a new immutable
+   *          array containing the first `max(n, 0)` elements, copied into an array of
+   *          the same element type
+   */
   override def take(n: Int): ArraySeq[A] =
     if (unsafeArray.length <= n)
       this
     else
       ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).take(n)).asInstanceOf[ArraySeq[A]]
 
+  /** Returns an immutable array containing the last `n` elements of this immutable
+   *  array.
+   *
+   *  @param n the number of elements to take
+   *  @return this immutable array itself if `n >= length`, otherwise a new immutable
+   *          array containing the last `max(n, 0)` elements, copied into an array of
+   *          the same element type
+   */
   override def takeRight(n: Int): ArraySeq[A] =
     if (unsafeArray.length <= n)
       this
     else
       ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).takeRight(n)).asInstanceOf[ArraySeq[A]]
 
+  /** Returns an immutable array containing all elements of this immutable array
+   *  except the first `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return this immutable array itself if `n <= 0`, otherwise a new immutable array
+   *          containing the remaining elements (empty if `n >= length`), copied into
+   *          an array of the same element type
+   */
   override def drop(n: Int): ArraySeq[A] =
     if (n <= 0)
       this
     else
       ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).drop(n)).asInstanceOf[ArraySeq[A]]
 
+  /** Returns an immutable array containing all elements of this immutable array
+   *  except the last `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return this immutable array itself if `n <= 0`, otherwise a new immutable array
+   *          containing the remaining elements (empty if `n >= length`), copied into
+   *          an array of the same element type
+   */
   override def dropRight(n: Int): ArraySeq[A] =
     if (n <= 0)
       this
     else
       ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).dropRight(n)).asInstanceOf[ArraySeq[A]]
 
+  /** Returns an immutable array containing the elements of this immutable array from
+   *  index `from` (inclusive) up to index `until` (exclusive).
+   *
+   *  Both indices are clamped to the valid range, so the result is empty when
+   *  `until <= from` after clamping.
+   *
+   *  @param from the index of the first element to include
+   *  @param until the index one past the last element to include
+   *  @return this immutable array itself if the slice covers it entirely
+   *          (`from <= 0` and `until >= length`), otherwise a new immutable array
+   *          containing the selected elements, copied into an array of the same
+   *          element type
+   */
   override def slice(from: Int, until: Int): ArraySeq[A] =
     if (from <= 0 && unsafeArray.length <= until)
       this
     else
       ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).slice(from, until)).asInstanceOf[ArraySeq[A]]
 
+  /** Applies a binary operator to a start value and all elements of this immutable
+   *  array, going left to right.
+   *
+   *  @tparam B the result type of the binary operator
+   *  @param z the start value
+   *  @param f the binary operator, applied to the accumulated value and the next
+   *           element
+   *  @return the result of inserting `f` between consecutive elements, going left to
+   *          right, with the start value `z` on the left; `z` if this immutable array
+   *          is empty
+   */
   override def foldLeft[B](z: B)(f: (B, A) => B): B = {
     // For ArraySeqs with sizes of [100, 1000, 10000] this is [1.3, 1.8, 1.8]x as fast
     // as the same while-loop over this instead of unsafeArray.
@@ -233,6 +413,17 @@ sealed abstract class ArraySeq[+A]
     b
   }
 
+  /** Applies a binary operator to all elements of this immutable array and a start
+   *  value, going right to left.
+   *
+   *  @tparam B the result type of the binary operator
+   *  @param z the start value
+   *  @param f the binary operator, applied to the next element and the accumulated
+   *           value
+   *  @return the result of inserting `f` between consecutive elements, going right to
+   *          left, with the start value `z` on the right; `z` if this immutable array
+   *          is empty
+   */
   override def foldRight[B](z: B)(f: (A, B) => B): B = {
     // For ArraySeqs with sizes of [100, 1000, 10000] this is [1.6, 1.8, 2.7]x as fast
     // as the same while-loop over this instead of unsafeArray.
@@ -247,12 +438,41 @@ sealed abstract class ArraySeq[+A]
     b
   }
 
+  /** Returns a new immutable array containing all elements of this immutable array
+   *  except the first.
+   *
+   *  @throws UnsupportedOperationException if this immutable array is empty
+   */
   override def tail: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).tail).asInstanceOf[ArraySeq[A]]
 
+  /** Returns a new immutable array with the elements of this immutable array in
+   *  reverse order.
+   */
   override def reverse: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).reverse).asInstanceOf[ArraySeq[A]]
 
+  /** Returns `"ArraySeq"`, the name of this collection type used in `toString` output. */
   override protected def className = "ArraySeq"
 
+  /** Copies elements of this immutable array to another array, beginning at index
+   *  `start` of `xs`.
+   *
+   *  The number of elements copied is the minimum of `len`, the length of this
+   *  immutable array, and the remaining capacity of `xs` from `start`; if that
+   *  minimum is not positive, nothing is copied. Copying is performed by a single
+   *  `Array.copy` of the underlying array.
+   *
+   *  A negative `start` is not rejected before that count is computed: the whole
+   *  length of `xs` is taken as the capacity, and the `Array.copy` that follows a
+   *  positive count throws.
+   *
+   *  @tparam B the element type of the destination array, a supertype of `A`
+   *  @param xs the destination array
+   *  @param start the index of `xs` at which to write the first element
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements actually copied
+   *  @throws ArrayIndexOutOfBoundsException if `start` is negative and at least one
+   *          element would be copied
+   */
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {
@@ -261,8 +481,23 @@ sealed abstract class ArraySeq[+A]
     copied
   }
 
+  /** Returns `Int.MaxValue`, indicating that indexed access via `apply` is never more
+   *  expensive than `iterator`, so element scans such as `sameElements` always use
+   *  indexed access.
+   */
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
+  /** Returns an immutable array with the elements of this immutable array sorted
+   *  according to the given ordering.
+   *
+   *  Returns this immutable array itself if it has fewer than two elements. Otherwise
+   *  the elements are copied into a boxed array and sorted with a stable sort, so the
+   *  result is backed by an `Array[AnyRef]`; several specialized subclasses override
+   *  this to keep a primitive representation when sorting by the natural ordering.
+   *
+   *  @tparam B the type on which `ord` is defined, a supertype of `A`
+   *  @param ord the ordering used to compare elements
+   */
   override def sorted[B >: A](implicit ord: Ordering[B]): ArraySeq[A] =
     if(unsafeArray.length <= 1) this
     else {
@@ -278,22 +513,82 @@ sealed abstract class ArraySeq[+A]
  */
 @SerialVersionUID(3L)
 object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
+  /** A factory for immutable `ArraySeq`s that requires no `ClassTag`.
+   *
+   *  Because no element type is known, the immutable arrays this factory constructs
+   *  are backed by an `Array[AnyRef]` and store primitive values boxed. Its `from`
+   *  constructs nothing when the source is already an `ArraySeq`, returning it with
+   *  whatever backing array it has.
+   */
   val untagged: SeqFactory[ArraySeq] = new ClassTagSeqFactory.AnySeqDelegate(self)
 
   private lazy val emptyImpl = new ArraySeq.ofRef[Nothing](new Array[Nothing](0))
 
+  /** Returns the empty immutable array.
+   *
+   *  The same instance, backed by an empty array, is shared for all element types;
+   *  the `ClassTag` is never consulted.
+   *
+   *  @tparam A the element type
+   */
   def empty[A : ClassTag]: ArraySeq[A] = emptyImpl
 
+  /** Returns an immutable array containing the elements of the given collection.
+   *
+   *  If `it` is already an immutable `ArraySeq`, it is returned unchanged and `tag`
+   *  is not consulted. Otherwise the elements are copied into a new array whose
+   *  element type is determined by `tag`, and the result wraps that array.
+   *
+   *  @tparam A the element type
+   *  @param it the source collection
+   *  @param tag the class tag determining the element type of the backing array when
+   *             a new one is created
+   */
   def from[A](it: scala.collection.IterableOnce[A]^)(implicit tag: ClassTag[A]): ArraySeq[A] = it match {
     case as: ArraySeq[A] => as
     case _ => unsafeWrapArray(Array.from[A](it))
   }
 
+  /** Returns a new builder for an immutable `ArraySeq`.
+   *
+   *  The builder collects elements into an `ArrayBuffer`; when the result is
+   *  requested they are copied into a new array whose element type is determined by
+   *  the `ClassTag`, and the result wraps that array.
+   *
+   *  @tparam A the element type
+   */
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] =
     ArrayBuffer.newBuilder[A].mapResult(b => unsafeWrapArray[A](b.toArray))
 
+  /** Returns an immutable array of `n` elements, or an empty one if `n` is not
+   *  positive, where each element is the result of one evaluation of `elem`.
+   *
+   *  `elem` is evaluated once per element of the result, so not at all when `n` is
+   *  not positive. The element type of the backing array is determined by the
+   *  `ClassTag`.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param elem the by-name expression computing each element
+   *  @return an immutable array with `n` evaluations of `elem`, or an empty immutable
+   *          array if `n` is not positive
+   */
   override def fill[A : ClassTag](n: Int)(elem: => A): ArraySeq[A] = tabulate(n)(_ => elem)
 
+  /** Returns an immutable array of `n` elements, or an empty one if `n` is not
+   *  positive, where the element at each index is the result of applying `f` to
+   *  that index.
+   *
+   *  `f` is applied to the indices `0` to `n - 1` in ascending order, so not at all
+   *  when `n` is not positive. The element type of the backing array is determined
+   *  by the `ClassTag`.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param f the function computing the element at each index
+   *  @return an immutable array with the values `f(0), ..., f(n - 1)`, or an empty
+   *          immutable array if `n` is not positive
+   */
   override def tabulate[A : ClassTag](n: Int)(f: Int => A): ArraySeq[A] = {
     val elements = Array.ofDim[A](scala.math.max(n, 0))
     var i = 0
@@ -333,13 +628,45 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     case x: Array[Unit]    => new ofUnit(x)
   }).asInstanceOf[ArraySeq[T]]
 
+  /** An immutable `ArraySeq` backed by an array of reference values.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @tparam T the element type, a reference type
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef | Null](val unsafeArray: Array[T]) extends ArraySeq[T] {
+    /** Returns a class tag for the runtime component type of the underlying array,
+     *  which may be a subtype or supertype of `T`.
+     */
     def elemTag: ClassTag[T] = ClassTag[T](unsafeArray.getClass.getComponentType)
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): T = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofRef` instances are equal if their underlying arrays contain equal
+     *  elements (compared with `equals`) in the same order. Comparison with
+     *  anything else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofRef` whose underlying array has equal
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any): Boolean = that match {
       case that: ofRef[?] =>
         Array.equals(
@@ -347,6 +674,17 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
           that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements;
+     *  otherwise a clone of the underlying array is sorted with a stable sort and
+     *  wrapped in a new `ofRef`, preserving the runtime element type of the
+     *  underlying array.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `T`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq.ofRef[T] = {
       if(unsafeArray.length <= 1) this
       else {
@@ -355,7 +693,19 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         new ArraySeq.ofRef(a)
       }
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[T] = new ArrayOps.ArrayIterator[T](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  If a value-shaped stepper is requested for an element type that boxes a
+     *  primitive, the stepper unboxes the values; otherwise it steps over the
+     *  reference values directly.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `T`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[T, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         new ObjectArrayStepper(unsafeArray, 0, unsafeArray.length)
@@ -363,18 +713,59 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     ).asInstanceOf[S & EfficientSplit]
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Byte]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofByte(val unsafeArray: Array[Byte]) extends ArraySeq[Byte] {
     // Type erases to `ManifestFactory.ByteManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Byte`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Byte.type = ClassTag.Byte
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Byte = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofByte` instances are equal if their underlying arrays contain the same
+     *  elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofByte` whose underlying array has the same
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Byte`, a copy of the underlying array is sorted and
+     *  wrapped in a new `ofByte`; for any other ordering the generic implementation
+     *  is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Byte`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Byte](implicit ord: Ordering[B]): ArraySeq[Byte] =
       if(length <= 1) this
       else if(ord eq Ordering.Byte) {
@@ -382,22 +773,66 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Arrays.sort(a)
         new ArraySeq.ofByte(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Byte] = new ArrayOps.ArrayIterator[Byte](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Byte` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Byte`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Byte, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedByteArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new WidenedByteArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Byte`, the result is an `ofByte` backed by a new
+     *  `Array[Byte]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Byte`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Byte](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Byte => new ArraySeq.ofByte(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Byte`, the result is an `ofByte` backed by a new
+     *  `Array[Byte]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Byte`
+     *  @param elem the element to append
+     */
     override def appended[B >: Byte](elem: B): ArraySeq[B] =
       elem match {
         case b: Byte => new ArraySeq.ofByte(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Byte`, the result is an `ofByte` backed by a new
+     *  `Array[Byte]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Byte`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Byte](elem: B): ArraySeq[B] =
       elem match {
         case b: Byte => new ArraySeq.ofByte(unsafeArray.prepended(b))
@@ -405,18 +840,59 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Short]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofShort(val unsafeArray: Array[Short]) extends ArraySeq[Short] {
     // Type erases to `ManifestFactory.ShortManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Short`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Short.type = ClassTag.Short
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Short = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofShort` instances are equal if their underlying arrays contain the same
+     *  elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofShort` whose underlying array has the same
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Short`, a copy of the underlying array is sorted and
+     *  wrapped in a new `ofShort`; for any other ordering the generic implementation
+     *  is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Short`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Short](implicit ord: Ordering[B]): ArraySeq[Short] =
       if(length <= 1) this
       else if(ord eq Ordering.Short) {
@@ -424,22 +900,66 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Arrays.sort(a)
         new ArraySeq.ofShort(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Short] = new ArrayOps.ArrayIterator[Short](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Short` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Short`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Short, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedShortArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new WidenedShortArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Short`, the result is an `ofShort` backed by a new
+     *  `Array[Short]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Short`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Short](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Short => new ArraySeq.ofShort(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Short`, the result is an `ofShort` backed by a new
+     *  `Array[Short]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Short`
+     *  @param elem the element to append
+     */
     override def appended[B >: Short](elem: B): ArraySeq[B] =
       elem match {
         case b: Short => new ArraySeq.ofShort(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Short`, the result is an `ofShort` backed by a new
+     *  `Array[Short]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Short`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Short](elem: B): ArraySeq[B] =
       elem match {
         case b: Short => new ArraySeq.ofShort(unsafeArray.prepended(b))
@@ -447,18 +967,59 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Char]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofChar(val unsafeArray: Array[Char]) extends ArraySeq[Char] {
     // Type erases to `ManifestFactory.CharManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Char`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Char.type = ClassTag.Char
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Char = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofChar` instances are equal if their underlying arrays contain the same
+     *  elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofChar` whose underlying array has the same
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Char`, a copy of the underlying array is sorted and
+     *  wrapped in a new `ofChar`; for any other ordering the generic implementation
+     *  is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Char`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Char](implicit ord: Ordering[B]): ArraySeq[Char] =
       if(length <= 1) this
       else if(ord eq Ordering.Char) {
@@ -466,44 +1027,142 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Arrays.sort(a)
         new ArraySeq.ofChar(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Char] = new ArrayOps.ArrayIterator[Char](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Char` values, widened to `Int`, unless
+     *  a reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Char`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Char, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new WidenedCharArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new WidenedCharArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Char`, the result is an `ofChar` backed by a new
+     *  `Array[Char]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Char`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Char](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Char => new ArraySeq.ofChar(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Char`, the result is an `ofChar` backed by a new
+     *  `Array[Char]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Char`
+     *  @param elem the element to append
+     */
     override def appended[B >: Char](elem: B): ArraySeq[B] =
       elem match {
         case b: Char => new ArraySeq.ofChar(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Char`, the result is an `ofChar` backed by a new
+     *  `Array[Char]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Char`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Char](elem: B): ArraySeq[B] =
       elem match {
         case b: Char => new ArraySeq.ofChar(unsafeArray.prepended(b))
         case _ => super.prepended(elem)
       }
 
+    /** Appends the characters of this immutable array to a string builder, preceded
+     *  by the string `start`, separated by the string `sep`, and followed by the
+     *  string `end`.
+     *
+     *  Delegates to the implementation in [[scala.collection.mutable.ArraySeq.ofChar]],
+     *  which is optimized for the underlying `Array[Char]`.
+     *
+     *  @param sb the string builder to append to
+     *  @param start the starting string
+     *  @param sep the separator string
+     *  @param end the ending string
+     *  @return the string builder `sb` to which elements were appended
+     */
     override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
       (new MutableArraySeq.ofChar(unsafeArray)).addString(sb, start, sep, end)
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Int]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofInt(val unsafeArray: Array[Int]) extends ArraySeq[Int] {
     // Type erases to `ManifestFactory.IntManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Int`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Int.type = ClassTag.Int
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Int = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofInt` instances are equal if their underlying arrays contain the same
+     *  elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofInt` whose underlying array has the same
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Int`, a copy of the underlying array is sorted and
+     *  wrapped in a new `ofInt`; for any other ordering the generic implementation
+     *  is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Int`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Int](implicit ord: Ordering[B]): ArraySeq[Int] =
       if(length <= 1) this
       else if(ord eq Ordering.Int) {
@@ -511,22 +1170,65 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Arrays.sort(a)
         new ArraySeq.ofInt(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Int] = new ArrayOps.ArrayIterator[Int](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Int` values unless a reference-shaped
+     *  stepper is explicitly requested, in which case the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Int`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Int, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParIntStepper(new IntArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new IntArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is an `Int`, the result is an `ofInt` backed by a new
+     *  `Array[Int]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Int`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Int](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Int => new ArraySeq.ofInt(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is an `Int`, the result is an `ofInt` backed by a new
+     *  `Array[Int]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Int`
+     *  @param elem the element to append
+     */
     override def appended[B >: Int](elem: B): ArraySeq[B] =
       elem match {
         case b: Int => new ArraySeq.ofInt(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is an `Int`, the result is an `ofInt` backed by a new
+     *  `Array[Int]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Int`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Int](elem: B): ArraySeq[B] =
       elem match {
         case b: Int => new ArraySeq.ofInt(unsafeArray.prepended(b))
@@ -534,18 +1236,59 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Long]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofLong(val unsafeArray: Array[Long]) extends ArraySeq[Long] {
     // Type erases to `ManifestFactory.LongManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Long`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Long.type = ClassTag.Long
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Long = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofLong` instances are equal if their underlying arrays contain the same
+     *  elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofLong` whose underlying array has the same
+     *          elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Long`, a copy of the underlying array is sorted and
+     *  wrapped in a new `ofLong`; for any other ordering the generic implementation
+     *  is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Long`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Long](implicit ord: Ordering[B]): ArraySeq[Long] =
       if(length <= 1) this
       else if(ord eq Ordering.Long) {
@@ -553,22 +1296,65 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Arrays.sort(a)
         new ArraySeq.ofLong(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Long] = new ArrayOps.ArrayIterator[Long](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Long` values unless a reference-shaped
+     *  stepper is explicitly requested, in which case the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Long`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Long, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParLongStepper(new LongArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new LongArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Long`, the result is an `ofLong` backed by a new
+     *  `Array[Long]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Long`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Long](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Long => new ArraySeq.ofLong(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Long`, the result is an `ofLong` backed by a new
+     *  `Array[Long]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Long`
+     *  @param elem the element to append
+     */
     override def appended[B >: Long](elem: B): ArraySeq[B] =
       elem match {
         case b: Long => new ArraySeq.ofLong(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Long`, the result is an `ofLong` backed by a new
+     *  `Array[Long]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Long`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Long](elem: B): ArraySeq[B] =
       elem match {
         case b: Long => new ArraySeq.ofLong(unsafeArray.prepended(b))
@@ -576,14 +1362,47 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Float]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofFloat(val unsafeArray: Array[Float]) extends ArraySeq[Float] {
     // Type erases to `ManifestFactory.FloatManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Float`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Float.type = ClassTag.Float
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Float = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofFloat` instances are equal if they share the same underlying array,
+     *  or if their underlying arrays contain the same elements in the same order,
+     *  compared with `==`. A `NaN` element is not `==` to anything, so two
+     *  distinct arrays containing `NaN` are never equal. Comparison with anything
+     *  else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofFloat` sharing this underlying array or
+     *          holding the same elements in the same order, or is otherwise an
+     *          equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofFloat =>
         val array = unsafeArray
@@ -595,22 +1414,66 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         }
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Float` values, widened to `Double`,
+     *  unless a reference-shaped stepper is explicitly requested, in which case
+     *  the values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Float`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Float, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParDoubleStepper(new WidenedFloatArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new WidenedFloatArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Float`, the result is an `ofFloat` backed by a new
+     *  `Array[Float]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Float`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Float](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Float => new ArraySeq.ofFloat(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Float`, the result is an `ofFloat` backed by a new
+     *  `Array[Float]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Float`
+     *  @param elem the element to append
+     */
     override def appended[B >: Float](elem: B): ArraySeq[B] =
       elem match {
         case b: Float => new ArraySeq.ofFloat(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Float`, the result is an `ofFloat` backed by a new
+     *  `Array[Float]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Float`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Float](elem: B): ArraySeq[B] =
       elem match {
         case b: Float => new ArraySeq.ofFloat(unsafeArray.prepended(b))
@@ -618,14 +1481,47 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Double]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofDouble(val unsafeArray: Array[Double]) extends ArraySeq[Double] {
     // Type erases to `ManifestFactory.DoubleManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Double`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Double.type = ClassTag.Double
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Double = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofDouble` instances are equal if they share the same underlying array,
+     *  or if their underlying arrays contain the same elements in the same order,
+     *  compared with `==`. A `NaN` element is not `==` to anything, so two
+     *  distinct arrays containing `NaN` are never equal. Comparison with anything
+     *  else falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofDouble` sharing this underlying array or
+     *          holding the same elements in the same order, or is otherwise an
+     *          equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofDouble =>
         val array = unsafeArray
@@ -637,22 +1533,66 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         }
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  The stepper steps over the unboxed `Double` values unless a
+     *  reference-shaped stepper is explicitly requested, in which case the
+     *  values are boxed.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type `Double`
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Double, S]): S & EfficientSplit = (
       if(shape.shape == StepperShape.ReferenceShape)
         AnyStepper.ofParDoubleStepper(new DoubleArrayStepper(unsafeArray, 0, unsafeArray.length))
       else new DoubleArrayStepper(unsafeArray, 0, unsafeArray.length)
     ).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Double`, the result is an `ofDouble` backed by a new
+     *  `Array[Double]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Double`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Double](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Double => new ArraySeq.ofDouble(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Double`, the result is an `ofDouble` backed by a new
+     *  `Array[Double]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Double`
+     *  @param elem the element to append
+     */
     override def appended[B >: Double](elem: B): ArraySeq[B] =
       elem match {
         case b: Double => new ArraySeq.ofDouble(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Double`, the result is an `ofDouble` backed by a new
+     *  `Array[Double]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Double`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Double](elem: B): ArraySeq[B] =
       elem match {
         case b: Double => new ArraySeq.ofDouble(unsafeArray.prepended(b))
@@ -660,18 +1600,59 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Boolean]`, storing its elements
+   *  unboxed.
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ArraySeq[Boolean] {
     // Type erases to `ManifestFactory.BooleanManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Boolean`, the tag of the unboxed element type. */
     protected def elemTag: ClassTag.Boolean.type = ClassTag.Boolean
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the element at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Boolean = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofBoolean` instances are equal if their underlying arrays contain the
+     *  same elements in the same order. Comparison with anything else falls back to
+     *  general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofBoolean` whose underlying array has the
+     *          same elements in the same order, or is otherwise an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    /** Returns an immutable array with the elements of this immutable array sorted
+     *  according to the given ordering.
+     *
+     *  Returns this immutable array itself if it has fewer than two elements. If
+     *  `ord` is `Ordering.Boolean`, a copy of the underlying array is sorted (`false`
+     *  before `true`) and wrapped in a new `ofBoolean`; for any other ordering the
+     *  generic implementation is used, returning an immutable array of boxed values.
+     *
+     *  @tparam B the type on which `ord` is defined, a supertype of `Boolean`
+     *  @param ord the ordering used to compare elements
+     */
     override def sorted[B >: Boolean](implicit ord: Ordering[B]): ArraySeq[Boolean] =
       if(length <= 1) this
       else if(ord eq Ordering.Boolean) {
@@ -679,19 +1660,63 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
         Sorting.stableSort(a)
         new ArraySeq.ofBoolean(a)
       } else super.sorted[B]
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Boolean] = new ArrayOps.ArrayIterator[Boolean](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  There is no primitive stepper shape for `Boolean`, so the stepper always
+     *  steps over boxed values, and `shape` is never consulted.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type
+     *               `Boolean`; never used at runtime
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Boolean, S]): S & EfficientSplit =
       new BoxedBooleanArrayStepper(unsafeArray, 0, unsafeArray.length).asInstanceOf[S & EfficientSplit]
+    /** Returns a new immutable array with the element at `index` replaced by `elem`.
+     *
+     *  If `elem` is a `Boolean`, the result is an `ofBoolean` backed by a new
+     *  `Array[Boolean]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Boolean`
+     *  @param index the zero-based index of the element to replace
+     *  @param elem the value to store at `index`
+     *  @throws IndexOutOfBoundsException if `index` is negative or not less than
+     *          `length`
+     */
     override def updated[B >: Boolean](index: Int, elem: B): ArraySeq[B] =
       elem match {
         case b: Boolean => new ArraySeq.ofBoolean(unsafeArray.updated(index, b))
         case _ => super.updated(index, elem)
       }
+    /** Returns a new immutable array with `elem` appended after all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Boolean`, the result is an `ofBoolean` backed by a new
+     *  `Array[Boolean]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Boolean`
+     *  @param elem the element to append
+     */
     override def appended[B >: Boolean](elem: B): ArraySeq[B] =
       elem match {
         case b: Boolean => new ArraySeq.ofBoolean(unsafeArray.appended(b))
         case _ => super.appended(elem)
       }
+    /** Returns a new immutable array with `elem` prepended before all elements of
+     *  this immutable array.
+     *
+     *  If `elem` is a `Boolean`, the result is an `ofBoolean` backed by a new
+     *  `Array[Boolean]`; otherwise the generic implementation is used and the result
+     *  is backed by a boxed array.
+     *
+     *  @tparam B the element type of the returned immutable array, a supertype of `Boolean`
+     *  @param elem the element to prepend
+     */
     override def prepended[B >: Boolean](elem: B): ArraySeq[B] =
       elem match {
         case b: Boolean => new ArraySeq.ofBoolean(unsafeArray.prepended(b))
@@ -699,19 +1724,61 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       }
   }
 
+  /** An immutable `ArraySeq` backed by an `Array[Unit]` (at runtime, an array of
+   *  boxed unit values).
+   *
+   *  The array given at construction is wrapped directly, not copied, and must not
+   *  be mutated afterwards.
+   *
+   *  @param unsafeArray the underlying array, which must not be mutated after
+   *                     wrapping
+   */
   @SerialVersionUID(3L)
   final class ofUnit(val unsafeArray: Array[Unit]) extends ArraySeq[Unit] {
     // Type erases to `ManifestFactory.UnitManifest`, but can't annotate that because it's not accessible
+    /** Returns `ClassTag.Unit`, the tag of the element type. */
     protected def elemTag: ClassTag.Unit.type = ClassTag.Unit
+    /** Returns the number of elements in this immutable array. */
     def length: Int = unsafeArray.length
+    /** Returns the unit value at the given index of the underlying array.
+     *
+     *  @param i the zero-based index of the element
+     *  @throws ArrayIndexOutOfBoundsException if `i` is negative or not less than
+     *          `length`
+     */
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Unit = unsafeArray(i)
+    /** Returns a hash code computed from the array elements, consistent with the
+     *  hashing of other sequences.
+     */
     override def hashCode() = MurmurHash3.arraySeqHash(unsafeArray)
+    /** Compares this immutable array with another object for equality.
+     *
+     *  Two `ofUnit` instances are equal if their underlying arrays have the same
+     *  length, since all unit values are equal. Comparison with anything else
+     *  falls back to general sequence equality.
+     *
+     *  @param that the object to compare with
+     *  @return `true` if `that` is an `ofUnit` of the same length, or is otherwise
+     *          an equal sequence
+     */
     override def equals(that: Any) = that match {
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _ => super.equals(that)
     }
+    /** Returns an iterator over the elements of the underlying array. */
     override def iterator: Iterator[Unit] = new ArrayOps.ArrayIterator[Unit](unsafeArray)
+    /** Returns a stepper for the elements of this immutable array.
+     *
+     *  There is no primitive stepper shape for `Unit`, so the stepper always steps
+     *  over the boxed unit values, and `shape` is never consulted.
+     *
+     *  @tparam S the type of the stepper, determined by `shape`
+     *  @param shape implicit evidence selecting the stepper type for the element type
+     *               `Unit`; never used at runtime
+     *  @return a stepper over the elements, supporting efficient splitting for
+     *          parallel processing
+     */
     override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Unit, S]): S & EfficientSplit =
       new ObjectArrayStepper[AnyRef](unsafeArray.asInstanceOf[Array[AnyRef]], 0, unsafeArray.length).asInstanceOf[S & EfficientSplit]
   }

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -45,19 +45,29 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     with MapFactoryDefaults[K, V, HashMap, Iterable]
     with DefaultSerializable {
 
+  /** Creates an empty map, backed by the shared empty root node. */
   def this() = this(MapNode.empty)
 
   // This release fence is present because rootNode may have previously been mutated during construction.
   releaseFence()
 
+  /** Returns the [[HashMap$ HashMap]] companion object, the factory used to build new hash maps. */
   override def mapFactory: MapFactory[HashMap] = HashMap
 
+  /** Returns the number of key-value pairs in this map. The size is cached in the root node,
+   *  so this is always known and never `-1`.
+   */
   override def knownSize: Int = rootNode.size
 
+  /** Returns the number of key-value pairs in this map, read from the cached count in the root node. */
   override def size: Int = rootNode.size
 
+  /** Returns `true` if this map contains no key-value pairs, `false` otherwise. */
   override def isEmpty: Boolean = rootNode.size == 0
 
+  /** Returns the set of all keys in this map. For a non-empty map the result shares this map's
+   *  trie structure rather than copying the keys; for an empty map it is `Set.empty`.
+   */
   override def keySet: Set[K] = if (size == 0) Set.empty else new HashKeySet
 
 
@@ -79,15 +89,24 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     override def filterNot(pred: K => Boolean): Set[K] = newKeySetOrThis(HashMap.this.filterNot(kv => pred(kv._1)))
   }
 
+  /** Returns an iterator over the key-value pairs of this map, in the depth-first order of the
+   *  underlying trie (payload entries of a node before its sub-nodes).
+   */
   def iterator: Iterator[(K, V)] = {
     if (isEmpty) Iterator.empty
     else new MapKeyValueTupleIterator[K, V](rootNode)
   }
 
+  /** Returns an iterator over the keys of this map, in the same order as `iterator`, without
+   *  allocating a tuple per entry.
+   */
   override def keysIterator: Iterator[K] = {
     if (isEmpty) Iterator.empty
     else new MapKeyIterator[K, V](rootNode)
   }
+  /** Returns an iterator over the values of this map, in the same order as `iterator`, without
+   *  allocating a tuple per entry.
+   */
   override def valuesIterator: Iterator[V] = {
     if (isEmpty) Iterator.empty
     else new MapValueIterator[K, V](rootNode)
@@ -98,10 +117,26 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     else new MapKeyValueTupleReverseIterator[K, V](rootNode)
   }
 
+  /** Returns a stepper over the key-value pairs of this map that supports efficient splitting,
+   *  for use with Java streams and parallel processing. The stepper walks the trie nodes
+   *  directly rather than going through an iterator.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape the implicit evidence selecting the stepper implementation for `(K, V)` tuples
+   *  @return an efficiently splittable stepper over the key-value pairs
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[(K, V), S]): S & EfficientSplit =
     shape.
       parUnbox(collection.convert.impl.AnyChampStepper.from[(K, V), MapNode[K, V]](size, rootNode, (node, i) => node.getPayload(i)))
 
+  /** Returns a stepper over the keys of this map that supports efficient splitting, for use with
+   *  Java streams and parallel processing. When the key type is `Int`, `Long`, or `Double`, the
+   *  returned stepper is a primitive one that avoids boxing.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape the implicit evidence selecting the stepper implementation for the key type
+   *  @return an efficiently splittable stepper over the keys
+   */
   override def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S & EfficientSplit = {
     import collection.convert.impl._
     val s = shape.shape match {
@@ -113,6 +148,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns a stepper over the values of this map that supports efficient splitting, for use
+   *  with Java streams and parallel processing. When the value type is `Int`, `Long`, or
+   *  `Double`, the returned stepper is a primitive one that avoids boxing.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape the implicit evidence selecting the stepper implementation for the value type
+   *  @return an efficiently splittable stepper over the values
+   */
   override def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S & EfficientSplit = {
     import collection.convert.impl._
     val s = shape.shape match {
@@ -124,24 +167,49 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Tests whether this map contains a binding for a key.
+   *
+   *  @param key the key to look up
+   *  @return `true` if this map contains a binding for `key`, `false` otherwise
+   */
   override final def contains(key: K): Boolean = {
     val keyUnimprovedHash = key.##
     val keyHash = improve(keyUnimprovedHash)
     rootNode.containsKey(key, keyUnimprovedHash, keyHash, 0)
   }
 
+  /** Returns the value associated with a key.
+   *
+   *  @param key the key to look up
+   *  @return the value associated with `key`
+   *  @throws NoSuchElementException if this map contains no binding for `key`
+   */
   override def apply(key: K): V = {
     val keyUnimprovedHash = key.##
     val keyHash = improve(keyUnimprovedHash)
     rootNode.apply(key, keyUnimprovedHash, keyHash, 0)
   }
 
+  /** Optionally returns the value associated with a key.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if `key` is bound to `value` in this map, `None` otherwise
+   */
   def get(key: K): Option[V] = {
     val keyUnimprovedHash = key.##
     val keyHash = improve(keyUnimprovedHash)
     rootNode.get(key, keyUnimprovedHash, keyHash, 0)
   }
 
+  /** Returns the value associated with a key, or a default value if the key is not contained in
+   *  this map.
+   *
+   *  @tparam V1 the result type, a supertype of `V`
+   *  @param key the key to look up
+   *  @param default a computation that yields the default value; only evaluated if `key` is not
+   *                bound in this map
+   *  @return the value bound to `key`, or `default` if `key` is not bound
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val keyUnimprovedHash = key.##
     val keyHash = improve(keyUnimprovedHash)
@@ -151,20 +219,63 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
   @inline private def newHashMapOrThis[V1 >: V](newRootNode: BitmapIndexedMapNode[K, V1]): HashMap[K, V1] =
     if (newRootNode eq rootNode) this else new HashMap(newRootNode)
 
+  /** Returns a map containing all key-value pairs of this map, with `key` bound to `value`,
+   *  replacing any existing binding for `key`.
+   *
+   *  This map is returned unchanged when it already holds the binding by identity, that is,
+   *  when the stored key is reference-equal to `key` and the stored value is reference-equal
+   *  to `value`. A stored key that is merely equal to `key` is replaced, producing a new map.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a map with `key` bound to `value`, or this map if it already holds that exact
+   *          binding
+   */
   def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] = {
     val keyUnimprovedHash = key.##
     newHashMapOrThis(rootNode.updated(key, value, keyUnimprovedHash, improve(keyUnimprovedHash), 0, replaceValue = true))
   }
 
   // preemptively overridden in anticipation of performance optimizations
+  /** Updates the binding for a key based on its current, optional value. The remapping function
+   *  is applied to `Some(currentValue)` if `key` is bound, or to `None` otherwise; the binding
+   *  is then set to the value in the function's result, or removed if the result is `None`.
+   *  Delegates to the inherited implementation; this override exists only so an optimized
+   *  version can be added without breaking binary compatibility.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param key the key whose binding is updated
+   *  @param remappingFunction the function mapping the current optional value to the new
+   *                          optional value
+   *  @return a map with the binding for `key` updated, added, or removed according to the
+   *          result of `remappingFunction`
+   */
   override def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): HashMap[K, V1] =
     super.updatedWith[V1](key)(remappingFunction)
 
+  /** Returns a map containing all key-value pairs of this map except any binding for `key`. If
+   *  `key` is not bound, returns this map unchanged.
+   *
+   *  @param key the key to remove
+   *  @return a map without a binding for `key`, or this map if none was present
+   */
   def removed(key: K): HashMap[K, V] = {
     val keyUnimprovedHash = key.##
     newHashMapOrThis(rootNode.removed(key, keyUnimprovedHash, improve(keyUnimprovedHash), 0))
   }
 
+  /** Returns a map containing all key-value pairs of this map and of `that`. For keys present in
+   *  both, the binding from `that` wins. When `that` is another `HashMap`, the two tries are
+   *  merged node by node, sharing unchanged subtrees with the inputs; for other collection types
+   *  the entries of `that` are added one at a time, mutating freshly created private nodes in
+   *  place. Where possible, one of the two original maps is returned unchanged.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param that the collection of key-value pairs to add
+   *  @return a map containing all pairs of this map and `that`, with `that` taking precedence
+   *          on duplicate keys
+   */
   override def concat[V1 >: V](that: scala.IterableOnce[(K, V1)]^): HashMap[K, V1] = (that: @unchecked) match {
     case hm: HashMap[K, V1] =>
       if (isEmpty) hm
@@ -262,16 +373,48 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
       }
   }
 
+  /** Returns a map containing all key-value pairs of this map except `head`. As maps are
+   *  unordered, which pair is removed is not defined.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def tail: HashMap[K, V] = this - head._1
 
+  /** Returns a map containing all key-value pairs of this map except `last`. As maps are
+   *  unordered, which pair is removed is not defined.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def init: HashMap[K, V] = this - last._1
 
+  /** Returns the first key-value pair in iteration order. As maps are unordered, which pair is
+   *  first is not defined.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def head: (K, V) = iterator.next()
 
+  /** Returns the last key-value pair in iteration order. As maps are unordered, which pair is
+   *  last is not defined.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def last: (K, V) = reverseIterator.next()
 
+  /** Applies a function to each key-value pair of this map, walking the trie directly rather
+   *  than going through an iterator.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function applied to each key-value pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = rootNode.foreach(f)
 
+  /** Applies a two-argument function to each key and value of this map, without allocating a
+   *  tuple per entry.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function applied to each key and its associated value
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = rootNode.foreachEntry(f)
 
   /** Applies a function to each key, value, and **original** hash value in this Map.
@@ -280,12 +423,23 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
    */
   @inline private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
+  /** Tests whether this map is equal to another object. Two `HashMap`s are compared by their
+   *  root nodes, exploiting the canonical trie structure to compare bitmaps and cached hashes
+   *  before contents; any other object is compared with the generic `Map` equality.
+   *
+   *  @param that the object to compare with
+   *  @return `true` if `that` is a map with the same key-value pairs as this map
+   */
   override def equals(that: Any): Boolean =
     that match {
       case map: HashMap[?, ?] => (this eq map) || (this.rootNode == map.rootNode)
       case _ => super.equals(that)
     }
 
+  /** Returns a hash code compatible with the universal `Map` hash: the unordered MurmurHash3 of
+   *  the key-value pairs. Key hash codes are read from the caches in the trie nodes instead of
+   *  being recomputed.
+   */
   override def hashCode(): Int = {
     if (isEmpty) MurmurHash3.emptyMapHash
     else {
@@ -298,6 +452,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     }
   }
 
+  /** The name of this collection class, used as the prefix in its `toString` representation. */
   override protected def className = "HashMap"
 
   /** Merges this HashMap with an other HashMap by combining all key-value pairs of both maps, and delegating to a merge
@@ -385,6 +540,15 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
       }
     }
 
+  /** Returns a map with the same keys as this map, where each value is the result of applying
+   *  `f` to the key and its current value. The trie structure is reused: subtrees whose values
+   *  are all returned unchanged (by reference) are shared with this map, and if no value
+   *  changes, this map itself is returned.
+   *
+   *  @tparam W the value type of the returned map
+   *  @param f the function applied to each key and its associated value
+   *  @return a map with each value replaced by the result of `f`
+   */
   override def transform[W](f: (K, V) => W): HashMap[K, W] =
     newHashMapOrThis(rootNode.transform[Any](f)).asInstanceOf[HashMap[K, W]]
 
@@ -395,6 +559,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     else new HashMap(newRootNode)
   }
 
+  /** Returns a map containing all key-value pairs of this map except those whose keys occur in
+   *  `keys`. Hash sets are handled specially so their cached key hashes are reused instead of
+   *  recomputed. Returns this map if no key is removed, and stops early with the empty map once
+   *  all entries have been removed.
+   *
+   *  @param keys the keys to remove
+   *  @return a map without bindings for any key in `keys`
+   */
   override def removedAll(keys: IterableOnce[K]^): HashMap[K, V] = {
     if (isEmpty) {
       this
@@ -464,6 +636,13 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     }
   }
 
+  /** Splits this map into a pair of maps: the key-value pairs that satisfy the predicate, and
+   *  those that do not. Delegates to the inherited implementation; this override exists only so
+   *  an optimized version can be added without breaking binary compatibility.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return a pair of maps: the pairs satisfying `p`, and the pairs not satisfying it
+   */
   override def partition(p: ((K, V)) => Boolean): (HashMap[K, V], HashMap[K, V]) = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -473,6 +652,15 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.partition(p)
   }
 
+  /** Returns a map containing the first `n` key-value pairs in iteration order, or this map if
+   *  it has at most `n` entries. As maps are unordered, which pairs are taken is not defined.
+   *  Delegates to the inherited implementation; this override exists only so an optimized
+   *  version can be added without breaking binary compatibility.
+   *
+   *  @param n the number of key-value pairs to take
+   *  @return a map of the first `n` pairs, the empty map if `n` is non-positive, or this map if
+   *          it has at most `n` entries
+   */
   override def take(n: Int): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -482,6 +670,15 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.take(n)
   }
 
+  /** Returns a map containing the last `n` key-value pairs in iteration order, or this map if
+   *  it has at most `n` entries. As maps are unordered, which pairs are taken is not defined.
+   *  Delegates to the inherited implementation; this override exists only so an optimized
+   *  version can be added without breaking binary compatibility.
+   *
+   *  @param n the number of key-value pairs to take
+   *  @return a map of the last `n` pairs, the empty map if `n` is non-positive, or this map if
+   *          it has at most `n` entries
+   */
   override def takeRight(n: Int): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -491,6 +688,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.takeRight(n)
   }
 
+  /** Returns a map containing the longest prefix of key-value pairs, in iteration order, that
+   *  all satisfy the predicate. As maps are unordered, the result is not defined beyond that.
+   *  Delegates to the inherited implementation; this override exists only so an optimized
+   *  version can be added without breaking binary compatibility.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return a map of the longest prefix of pairs satisfying `p`
+   */
   override def takeWhile(p: ((K, V)) => Boolean): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -500,6 +705,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.takeWhile(p)
   }
 
+  /** Returns a map containing the key-value pairs remaining after dropping the longest prefix,
+   *  in iteration order, that all satisfy the predicate. As maps are unordered, the result is
+   *  not defined beyond that. Delegates to the inherited implementation; this override exists
+   *  only so an optimized version can be added without breaking binary compatibility.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return a map of the pairs remaining after the longest prefix satisfying `p` is dropped
+   */
   override def dropWhile(p: ((K, V)) => Boolean): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -509,6 +722,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.dropWhile(p)
   }
 
+  /** Returns a map containing all key-value pairs except the last `n` in iteration order. As
+   *  maps are unordered, which pairs are dropped is not defined. Delegates to the inherited
+   *  implementation; this override exists only so an optimized version can be added without
+   *  breaking binary compatibility.
+   *
+   *  @param n the number of key-value pairs to drop
+   *  @return a map without the last `n` pairs, or this map if `n` is non-positive
+   */
   override def dropRight(n: Int): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -518,6 +739,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.dropRight(n)
   }
 
+  /** Returns a map containing all key-value pairs except the first `n` in iteration order. As
+   *  maps are unordered, which pairs are dropped is not defined. Delegates to the inherited
+   *  implementation; this override exists only so an optimized version can be added without
+   *  breaking binary compatibility.
+   *
+   *  @param n the number of key-value pairs to drop
+   *  @return a map without the first `n` pairs, or this map if `n` is non-positive
+   */
   override def drop(n: Int): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -527,6 +756,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.drop(n)
   }
 
+  /** Splits this map into the longest prefix of key-value pairs, in iteration order, that all
+   *  satisfy the predicate, and the remainder. As maps are unordered, the split point is not
+   *  defined beyond that. Delegates to the inherited implementation; this override exists only
+   *  so an optimized version can be added without breaking binary compatibility.
+   *
+   *  @param p the predicate used to test key-value pairs
+   *  @return a pair of maps: the longest prefix satisfying `p`, and the rest
+   */
   override def span(p: ((K, V)) => Boolean): (HashMap[K, V], HashMap[K, V]) = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -2232,9 +2469,26 @@ object HashMap extends MapFactory[HashMap] {
   @transient
   private final val EmptyMap = new HashMap(MapNode.empty)
 
+  /** Returns the empty `HashMap`: a single shared, immutable instance cast to the requested
+   *  key and value types.
+   *
+   *  @tparam K the key type of the returned map
+   *  @tparam V the value type of the returned map
+   *  @return the shared empty hash map
+   */
   def empty[K, V]: HashMap[K, V] =
     EmptyMap.asInstanceOf[HashMap[K, V]]
 
+  /** Returns a `HashMap` containing the key-value pairs of the given collection. When keys
+   *  repeat, later pairs win. A source that is already a `HashMap` is returned as is, a source
+   *  known to be empty yields the shared empty map, and anything else is copied through a
+   *  builder.
+   *
+   *  @tparam K the key type of the returned map
+   *  @tparam V the value type of the returned map
+   *  @param source the collection of key-value pairs
+   *  @return a hash map containing the pairs of `source`
+   */
   def from[K, V](source: collection.IterableOnce[(K, V)]^): HashMap[K, V] =
     (source: @unchecked) match {
       case hs: HashMap[K, V] => hs

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -40,6 +40,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     with IterableFactoryDefaults[A, HashSet]
     with DefaultSerializable {
 
+  /** Creates an empty hash set, backed by the shared empty root node. */
   def this() = this(SetNode.empty)
 
   // This release fence is present because rootNode may have previously been mutated during construction.
@@ -48,14 +49,26 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
   private def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
     if (rootNode eq newRootNode) this else new HashSet(newRootNode)
 
+  /** Returns the [[HashSet]] companion object, the factory used to build new sets of this kind. */
   override def iterableFactory: IterableFactory[HashSet] = HashSet
 
+  /** Returns the number of elements in this set. The size of a `HashSet` is always
+   *  known, cached in the root node, so this never returns -1.
+   */
   override def knownSize: Int = rootNode.size
 
+  /** Returns the number of elements in this set, read from the root node's cache
+   *  in constant time.
+   */
   override def size: Int = rootNode.size
 
+  /** Returns `true` if this set contains no elements. Constant time. */
   override def isEmpty: Boolean = rootNode.size == 0
 
+  /** Returns an iterator over the elements of this set, traversing the hash trie
+   *  depth-first. The resulting order depends on the elements' hash codes and is
+   *  effectively unspecified.
+   */
   def iterator: Iterator[A] = {
     if (isEmpty) Iterator.empty
     else new SetIterator[A](rootNode)
@@ -63,6 +76,15 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
 
   protected[immutable] def reverseIterator: Iterator[A] = new SetReverseIterator[A](rootNode)
 
+  /** Returns a stepper for the elements of this set, choosing a champ-trie stepper
+   *  specialized to `Int`, `Long`, or `Double` when the element type allows it, and
+   *  a reference stepper otherwise. The stepper supports efficient splitting, for
+   *  use with parallel processing.
+   *
+   *  @tparam S the type of the stepper, determined by the element type via `shape`
+   *  @param shape implicit evidence of the stepper type appropriate for element type `A`
+   *  @return a stepper over the elements of this set that can be split efficiently
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
@@ -74,12 +96,25 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns `true` if this set contains `element`. Elements are compared by their
+   *  hash codes (`##`) and `==`. Expected constant time: at most seven trie levels
+   *  are descended.
+   *
+   *  @param element the element to look for
+   */
   def contains(element: A): Boolean = {
     val elementUnimprovedHash = element.##
     val elementHash = improve(elementUnimprovedHash)
     rootNode.contains(element, elementUnimprovedHash, elementHash, 0)
   }
 
+  /** Returns a set that contains `element` and all elements of this set. Returns
+   *  this set itself if it already contains `element`; otherwise the result shares
+   *  all unaffected trie nodes with this set.
+   *
+   *  @param element the element to add
+   *  @return a set containing all elements of this set plus `element`
+   */
   def incl(element: A): HashSet[A] = {
     val elementUnimprovedHash = element.##
     val elementHash = improve(elementUnimprovedHash)
@@ -87,6 +122,13 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     newHashSetOrThis(newRootNode)
   }
 
+  /** Returns a set that contains all elements of this set except `element`. Returns
+   *  this set itself if it does not contain `element`; otherwise the result shares
+   *  all unaffected trie nodes with this set.
+   *
+   *  @param element the element to remove
+   *  @return a set containing all elements of this set except `element`
+   */
   def excl(element: A): HashSet[A] = {
     val elementUnimprovedHash = element.##
     val elementHash = improve(elementUnimprovedHash)
@@ -94,6 +136,18 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     newHashSetOrThis(newRootNode)
   }
 
+  /** Returns a set containing all elements of this set and of `that`. When `that`
+   *  is also an immutable `HashSet` the two tries are merged structurally, sharing
+   *  unchanged subtrees; when it is a `mutable.HashSet` or `mutable.LinkedHashSet`
+   *  its cached element hashes are reused instead of being recomputed. In every
+   *  case, if `that` contributes no new elements this set itself is returned. The one
+   *  exception comes first: when this set is empty and `that` is an immutable
+   *  `HashSet`, `that` is returned, even where both are empty and so are distinct
+   *  instances of the same set.
+   *
+   *  @param that the elements to add
+   *  @return a set containing the union of this set and `that`
+   */
   override def concat(that: IterableOnce[A]^): HashSet[A] =
     (that: @unchecked) match {
       case hs: HashSet[A] =>
@@ -176,14 +230,38 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
         this
     }
 
+  /** Returns a set containing all elements of this set except `head`, the first
+   *  element in iteration order.
+   *
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def tail: HashSet[A] = this - head
 
+  /** Returns a set containing all elements of this set except `last`, the last
+   *  element in iteration order.
+   *
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def init: HashSet[A] = this - last
 
+  /** Returns the first element in the iteration order of this set.
+   *
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def head: A = iterator.next()
 
+  /** Returns the last element in the iteration order of this set.
+   *
+   *  @throws NoSuchElementException if this set is empty
+   */
   override def last: A = reverseIterator.next()
 
+  /** Applies `f` to each element of this set, for its side effects. Traverses the
+   *  trie directly, without allocating an iterator.
+   *
+   *  @tparam U the result type of `f`; results are discarded
+   *  @param f the function to apply to each element
+   */
   override def foreach[U](f: A => U): Unit = rootNode.foreach(f)
 
   /** Applies a function f to each element, and its corresponding **original** hash, in this Set.
@@ -201,21 +279,50 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
 
   // For binary compatibility, the method used to have this signature by mistake.
   // protected is public in bytecode.
+  /** Returns `true` if this set is a subset of `that`. This overload, restricted to
+   *  immutable sets, exists only for binary compatibility (see the comment above);
+   *  it forwards to the `collection.Set` overload.
+   *
+   *  @param that the set to test against
+   *  @return `true` if every element of this set is contained in `that`
+   */
   protected def subsetOf(that: Set[A]): Boolean = subsetOf(that: collection.Set[A])
 
+  /** Returns `true` if this set is a subset of `that`, i.e. every element of this
+   *  set is contained in `that`. The empty set is a subset of every set. When
+   *  `that` is also a `HashSet` the two tries are compared structurally, level by
+   *  level, instead of testing each element individually.
+   *
+   *  @param that the set to test against
+   *  @return `true` if every element of this set is contained in `that`
+   */
   override def subsetOf(that: collection.Set[A]): Boolean = isEmpty || !that.isEmpty && (that match {
     case set: HashSet[A] => rootNode.subsetOf(set.rootNode, 0)
     case _ => super.subsetOf(that)
   })
 
+  /** Returns `true` if `that` is a set containing the same elements as this set.
+   *  When `that` is also an immutable `HashSet` the root nodes are compared
+   *  structurally (with fast rejection on cached sizes and hash codes); any other
+   *  value is compared with the generic set equality inherited from `Set`.
+   *
+   *  @param that the value to compare with
+   *  @return `true` if `that` is an equal set
+   */
   override def equals(that: Any): Boolean =
     that match {
       case set: HashSet[?] => (this eq set) || (this.rootNode == set.rootNode)
       case _ => super.equals(that)
     }
 
+  /** Returns `"HashSet"`, the collection name used as the prefix in `toString`. */
   override protected def className = "HashSet"
 
+  /** Returns a hash code consistent with `equals`: an unordered MurmurHash3 hash
+   *  over the elements' original hash codes, which are read from the trie's cache
+   *  rather than recomputed. Equal to the hash code of any other `Set` with the
+   *  same elements.
+   */
   override def hashCode(): Int = {
     val it = new SetHashIterator(rootNode)
     val hash = MurmurHash3.unorderedHash(it, MurmurHash3.setSeed)
@@ -223,6 +330,16 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     hash
   }
 
+  /** Returns a set containing the elements of this set that are not contained in
+   *  `that`. When `that` is also an immutable `HashSet` the tries are diffed
+   *  structurally, sharing unchanged subtrees; when it is a `mutable.HashSet` its
+   *  cached element hashes are reused; otherwise a size heuristic chooses between
+   *  removing `that`'s elements from this set and filtering this set by
+   *  `that.contains`. Returns this set itself when nothing is removed.
+   *
+   *  @param that the set of elements to remove
+   *  @return a set containing the elements of this set not present in `that`
+   */
   override def diff(that: collection.Set[A]): HashSet[A] = {
     if (isEmpty) {
       this
@@ -317,6 +434,16 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     this
   }
 
+  /** Returns a set containing the elements of this set that are not contained in
+   *  `that`. Delegates to `diff` when `that` is a set. For a `Range` with more
+   *  elements than this set, filters this set's `Int` elements by range membership
+   *  (keeping any non-`Int` elements) instead of iterating the whole range.
+   *  Otherwise removes `that`'s elements one by one, mutating only privately
+   *  created nodes.
+   *
+   *  @param that the elements to remove
+   *  @return a set containing the elements of this set not present in `that`
+   */
   override def removedAll(that: IterableOnce[A]^): HashSet[A] = (that: @unchecked) match {
     case set: scala.collection.Set[A] => diff(set)
     case range: Range if range.length > size =>
@@ -329,12 +456,29 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
       removedAllWithShallowMutations(that)
   }
 
+  /** Returns a pair of sets: the elements of this set that satisfy `p`, and those
+   *  that do not. This override only forwards to the inherited implementation; it
+   *  exists so that an optimized implementation can be introduced in a minor
+   *  release without breaking binary compatibility.
+   *
+   *  @param p the predicate on which to partition
+   *  @return a pair of sets: (elements satisfying `p`, elements not satisfying `p`)
+   */
   override def partition(p: A => Boolean): (HashSet[A], HashSet[A]) = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.partition(p)
   }
 
+  /** Returns a pair of sets: the longest prefix of this set's iteration order whose
+   *  elements all satisfy `p`, and the rest of the elements. This override only
+   *  forwards to the inherited implementation; it exists so that an optimized
+   *  implementation can be introduced in a minor release without breaking binary
+   *  compatibility.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of sets: (longest prefix satisfying `p`, remaining elements)
+   */
   override def span(p: A => Boolean): (HashSet[A], HashSet[A]) = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -348,42 +492,106 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     else new HashSet(newRootNode)
   }
 
+  /** Returns a set containing the elements of this set that are also contained in
+   *  `that`. This override only forwards to the inherited implementation; it exists
+   *  so that an optimized implementation can be introduced in a minor release
+   *  without breaking binary compatibility.
+   *
+   *  @param that the set to intersect with
+   *  @return a set containing the elements common to this set and `that`
+   */
   override def intersect(that: collection.Set[A]): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.intersect(that)
   }
 
+  /** Returns a set containing the first `n` elements of this set's iteration
+   *  order, or this whole set if it has at most `n` elements. This override only
+   *  forwards to the inherited implementation; it exists so that an optimized
+   *  implementation can be introduced in a minor release without breaking binary
+   *  compatibility.
+   *
+   *  @param n the number of elements to take; a negative value is treated as 0
+   *  @return a set containing the first `n` elements, all of them if there are fewer
+   *          than `n`, or the empty set if `n` is not positive
+   */
   override def take(n: Int): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.take(n)
   }
 
+  /** Returns a set containing the last `n` elements of this set's iteration order,
+   *  or this whole set if it has at most `n` elements. This override only forwards
+   *  to the inherited implementation; it exists so that an optimized implementation
+   *  can be introduced in a minor release without breaking binary compatibility.
+   *
+   *  @param n the number of elements to take; a negative value is treated as 0
+   *  @return a set containing the last `n` elements, all of them if there are fewer
+   *          than `n`, or the empty set if `n` is not positive
+   */
   override def takeRight(n: Int): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.takeRight(n)
   }
 
+  /** Returns a set containing the longest prefix of this set's iteration order
+   *  whose elements all satisfy `p`. This override only forwards to the inherited
+   *  implementation; it exists so that an optimized implementation can be
+   *  introduced in a minor release without breaking binary compatibility.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a set containing the longest prefix whose elements satisfy `p`
+   */
   override def takeWhile(p: A => Boolean): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.takeWhile(p)
   }
 
+  /** Returns a set containing all elements of this set except the first `n` of its
+   *  iteration order, or the empty set if this set has at most `n` elements. This
+   *  override only forwards to the inherited implementation; it exists so that an
+   *  optimized implementation can be introduced in a minor release without breaking
+   *  binary compatibility.
+   *
+   *  @param n the number of elements to drop; a negative value is treated as 0
+   *  @return a set containing all but the first `n` elements, or this whole set if `n`
+   *          is not positive
+   */
   override def drop(n: Int): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.drop(n)
   }
 
+  /** Returns a set containing all elements of this set except the last `n` of its
+   *  iteration order, or the empty set if this set has at most `n` elements. This
+   *  override only forwards to the inherited implementation; it exists so that an
+   *  optimized implementation can be introduced in a minor release without breaking
+   *  binary compatibility.
+   *
+   *  @param n the number of elements to drop; a negative value is treated as 0
+   *  @return a set containing all but the last `n` elements, or this whole set if `n`
+   *          is not positive
+   */
   override def dropRight(n: Int): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     super.dropRight(n)
   }
 
+  /** Returns a set containing all elements of this set except the longest prefix
+   *  of its iteration order whose elements all satisfy `p`. This override only
+   *  forwards to the inherited implementation; it exists so that an optimized
+   *  implementation can be introduced in a minor release without breaking binary
+   *  compatibility.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a set containing the elements after the longest prefix satisfying `p`
+   */
   override def dropWhile(p: A => Boolean): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
@@ -1941,9 +2149,24 @@ object HashSet extends IterableFactory[HashSet] {
   @transient
   private final val EmptySet = new HashSet(SetNode.empty)
 
+  /** Returns the empty immutable hash set. Always the same cached instance, cast
+   *  to the requested element type; the cast is safe because the set contains no
+   *  elements.
+   *
+   *  @tparam A the element type of the set
+   *  @return the empty `HashSet`
+   */
   def empty[A]: HashSet[A] =
     EmptySet.asInstanceOf[HashSet[A]]
 
+  /** Returns a `HashSet` containing the elements of `source`. Returns `source`
+   *  itself if it already is a `HashSet`, and the shared empty set if `source` is
+   *  known to be empty; otherwise builds a new set.
+   *
+   *  @tparam A the element type of the set
+   *  @param source the elements of the resulting set
+   *  @return a `HashSet` containing the elements of `source`
+   */
   def from[A](source: collection.IterableOnce[A]^): HashSet[A] =
     (source: @unchecked) match {
       case hs: HashSet[A] => hs

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -34,8 +34,23 @@ trait Map[K, +V]
      with MapOps[K, V, Map, Map[K, V]]
      with MapFactoryDefaults[K, V, Map, Iterable] {
 
+  /** Returns the `immutable.Map` companion object as the factory for maps of this kind. */
   override def mapFactory: scala.collection.MapFactory[Map] = Map
 
+  /** Returns this map, typed as an immutable `Map[K2, V2]`.
+   *
+   *  Since this map is already immutable, a non-empty default map implementation is
+   *  returned unchanged, without copying; implementations with a reified key type,
+   *  such as sorted maps, are rebuilt as a default `Map`. Any empty map yields the
+   *  shared `Map.empty`, so an empty `HashMap`, `ListMap` or `VectorMap` is not
+   *  returned unchanged.
+   *
+   *  @tparam K2 the key type of the resulting map, a supertype of `K`
+   *  @tparam V2 the value type of the resulting map, a supertype of `V`
+   *  @param ev evidence that the element type `(K, V)` conforms to `(K2, V2)`;
+   *            never called
+   *  @return this map, widened to `Map[K2, V2]`
+   */
   override final def toMap[K2, V2](implicit ev: (K, V) <:< (K2, V2)): Map[K2, V2] = Map.from(this.asInstanceOf[Map[K2, V2]])
 
   /** The same map with a given default function.
@@ -78,6 +93,9 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
     with collection.MapOps[K, V, CC, C]
     with caps.Pure {
 
+  /** Returns this map, typed as both the concrete map type `C` and `CC[K, V]`,
+   *  so that it can be used where either type is required.
+   */
   protected def coll: C & CC[K, V]
 
   /** Removes a key from this map, returning a new map.
@@ -93,6 +111,15 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   @`inline` final def - (key: K): C = removed(key)
 
+  /** Returns a $coll with the two given keys and all keys in `keys` removed, by
+   *  chaining `removed`.
+   *
+   *  @param key1 the first key to remove
+   *  @param key2 the second key to remove
+   *  @param keys the remaining keys to remove
+   *  @return a $coll without bindings for any of the given keys; the built-in
+   *          immutable maps return themselves when none of the keys is bound
+   */
   @deprecated("Use -- with an explicit collection", "2.13.0")
   def - (key1: K, key2: K, keys: K*): C = removed(key1).removed(key2).removedAll(keys)
 
@@ -160,6 +187,13 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   def transform[W](f: (K, V) => W): CC[K, W] = map { case (k, v) => (k, f(k, v)) }
 
+  /** Returns an immutable set of the keys contained in this map.
+   *
+   *  The returned set holds a reference to this map and reads the keys from it
+   *  lazily, rather than copying them.
+   *
+   *  @return a set containing the keys of this map
+   */
   override def keySet: Set[K] = new LazyImmutableKeySet
 
   /** The implementation class of the set returned by `keySet`. */
@@ -183,6 +217,16 @@ transparent trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?]
     with collection.StrictOptimizedMapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {
 
+  /** Returns a $coll containing the key/value pairs of this $coll followed
+   *  by those of `that`, built eagerly by adding the pairs one at a time to this
+   *  $coll, so an empty `that` leaves this $coll itself as the result.
+   *
+   *  Pairs in `that` override pairs of this $coll with the same key.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param that the key/value pairs to add
+   *  @return a $coll with the combined bindings
+   */
   override def concat [V1 >: V](that: collection.IterableOnce[(K, V1)]^): CC[K, V1] = {
     var result: CC[K, V1] = coll
     val it = that.iterator
@@ -199,42 +243,129 @@ transparent trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?]
 @SerialVersionUID(3L)
 object Map extends MapFactory[Map] {
 
+  /** An immutable map that wraps `underlying` and adds a default function,
+   *  used by `apply` when a requested key is not present.
+   *
+   *  Only `apply` uses the default; `get`, `contains`, `iterator`, and other
+   *  queries are unaffected. Operations that produce a map of the same type,
+   *  such as `updated`, `removed`, `concat`, and `filter`, preserve the
+   *  default; transformations to other element types, such as `map` and
+   *  `flatMap`, return maps without it.
+   *
+   *  @tparam K the type of the keys in this map
+   *  @tparam V the type of the values associated with the keys
+   *  @param underlying the map providing the actual bindings
+   *  @param defaultValue the function computing a default value for a missing key
+   */
   @SerialVersionUID(3L)
   class WithDefault[K, +V](val underlying: Map[K, V], val defaultValue: K -> V)
     extends AbstractMap[K, V]
       with MapOps[K, V, Map, WithDefault[K, V]] with Serializable {
 
+    /** Returns the value associated with `key` in the underlying map as an
+     *  option. The default value is not used.
+     *
+     *  @param key the key value
+     *  @return an option value containing the value associated with `key`, or
+     *          `None` if `key` is not present in the underlying map
+     */
     def get(key: K): Option[V] = underlying.get(key)
 
+    /** Defines the default value computation for the map, returned by `apply`
+     *  when a key is not found.
+     *
+     *  @param key the given key value for which a binding is missing
+     *  @return the result of applying `defaultValue` to `key`
+     */
     override def default(key: K): V = defaultValue(key)
 
+    /** Returns the factory for `Iterable` collections used by the underlying map. */
     override def iterableFactory: IterableFactory[Iterable] = underlying.iterableFactory
 
+    /** Returns an iterator over the key/value pairs of the underlying map. */
     def iterator: Iterator[(K, V)] = underlying.iterator
 
+    /** Returns `true` if the underlying map contains no bindings. */
     override def isEmpty: Boolean = underlying.isEmpty
 
+    /** Returns the factory of the underlying map. Maps it builds do not have a default value. */
     override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
+    /** Returns a new `WithDefault` map containing the bindings of the
+     *  underlying map followed by those of `xs`, with the same default value
+     *  function as this map.
+     *
+     *  Bindings in `xs` override bindings of this map with the same key.
+     *
+     *  @tparam V2 the value type of the returned map, a supertype of `V`
+     *  @param xs the key/value pairs to add
+     *  @return a new `WithDefault` map with the combined bindings and this map's default
+     */
     override def concat [V2 >: V](xs: collection.IterableOnce[(K, V2)]^): WithDefault[K, V2] =
       new WithDefault(underlying.concat(xs), defaultValue)
 
+    /** Returns a new `WithDefault` map with the binding for `key` removed from
+     *  the underlying map, and with the same default value function as this map.
+     *
+     *  @param key the key to remove
+     *  @return a new `WithDefault` map without a binding for `key`
+     */
     def removed(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.removed(key), defaultValue)
 
+    /** Returns a new `WithDefault` map with `key` bound to `value`, replacing
+     *  any existing binding, and with the same default value function as this
+     *  map.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new `WithDefault` map with the binding added and this map's default
+     */
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
+    /** Returns a new, empty `WithDefault` map with the same default value function as this map. */
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
+    /** Returns a new `WithDefault` map containing the elements of `coll` and
+     *  the same default value function as this map.
+     *
+     *  @param coll the key/value pairs for the new map
+     *  @return a new `WithDefault` map with those bindings and this map's default
+     */
     override protected def fromSpecific(coll: (collection.IterableOnce[(K, V)]^) @uncheckedVariance): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
+    /** Returns a builder that produces a `WithDefault` map with the same default value function as this map. */
     override protected def newSpecificBuilder: Builder[(K, V), WithDefault[K, V]] @uncheckedVariance =
       Map.newBuilder.mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 
+  /** Returns the empty immutable map.
+   *
+   *  A single empty map instance is shared: the same instance is returned for
+   *  every call, cast to the requested key and value types.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return the empty immutable map
+   */
   def empty[K, V]: Map[K, V] = EmptyMap.asInstanceOf[Map[K, V]]
 
+  /** Returns an immutable map containing the key/value pairs of `it`.
+   *
+   *  An empty `Iterable` yields the shared empty map. Otherwise, if `it` is already
+   *  one of the default immutable map implementations, such as a `HashMap`,
+   *  `ListMap`, `VectorMap`, or one of the specialized small maps, it is returned
+   *  unchanged. In every other case, including for maps with a reified key type such
+   *  as sorted maps, a new map is built from its elements, with later bindings
+   *  overriding earlier ones with the same key.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the source collection of key/value pairs
+   *  @return an immutable map with the bindings of `it`
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): Map[K, V] =
     (it: @unchecked) match {
       case it: Iterable[?] if it.isEmpty => empty[K, V]
@@ -261,6 +392,13 @@ object Map extends MapFactory[Map] {
       case _ => newBuilder[K, V].addAll(it).result()
     }
 
+  /** Returns a new builder for an immutable map.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return a builder that produces the specialized small maps for up to four
+   *          distinct keys, and a `HashMap` beyond that
+   */
   def newBuilder[K, V]: Builder[(K, V), Map[K, V]] = new MapBuilderImpl
 
   @SerialVersionUID(3L)
@@ -283,37 +421,118 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  /** An immutable map with exactly one binding, stored directly in fields.
+   *
+   *  @tparam K the type of the key
+   *  @tparam V the type of the value
+   *  @param key1 the key of the single binding
+   *  @param value1 the value of the single binding
+   */
   @SerialVersionUID(3L)
   final class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] with Serializable {
+    /** Returns `1`: this map has exactly one binding. */
     override def size: Int = 1
+    /** Returns `1`: the size is always known. */
     override def knownSize: Int = 1
+    /** Returns `false`: this map always has one binding. */
     override def isEmpty: Boolean = false
+    /** Returns the value associated with `key`.
+     *
+     *  @param key the key to look up
+     *  @return the value associated with `key`
+     *  @throws NoSuchElementException if `key` is not the key of this map
+     */
     override def apply(key: K): V = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
+    /** Returns `true` if `key` is the key of this map, `false` otherwise.
+     *
+     *  @param key the key to test
+     */
     override def contains(key: K): Boolean = key == key1
+    /** Returns the value associated with `key` as an option.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value associated with `key`, or `None` if `key`
+     *          is not the key of this map
+     */
     def get(key: K): Option[V] =
       if (key == key1) Some(value1) else None
+    /** Returns the value associated with `key`, or `default` if `key` is not
+     *  present.
+     *
+     *  @tparam V1 the type of the result, a supertype of `V`
+     *  @param key the key to look up
+     *  @param default the value to return if `key` is not present; evaluated
+     *                 only in that case
+     *  @return the value associated with `key`, or the value of `default`
+     */
     override def getOrElse [V1 >: V](key: K, default: => V1): V1 =
       if (key == key1) value1 else default
+    /** Returns an iterator over the single key/value pair of this map. */
     def iterator: Iterator[(K, V)] = Iterator.single((key1, value1))
+    /** Returns an iterator over the single key of this map. */
     override def keysIterator: Iterator[K] = Iterator.single(key1)
+    /** Returns an iterator over the single value of this map. */
     override def valuesIterator: Iterator[V] = Iterator.single(value1)
+    /** Returns a new map with `key` bound to `value`.
+     *
+     *  If `key` equals the key of this map, returns a new `Map1` with the
+     *  value replaced; otherwise returns a `Map2` with both bindings.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new map of one or two bindings containing `key -> value`
+     */
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map1(key1, value)
       else new Map2(key1, value1, key, value)
+    /** Returns the empty map if `key` is the key of this map, or this map
+     *  itself otherwise.
+     *
+     *  @param key the key to remove
+     *  @return a map without a binding for `key`
+     */
     def removed(key: K): Map[K, V] =
       if (key == key1) Map.empty else this
+    /** Applies `f` to the single key/value pair of this map.
+     *
+     *  @tparam U the result type of `f`; the result is discarded
+     *  @param f the function to apply
+     */
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
     }
+    /** Returns `true` if the single key/value pair of this map satisfies `p`.
+     *
+     *  @param p the predicate to test
+     */
     override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1))
+    /** Returns `true` if the single key/value pair of this map satisfies `p`.
+     *  With exactly one binding, `forall` and `exists` coincide.
+     *
+     *  @param p the predicate to test
+     */
     override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1))
     override protected[collection] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] =
       if (pred((key1, value1)) != isFlipped) this else Map.empty
+    /** Returns a map obtained by applying `f` to the key and value of this map.
+     *
+     *  If the transformed value is reference-equal to the current value, this
+     *  map itself is returned; otherwise a new `Map1` with the same key and
+     *  the transformed value.
+     *
+     *  @tparam W the type of the transformed value
+     *  @param f the transformation function, applied to the key and value
+     *  @return a one-binding map with the same key and the transformed value
+     */
     override def transform[W](f: (K, V) => W): Map[K, W] = {
       val walue1 = f(key1, value1)
       if (walue1.asInstanceOf[AnyRef] eq value1.asInstanceOf[AnyRef]) this.asInstanceOf[Map[K, W]]
       else new Map1(key1, walue1)
     }
+    /** Returns a hash code computed with MurmurHash3 from the single key/value
+     *  pair, equal to the hash code of any other map with the same binding.
+     */
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       var a, b = 0
@@ -333,30 +552,70 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  /** An immutable map with exactly two bindings, stored directly in fields.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param key1 the key of the first binding
+   *  @param value1 the value of the first binding
+   *  @param key2 the key of the second binding
+   *  @param value2 the value of the second binding
+   */
   @SerialVersionUID(3L)
   final class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] with Serializable {
+    /** Returns `2`: this map has exactly two bindings. */
     override def size: Int = 2
+    /** Returns `2`: the size is always known. */
     override def knownSize: Int = 2
+    /** Returns `false`: this map always has two bindings. */
     override def isEmpty: Boolean = false
+    /** Returns the value associated with `key`.
+     *
+     *  @param key the key to look up
+     *  @return the value associated with `key`
+     *  @throws NoSuchElementException if `key` is not a key of this map
+     */
     override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else throw new NoSuchElementException("key not found: " + key)
+    /** Returns `true` if `key` is one of the keys of this map, `false` otherwise.
+     *
+     *  @param key the key to test
+     */
     override def contains(key: K): Boolean = (key == key1) || (key == key2)
+    /** Returns the value associated with `key` as an option.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value associated with `key`, or `None` if `key`
+     *          is not a key of this map
+     */
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else None
+    /** Returns the value associated with `key`, or `default` if `key` is not
+     *  present.
+     *
+     *  @tparam V1 the type of the result, a supertype of `V`
+     *  @param key the key to look up
+     *  @param default the value to return if `key` is not present; evaluated
+     *                 only in that case
+     *  @return the value associated with `key`, or the value of `default`
+     */
     override def getOrElse [V1 >: V](key: K, default: => V1): V1 =
       if (key == key1) value1
       else if (key == key2) value2
       else default
+    /** Returns an iterator over the two key/value pairs of this map. */
     def iterator: Iterator[(K, V)] = new Map2Iterator[(K, V)] {
       override protected def nextResult(k: K, v: V): (K, V) = (k, v)
     }
+    /** Returns an iterator over the two keys of this map. */
     override def keysIterator: Iterator[K] = new Map2Iterator[K] {
       override protected def nextResult(k: K, v: V): K = k
     }
+    /** Returns an iterator over the two values of this map. */
     override def valuesIterator: Iterator[V] = new Map2Iterator[V] {
       override protected def nextResult(k: K, v: V): V = v
     }
@@ -376,18 +635,51 @@ object Map extends MapFactory[Map] {
       override def drop(n: Int): Iterator[A] = { i += n; this }
       protected def nextResult(k: K, v: V @uncheckedVariance): A
     }
+    /** Returns a new map with `key` bound to `value`.
+     *
+     *  If `key` equals one of the keys of this map, returns a new `Map2` with
+     *  that key's value replaced; otherwise returns a `Map3` with the new
+     *  binding added after the existing ones.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new map of two or three bindings containing `key -> value`
+     */
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map2(key1, value, key2, value2)
       else if (key == key2) new Map2(key1, value1, key2, value)
       else new Map3(key1, value1, key2, value2, key, value)
+    /** Returns a `Map1` of the remaining binding if `key` is a key of this
+     *  map, or this map itself otherwise.
+     *
+     *  @param key the key to remove
+     *  @return a map without a binding for `key`
+     */
     def removed(key: K): Map[K, V] =
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
+    /** Applies `f` to each key/value pair of this map.
+     *
+     *  @tparam U the result type of `f`; the results are discarded
+     *  @param f the function to apply
+     */
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
     }
+    /** Returns `true` if at least one key/value pair of this map satisfies
+     *  `p`. The predicate is not applied to the second pair if the first one
+     *  satisfies it.
+     *
+     *  @param p the predicate to test
+     */
     override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2))
+    /** Returns `true` if both key/value pairs of this map satisfy `p`. The
+     *  predicate is not applied to the second pair if the first one fails it.
+     *
+     *  @param p the predicate to test
+     */
     override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2))
     override protected[collection] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
       var k1 = null.asInstanceOf[K]
@@ -402,6 +694,16 @@ object Map extends MapFactory[Map] {
         case 2 => this
       }
     }
+    /** Returns a map obtained by applying `f` to each key and its value.
+     *
+     *  If every transformed value is reference-equal to the current one, this
+     *  map itself is returned; otherwise a new `Map2` with the same keys and
+     *  the transformed values.
+     *
+     *  @tparam W the type of the transformed values
+     *  @param f the transformation function, applied to each key and its value
+     *  @return a two-binding map with the same keys and the transformed values
+     */
     override def transform[W](f: (K, V) => W): Map[K, W] = {
       val walue1 = f(key1, value1)
       val walue2 = f(key2, value2)
@@ -409,6 +711,9 @@ object Map extends MapFactory[Map] {
           (walue2.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef])) this.asInstanceOf[Map[K, W]]
       else new Map2(key1, walue1, key2, walue2)
     }
+    /** Returns a hash code computed with MurmurHash3 from the two key/value
+     *  pairs, equal to the hash code of any other map with the same bindings.
+     */
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       var a, b = 0
@@ -433,33 +738,75 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  /** An immutable map with exactly three bindings, stored directly in fields.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param key1 the key of the first binding
+   *  @param value1 the value of the first binding
+   *  @param key2 the key of the second binding
+   *  @param value2 the value of the second binding
+   *  @param key3 the key of the third binding
+   *  @param value3 the value of the third binding
+   */
   @SerialVersionUID(3L)
   class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] with Serializable {
+    /** Returns `3`: this map has exactly three bindings. */
     override def size: Int = 3
+    /** Returns `3`: the size is always known. */
     override def knownSize: Int = 3
+    /** Returns `false`: this map always has three bindings. */
     override def isEmpty: Boolean = false
+    /** Returns the value associated with `key`.
+     *
+     *  @param key the key to look up
+     *  @return the value associated with `key`
+     *  @throws NoSuchElementException if `key` is not a key of this map
+     */
     override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else throw new NoSuchElementException("key not found: " + key)
+    /** Returns `true` if `key` is one of the keys of this map, `false` otherwise.
+     *
+     *  @param key the key to test
+     */
     override def contains(key: K): Boolean = (key == key1) || (key == key2) || (key == key3)
+    /** Returns the value associated with `key` as an option.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value associated with `key`, or `None` if `key`
+     *          is not a key of this map
+     */
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else if (key == key3) Some(value3)
       else None
+    /** Returns the value associated with `key`, or `default` if `key` is not
+     *  present.
+     *
+     *  @tparam V1 the type of the result, a supertype of `V`
+     *  @param key the key to look up
+     *  @param default the value to return if `key` is not present; evaluated
+     *                 only in that case
+     *  @return the value associated with `key`, or the value of `default`
+     */
     override def getOrElse [V1 >: V](key: K, default: => V1): V1 =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else default
+    /** Returns an iterator over the three key/value pairs of this map. */
     def iterator: Iterator[(K, V)] = new Map3Iterator[(K, V)] {
       override protected def nextResult(k: K, v: V): (K, V) = (k, v)
     }
+    /** Returns an iterator over the three keys of this map. */
     override def keysIterator: Iterator[K] = new Map3Iterator[K] {
       override protected def nextResult(k: K, v: V): K = k
     }
+    /** Returns an iterator over the three values of this map. */
     override def valuesIterator: Iterator[V] = new Map3Iterator[V] {
       override protected def nextResult(k: K, v: V): V = v
     }
@@ -480,20 +827,53 @@ object Map extends MapFactory[Map] {
       override def drop(n: Int): Iterator[A] = { i += n; this }
       protected def nextResult(k: K, v: V @uncheckedVariance): A
     }
+    /** Returns a new map with `key` bound to `value`.
+     *
+     *  If `key` equals one of the keys of this map, returns a new `Map3` with
+     *  that key's value replaced; otherwise returns a `Map4` with the new
+     *  binding added after the existing ones.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new map of three or four bindings containing `key -> value`
+     */
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1)      new Map3(key1, value, key2, value2, key3, value3)
       else if (key == key2) new Map3(key1, value1, key2, value, key3, value3)
       else if (key == key3) new Map3(key1, value1, key2, value2, key3, value)
       else new Map4(key1, value1, key2, value2, key3, value3, key, value)
+    /** Returns a `Map2` of the remaining bindings if `key` is a key of this
+     *  map, or this map itself otherwise.
+     *
+     *  @param key the key to remove
+     *  @return a map without a binding for `key`
+     */
     def removed(key: K): Map[K, V] =
       if (key == key1)      new Map2(key2, value2, key3, value3)
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
       else this
+    /** Applies `f` to each key/value pair of this map.
+     *
+     *  @tparam U the result type of `f`; the results are discarded
+     *  @param f the function to apply
+     */
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
     }
+    /** Returns `true` if at least one key/value pair of this map satisfies
+     *  `p`. The predicate is not applied to the remaining pairs once one
+     *  satisfies it.
+     *
+     *  @param p the predicate to test
+     */
     override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2)) || p((key3, value3))
+    /** Returns `true` if all three key/value pairs of this map satisfy `p`.
+     *  The predicate is not applied to the remaining pairs once one fails it.
+     *
+     *  @param p the predicate to test
+     */
     override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2)) && p((key3, value3))
     override protected[collection] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
       var k1, k2 = null.asInstanceOf[K]
@@ -510,6 +890,16 @@ object Map extends MapFactory[Map] {
         case 3 => this
       }
     }
+    /** Returns a map obtained by applying `f` to each key and its value.
+     *
+     *  If every transformed value is reference-equal to the current one, this
+     *  map itself is returned; otherwise a new `Map3` with the same keys and
+     *  the transformed values.
+     *
+     *  @tparam W the type of the transformed values
+     *  @param f the transformation function, applied to each key and its value
+     *  @return a three-binding map with the same keys and the transformed values
+     */
     override def transform[W](f: (K, V) => W): Map[K, W] = {
       val walue1 = f(key1, value1)
       val walue2 = f(key2, value2)
@@ -519,6 +909,9 @@ object Map extends MapFactory[Map] {
           (walue3.asInstanceOf[AnyRef] eq value3.asInstanceOf[AnyRef])) this.asInstanceOf[Map[K, W]]
       else new Map3(key1, walue1, key2, walue2, key3, walue3)
     }
+    /** Returns a hash code computed with MurmurHash3 from the three key/value
+     *  pairs, equal to the hash code of any other map with the same bindings.
+     */
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       var a, b = 0
@@ -548,38 +941,82 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  /** An immutable map with exactly four bindings, stored directly in fields.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param key1 the key of the first binding
+   *  @param value1 the value of the first binding
+   *  @param key2 the key of the second binding
+   *  @param value2 the value of the second binding
+   *  @param key3 the key of the third binding
+   *  @param value3 the value of the third binding
+   *  @param key4 the key of the fourth binding
+   *  @param value4 the value of the fourth binding
+   */
   @SerialVersionUID(3L)
   final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V)
     extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] with Serializable {
 
+    /** Returns `4`: this map has exactly four bindings. */
     override def size: Int = 4
+    /** Returns `4`: the size is always known. */
     override def knownSize: Int = 4
+    /** Returns `false`: this map always has four bindings. */
     override def isEmpty: Boolean = false
+    /** Returns the value associated with `key`.
+     *
+     *  @param key the key to look up
+     *  @return the value associated with `key`
+     *  @throws NoSuchElementException if `key` is not a key of this map
+     */
     override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else if (key == key4) value4
       else throw new NoSuchElementException("key not found: " + key)
+    /** Returns `true` if `key` is one of the keys of this map, `false` otherwise.
+     *
+     *  @param key the key to test
+     */
     override def contains(key: K): Boolean = (key == key1) || (key == key2) || (key == key3) || (key == key4)
+    /** Returns the value associated with `key` as an option.
+     *
+     *  @param key the key to look up
+     *  @return `Some` of the value associated with `key`, or `None` if `key`
+     *          is not a key of this map
+     */
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else if (key == key3) Some(value3)
       else if (key == key4) Some(value4)
       else None
+    /** Returns the value associated with `key`, or `default` if `key` is not
+     *  present.
+     *
+     *  @tparam V1 the type of the result, a supertype of `V`
+     *  @param key the key to look up
+     *  @param default the value to return if `key` is not present; evaluated
+     *                 only in that case
+     *  @return the value associated with `key`, or the value of `default`
+     */
     override def getOrElse [V1 >: V](key: K, default: => V1): V1 =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else if (key == key4) value4
       else default
+    /** Returns an iterator over the four key/value pairs of this map. */
     def iterator: Iterator[(K, V)] = new Map4Iterator[(K, V)] {
       override protected def nextResult(k: K, v: V): (K, V) = (k, v)
     }
+    /** Returns an iterator over the four keys of this map. */
     override def keysIterator: Iterator[K] = new Map4Iterator[K] {
       override protected def nextResult(k: K, v: V): K = k
     }
+    /** Returns an iterator over the four values of this map. */
     override def valuesIterator: Iterator[V] = new Map4Iterator[V] {
       override protected def nextResult(k: K, v: V): V = v
     }
@@ -601,22 +1038,55 @@ object Map extends MapFactory[Map] {
       override def drop(n: Int): Iterator[A] = { i += n; this }
       protected def nextResult(k: K, v: V @uncheckedVariance): A
     }
+    /** Returns a new map with `key` bound to `value`.
+     *
+     *  If `key` equals one of the keys of this map, returns a new `Map4` with
+     *  that key's value replaced; otherwise returns a `HashMap` of the five
+     *  bindings.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new map of four or five bindings containing `key -> value`
+     */
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1)      new Map4(key1, value, key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map4(key1, value1, key2, value, key3, value3, key4, value4)
       else if (key == key3) new Map4(key1, value1, key2, value2, key3, value, key4, value4)
       else if (key == key4) new Map4(key1, value1, key2, value2, key3, value3, key4, value)
       else HashMap.empty[K, V1].updated(key1,value1).updated(key2, value2).updated(key3, value3).updated(key4, value4).updated(key, value)
+    /** Returns a `Map3` of the remaining bindings if `key` is a key of this
+     *  map, or this map itself otherwise.
+     *
+     *  @param key the key to remove
+     *  @return a map without a binding for `key`
+     */
     def removed(key: K): Map[K, V] =
       if (key == key1)      new Map3(key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map3(key1, value1, key3, value3, key4, value4)
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)
       else if (key == key4) new Map3(key1, value1, key2, value2, key3, value3)
       else this
+    /** Applies `f` to each key/value pair of this map.
+     *
+     *  @tparam U the result type of `f`; the results are discarded
+     *  @param f the function to apply
+     */
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
     }
+    /** Returns `true` if at least one key/value pair of this map satisfies
+     *  `p`. The predicate is not applied to the remaining pairs once one
+     *  satisfies it.
+     *
+     *  @param p the predicate to test
+     */
     override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2)) || p((key3, value3)) || p((key4, value4))
+    /** Returns `true` if all four key/value pairs of this map satisfy `p`.
+     *  The predicate is not applied to the remaining pairs once one fails it.
+     *
+     *  @param p the predicate to test
+     */
     override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2)) && p((key3, value3)) && p((key4, value4))
     override protected[collection] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
       var k1, k2, k3 = null.asInstanceOf[K]
@@ -635,6 +1105,16 @@ object Map extends MapFactory[Map] {
         case 4 => this
       }
     }
+    /** Returns a map obtained by applying `f` to each key and its value.
+     *
+     *  If every transformed value is reference-equal to the current one, this
+     *  map itself is returned; otherwise a new `Map4` with the same keys and
+     *  the transformed values.
+     *
+     *  @tparam W the type of the transformed values
+     *  @param f the transformation function, applied to each key and its value
+     *  @return a four-binding map with the same keys and the transformed values
+     */
     override def transform[W](f: (K, V) => W): Map[K, W] = {
       val walue1 = f(key1, value1)
       val walue2 = f(key2, value2)
@@ -648,6 +1128,9 @@ object Map extends MapFactory[Map] {
     }
     private[immutable] def buildTo[V1 >: V](builder: HashMapBuilder[K, V1]): builder.type =
       builder.addOne(key1, value1).addOne(key2, value2).addOne(key3, value3).addOne(key4, value4)
+    /** Returns a hash code computed with MurmurHash3 from the four key/value
+     *  pairs, equal to the hash code of any other map with the same bindings.
+     */
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       var a, b = 0

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -36,8 +36,24 @@ import scala.runtime.ScalaRunTime.nullForGC
 @SerialVersionUID(3L)
 object Vector extends StrictOptimizedSeqFactory[Vector] {
 
+  /** Returns the empty vector.
+   *
+   *  @tparam A the element type of the vector
+   *  @return the empty vector, a single shared instance
+   */
   def empty[A]: Vector[A] = Vector0
 
+  /** Returns a vector containing the elements of `it`.
+   *
+   *  Returns `it` itself if it is already a `Vector`, and the shared empty vector
+   *  if its size is known to be 0. A source with a known size between 1 and 32
+   *  elements is copied directly into a single-array vector (reusing the underlying
+   *  array of an `ArraySeq.ofRef` of `AnyRef`s without copying); other sources are
+   *  added to a fresh [[VectorBuilder]].
+   *
+   *  @tparam E the element type of the vector
+   *  @param it the collection whose elements end up in the vector
+   */
   def from[E](it: collection.IterableOnce[E]^): Vector[E] =
     it match {
       case v: Vector[E] => v
@@ -65,6 +81,11 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
         }
     }
 
+  /** Returns a new, empty [[VectorBuilder]].
+   *
+   *  @tparam A the element type of the vector to build
+   *  @return a reusable builder that produces a `Vector[A]`
+   */
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
   /** Creates a Vector with the same element at each index.
@@ -131,12 +152,22 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     with IterableFactoryDefaults[A, Vector]
     with DefaultSerializable {
 
+  /** Returns the [[Vector$ Vector]] companion object, the factory used to build new vectors. */
   override def iterableFactory: SeqFactory[Vector] = Vector
 
+  /** Returns the number of elements in this vector.
+   *
+   *  The length is stored (or, for a single-array vector, is the length of
+   *  that array), so this operation takes constant time.
+   */
   override final def length: Int =
     if(this.isInstanceOf[BigVector[?]]) this.asInstanceOf[BigVector[?]].length0
     else prefix1.length
 
+  /** Returns an iterator over the elements of this vector.
+   *
+   *  The empty vector always returns the same shared, exhausted iterator.
+   */
   override final def iterator: Iterator[A] =
     if(this.isInstanceOf[Vector0.type]) Vector.emptyIterator
     else new NewVectorIterator(this, length, vectorSliceCount)
@@ -201,9 +232,43 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   }
 
   // Dummy overrides to refine result types for binary compatibility:
+  /** Returns a copy of this vector with the element at `index` replaced by `elem`.
+   *
+   *  Only the arrays on the path to the affected slot are copied; the rest of
+   *  the structure is shared, so this operation takes O(log n) time.
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param index the index of the element to replace
+   *  @param elem the replacement element
+   *  @throws IndexOutOfBoundsException if `index` is negative or `>= length`
+   */
   override def updated[B >: A](index: Int, elem: B): Vector[B] = super.updated(index, elem)
+  /** Returns a copy of this vector with `elem` appended.
+   *
+   *  This operation takes amortized constant time (worst case O(log n)).
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param elem the appended element
+   *  @return a vector with `elem` as its last element
+   */
   override def appended[B >: A](elem: B): Vector[B] = super.appended(elem)
+  /** Returns a copy of this vector with `elem` prepended.
+   *
+   *  This operation takes amortized constant time (worst case O(log n)).
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param elem the prepended element
+   *  @return a vector with `elem` as its first element
+   */
   override def prepended[B >: A](elem: B): Vector[B] = super.prepended(elem)
+  /** Returns a vector containing the elements of `prefix` followed by the
+   *  elements of this vector.
+   *
+   *  Returns this vector itself if `prefix` is known to be empty.
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param prefix the collection whose elements precede this vector's elements
+   */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): Vector[B] = {
     val k = prefix.knownSize
     if (k == 0) this
@@ -211,6 +276,14 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     else prependedAll0(prefix, k)
   }
 
+  /** Returns a vector containing the elements of this vector followed by the
+   *  elements of `suffix`.
+   *
+   *  Returns this vector itself if `suffix` is known to be empty.
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param suffix the collection whose elements follow this vector's elements
+   */
   override final def appendedAll[B >: A](suffix: collection.IterableOnce[B]^): Vector[B] = {
     val k = suffix.knownSize
     if (k == 0) this
@@ -218,6 +291,22 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     else appendedAll0(suffix, k)
   }
 
+  /** Implements `prependedAll` for a prefix with known size `k`.
+   *
+   *  Prepends the elements one by one if there are only a few, appends this
+   *  vector's elements to `prefix` instead if that is a vector more than 32
+   *  times as large, and uses a [[VectorBuilder]] aligned to `k` when this
+   *  vector is sufficiently larger than the prefix, so that the result can
+   *  share this vector's structure; falls back to the generic implementation
+   *  otherwise. The concrete subclasses override this with an additional
+   *  fast path that copies `prefix` into the leading element array when it
+   *  fits.
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param prefix the collection whose elements precede this vector's elements
+   *  @param k the known size of `prefix`; always `>= 0`
+   *  @return a vector containing `prefix` followed by this vector
+   */
   protected def prependedAll0[B >: A](prefix: collection.IterableOnce[B]^, k: Int): Vector[B] = {
     // k >= 0, k = prefix.knownSize
     val tinyAppendLimit = 4 + vectorSliceCount
@@ -236,6 +325,22 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     } else super.prependedAll(prefix)
   }
 
+  /** Implements `appendedAll` for a suffix with known size `k`.
+   *
+   *  Appends the elements one by one if there are only a few, prepends this
+   *  vector's elements to `suffix` instead if that is a vector more than 32
+   *  times as large, and uses a [[VectorBuilder]] aligned to this vector's
+   *  size when `suffix` is a sufficiently larger vector, so that the result
+   *  can share the suffix vector's structure; otherwise builds the result by
+   *  initializing a [[VectorBuilder]] from this vector and adding `suffix`.
+   *  The concrete subclasses override this with an additional fast path that
+   *  copies `suffix` into the last element array when it fits.
+   *
+   *  @tparam B the element type of the returned vector
+   *  @param suffix the collection whose elements follow this vector's elements
+   *  @param k the known size of `suffix`; always `>= 0`
+   *  @return a vector containing this vector followed by `suffix`
+   */
   protected def appendedAll0[B >: A](suffix: collection.IterableOnce[B]^, k: Int): Vector[B] = {
     // k >= 0, k = suffix.knownSize
     val tinyAppendLimit = 4 + vectorSliceCount
@@ -257,13 +362,46 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     } else new VectorBuilder[B].initFrom(this).addAll(suffix).result()
   }
 
+  /** The collection name "Vector", used as the prefix of the `toString` representation. */
   override def className = "Vector"
 
+  /** Returns a vector containing the first `n` elements of this vector.
+   *
+   *  @param n the number of elements to take
+   *  @return a vector containing the first `n` elements, this vector itself
+   *          if `n >= length`, or the empty vector if `n <= 0`
+   */
   @inline override final def take(n: Int): Vector[A] = slice(0, n)
+  /** Returns a vector containing all elements of this vector except the first `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a vector containing the elements after the first `n`, this
+   *          vector itself if `n <= 0`, or the empty vector if `n >= length`
+   */
   @inline override final def drop(n: Int): Vector[A] = slice(n, length)
+  /** Returns a vector containing the last `n` elements of this vector.
+   *
+   *  @param n the number of elements to take
+   *  @return a vector containing the last `n` elements, this vector itself
+   *          if `n >= length`, or the empty vector if `n <= 0`
+   */
   @inline override final def takeRight(n: Int): Vector[A] = slice(length - mmax(n, 0), length)
+  /** Returns a vector containing all elements of this vector except the last `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a vector containing the elements before the last `n`, this
+   *          vector itself if `n <= 0`, or the empty vector if `n >= length`
+   */
   @inline override final def dropRight(n: Int): Vector[A] = slice(0, length - mmax(n, 0))
+  /** Returns a vector containing all elements of this vector except the first.
+   *
+   *  @throws UnsupportedOperationException if this vector is empty
+   */
   override def tail: Vector[A] = slice(1, length)
+  /** Returns a vector containing all elements of this vector except the last.
+   *
+   *  @throws UnsupportedOperationException if this vector is empty
+   */
   override def init: Vector[A] = slice(0, length-1)
 
   /** Like slice but parameters must be `0 <= lo < hi <= length`.
@@ -289,12 +427,43 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
    */
   protected[immutable] def vectorSlicePrefixLength(idx: Int): Int
 
+  /** Copies elements of this vector to an array, using bulk copies from the
+   *  underlying element arrays.
+   *
+   *  Copying starts at index `start` of `xs` and continues until either `len`
+   *  elements have been copied, the end of this vector is reached, or the end
+   *  of the array is reached.
+   *
+   *  @tparam B the element type of the array
+   *  @param xs the array to copy elements to
+   *  @param start the starting index in `xs`
+   *  @param len the maximum number of elements to copy
+   *  @return the number of elements copied
+   */
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = iterator.copyToArray(xs, start, len)
 
+  /** Returns this vector itself, as it is already a vector. */
   override def toVector: Vector[A] = this
 
+  /** Returns the maximum vector length up to which index-based `apply` is
+   *  preferred over an iterator when comparing elements.
+   *
+   *  Configurable via the system property
+   *  `scala.collection.immutable.Vector.defaultApplyPreferredMaxLength`
+   *  (default 250).
+   */
   override protected def applyPreferredMaxLength: Int = Vector.defaultApplyPreferredMaxLength
 
+  /** Returns a stepper over the elements of this vector.
+   *
+   *  The stepper is specialized to `Int`, `Long`, or `Double` when `shape`
+   *  indicates the corresponding primitive element type, and supports
+   *  efficient splitting for parallel processing.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape determines the element shape and thereby the type of stepper returned
+   *  @return a stepper that also allows efficient splitting
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntVectorStepper(iterator.asInstanceOf[NewVectorIterator[Int]])
@@ -305,13 +474,27 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns a new `IndexOutOfBoundsException` for the given index, to be
+   *  thrown by the caller.
+   *
+   *  @param index the out-of-bounds index
+   *  @return an exception reporting `index` and the valid index range
+   */
   protected def ioob(index: Int): IndexOutOfBoundsException =
     CommonErrors.indexOutOfBounds(index = index, max = length - 1)
 
+  /** Returns the first element of this vector.
+   *
+   *  @throws NoSuchElementException if this vector is empty
+   */
   override final def head: A =
     if (prefix1.length == 0) throw new NoSuchElementException("empty.head")
     else prefix1(0).asInstanceOf[A]
 
+  /** Returns the last element of this vector.
+   *
+   *  @throws NoSuchElementException if this vector is empty
+   */
   override final def last: A = {
     if(this.isInstanceOf[BigVector[?]]) {
       val suffix = this.asInstanceOf[BigVector[?]].suffix1
@@ -320,6 +503,14 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     } else prefix1(prefix1.length-1)
   }.asInstanceOf[A]
 
+  /** Applies `f` to each element of this vector.
+   *
+   *  Iterates directly over the underlying array slices instead of using an
+   *  iterator.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each element for its side effects
+   */
   override final def foreach[U](f: A => U): Unit = {
     val c = vectorSliceCount
     var i = 0
@@ -1510,6 +1701,17 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
 }
 
 
+/** A reusable builder for a [[Vector]].
+ *
+ *  Elements are collected in a mutable tree of arrays (`a1` through `a6`)
+ *  that mirrors the structure of the resulting vector and grows in depth as
+ *  elements are added; `result()` cuts and copies these arrays into an
+ *  immutable vector. The builder can also be initialized from an existing
+ *  vector, or aligned to an offset so that the result shares array structure
+ *  with a vector appended to it.
+ *
+ *  @tparam A the element type of the vector being built
+ */
 final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
 
   private var a6: Arr6 = compiletime.uninitialized
@@ -1527,12 +1729,25 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     lenRest = i - len1
   }
 
+  /** Returns the number of elements added so far.
+   *
+   *  Computed as the current position in the tree (`len1 + lenRest`) minus
+   *  the `offset` of unused slots reserved in front by `alignTo`.
+   */
   override def knownSize: Int = len1 + lenRest - offset
 
+  /** Returns the number of elements added so far, like `knownSize`. */
   @inline def size: Int = knownSize
+  /** Returns `true` if this builder contains no elements. */
   @inline def isEmpty: Boolean = knownSize == 0
+  /** Returns `true` if this builder contains at least one element. */
   @inline def nonEmpty: Boolean = knownSize != 0
 
+  /** Clears the contents of this builder, making it available for reuse.
+   *
+   *  Resets the state to a single empty leaf array and releases the arrays
+   *  of all higher dimensions for garbage collection.
+   */
   def clear(): Unit = {
     a6 = nullForGC[Arr6]
     a5 = nullForGC[Arr5]
@@ -1813,6 +2028,14 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     prefixIsRightAligned = false
   }
 
+  /** Adds a single element to this builder.
+   *
+   *  Writes into the current leaf array, first advancing to a fresh leaf
+   *  (and growing the tree if necessary) when the current one is full.
+   *
+   *  @param elem the element to add
+   *  @return this builder
+   */
   def addOne(elem: A): this.type = {
     if(len1 == WIDTH) advance()
     a1(len1) = elem.asInstanceOf[AnyRef]
@@ -1932,6 +2155,15 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     this
   }
 
+  /** Adds all elements of `xs` to this builder.
+   *
+   *  An empty, unaligned builder is initialized directly from a `Vector`
+   *  argument; a vector added to a non-empty builder is copied in as whole
+   *  slices where possible. Other collections are added element by element.
+   *
+   *  @param xs the elements to add
+   *  @return this builder
+   */
   override def addAll(xs: IterableOnce[A]^): this.type = xs match {
     case v: Vector[?] =>
       if(len1 == 0 && lenRest == 0 && !prefixIsRightAligned) initFrom(v)
@@ -2003,6 +2235,16 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     }
   }
 
+  /** Returns a vector containing the elements added so far.
+   *
+   *  Cuts the builder's arrays down to the actual length and assembles them
+   *  into a vector of the appropriate level, splitting the prefix and suffix
+   *  fingers off the central data. The builder keeps its contents and
+   *  remains usable.
+   *
+   *  @throws IndexOutOfBoundsException if more than `Int.MaxValue` elements
+   *          were added, overflowing the length to a negative value
+   */
   def result(): Vector[A] = {
     if (prefixIsRightAligned) leftAlignPrefix()
     val len = len1 + lenRest
@@ -2093,6 +2335,7 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     }
   }
 
+  /** Returns a string showing the internal state of this builder, for debugging. */
   override def toString(): String =
     s"VectorBuilder(len1=$len1, lenRest=$lenRest, offset=$offset, depth=$depth)"
 


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for the indexed and hashed collections of `scala.collection.immutable` that are completely missing any Scaladoc documentation: `Vector`, `ArraySeq`, `HashMap`, `HashSet` and `Map`. It is only five files but they are the largest in the package, and it includes the CHAMP trie internals that back the hash collections and the small-arity `Map1` to `Map4` family. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.