### PR TITLE
collection, immutable, List, LazyList, sorted (12): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -38,16 +38,38 @@ sealed abstract class BitSet
     with collection.BitSetOps[BitSet]
     with Serializable {
 
+  /** Returns this bitset viewed as an unsorted `Set[Int]`.
+   *
+   *  No copy is made: the result is this same bitset, so its iteration order remains
+   *  increasing.
+   */
   override def unsorted: Set[Int] = this
 
+  /** Returns an immutable bitset containing the elements of the given collection.
+   *
+   *  @param coll the collection of non-negative integers to include
+   *  @return an immutable bitset containing the elements of `coll`, which is `coll`
+   *          itself if it is already an immutable bitset
+   */
   override protected def fromSpecific(coll: IterableOnce[Int]^): BitSet = bitSetFactory.fromSpecific(coll)
+  /** Returns a new builder that accumulates `Int` elements into an immutable bitset. */
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
+  /** Returns the empty immutable bitset. */
   override def empty: BitSet = bitSetFactory.empty
 
+  /** The factory used to build immutable bitsets, the [[BitSet$ `BitSet`]] companion object. */
   def bitSetFactory: BitSet.type = BitSet
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 
+  /** Returns a bitset containing `elem` and all elements of this bitset. Returns this
+   *  bitset itself if it already contains `elem`; otherwise only the word holding
+   *  `elem` differs, and the underlying storage grows if `elem` lies beyond it.
+   *
+   *  @param elem the element to add; must be non-negative
+   *  @return a bitset containing all elements of this bitset plus `elem`
+   *  @throws IllegalArgumentException if `elem` is negative
+   */
   def incl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
     if (contains(elem)) this
@@ -57,6 +79,14 @@ sealed abstract class BitSet
     }
   }
 
+  /** Returns a bitset containing all elements of this bitset except `elem`. Returns this
+   *  bitset itself if it does not contain `elem`; otherwise only the word holding `elem`
+   *  differs.
+   *
+   *  @param elem the element to remove; must be non-negative
+   *  @return a bitset containing all elements of this bitset except `elem`
+   *  @throws IllegalArgumentException if `elem` is negative
+   */
   def excl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
     if (contains(elem)) {
@@ -73,22 +103,81 @@ sealed abstract class BitSet
    */
   protected def updateWord(idx: Int, w: Long): BitSet
 
+  /** Builds a new bitset by applying a function to all elements of this bitset.
+   *
+   *  @param f the function to apply to each element; must return non-negative values
+   *  @return a new bitset containing the results of applying `f` to each element
+   *  @throws IllegalArgumentException if `f` returns a negative value for some element
+   */
   override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
+  /** Builds a new sorted set by applying a function to all elements of this bitset.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing the results of applying `f` to each element
+   */
   override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].map(f)
 
+  /** Builds a new bitset by applying a function to all elements of this bitset and
+   *  concatenating the results.
+   *
+   *  @param f the function to apply to each element; the collections it returns must
+   *           contain only non-negative values
+   *  @return a new bitset containing all elements of the collections returned by `f`
+   *  @throws IllegalArgumentException if a collection returned by `f` contains a negative value
+   */
   override def flatMap(f: Int => IterableOnce[Int]^): BitSet = strictOptimizedFlatMap(newSpecificBuilder, f)
+  /** Builds a new sorted set by applying a function to all elements of this bitset and
+   *  concatenating the results.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param f the function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing all elements of the collections returned by `f`
+   */
   override def flatMap[B](f: Int => IterableOnce[B]^)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].flatMap(f)
 
+  /** Builds a new bitset by applying a partial function to all elements of this bitset
+   *  on which the function is defined.
+   *
+   *  @param pf the partial function to apply to each element; must return non-negative
+   *            values where defined
+   *  @return a new bitset containing the results of applying `pf` to each element on
+   *          which it is defined
+   *  @throws IllegalArgumentException if `pf` returns a negative value for some element
+   */
   override def collect(pf: PartialFunction[Int, Int]^): BitSet = strictOptimizedCollect(newSpecificBuilder, pf)
+  /** Builds a new sorted set by applying a partial function to all elements of this
+   *  bitset on which the function is defined.
+   *
+   *  @tparam B the element type of the returned set
+   *  @param pf the partial function to apply to each element
+   *  @param ev the ordering used to sort the resulting elements
+   *  @return a new sorted set containing the results of applying `pf` to each element on
+   *          which it is defined
+   */
   override def collect[B](pf: scala.PartialFunction[Int, B]^)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
     super[StrictOptimizedSortedSetOps].collect(pf)
 
   // necessary for disambiguation
+  /** Returns a sorted set of pairs formed by zipping the elements of this bitset, in
+   *  increasing order, with the elements of `that`.
+   *
+   *  If one of the two collections is longer than the other, its remaining elements are
+   *  dropped.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection providing the second half of each result pair
+   *  @param ev the ordering used to sort the resulting pairs
+   *  @return a new sorted set of pairs
+   */
   override def zip[B](that: scala.IterableOnce[B]^)(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =
     super.zip(that)
 
+  /** Replaces this bitset with a serialization proxy that stores its words during Java serialization. */
   protected def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
 }
 
@@ -100,14 +189,31 @@ sealed abstract class BitSet
 @SerialVersionUID(3L)
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
+  /** Returns an immutable bitset containing the elements of `it`.
+   *
+   *  If `it` is already an immutable bitset it is returned unchanged; otherwise its
+   *  elements are collected into a new one.
+   *
+   *  @param it the collection of non-negative integers to include
+   *  @throws IllegalArgumentException if `it` contains a negative value
+   */
   def fromSpecific(it: scala.collection.IterableOnce[Int]^): BitSet =
     it match {
       case bs: BitSet => bs
       case _          => (newBuilder ++= it).result()
     }
 
+  /** The empty immutable bitset, a single all-zero word shared by every call to `empty`. */
   final val empty: BitSet = new BitSet1(0L)
 
+  /** Returns a new builder that accumulates `Int` elements into an immutable bitset.
+   *
+   *  The elements are collected in a mutable bitset, whose word array is handed to the
+   *  result without being copied. It becomes the result's backing array only when it
+   *  holds more than two words; a shorter result stores its words in fields instead.
+   *
+   *  @return a builder for immutable bitsets
+   */
   def newBuilder: Builder[Int, BitSet] =
     mutable.BitSet.newBuilder.mapResult(bs => fromBitMaskNoCopy(bs.elems))
 
@@ -143,6 +249,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     else new BitSetN(elems)
   }
 
+  /** An immutable bitset holding the elements `0` to `63` in a single word.
+   *
+   *  @param elems the word holding the bits of this bitset
+   */
   @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
   class BitSet1(val elems: Long) extends BitSet {
     protected[collection] def nwords = 1
@@ -153,6 +263,15 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       else this.fromBitMaskNoCopy(updateArray(Array(elems), idx, w))
 
 
+    /** Returns a bitset containing the elements of this bitset that are not in `other`.
+     *
+     *  When `other` is itself a bitset the difference is a single bitwise operation on
+     *  the words; any other set falls back to the inherited element-by-element
+     *  implementation.
+     *
+     *  @param other the set of elements to remove
+     *  @return a bitset with the elements of `other` removed
+     */
     override def diff(other: collection.Set[Int]): BitSet = other match {
       case bs: collection.BitSet => bs.nwords match {
         case 0 => this
@@ -163,12 +282,27 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       case _ => super.diff(other)
     }
 
+    /** Returns a bitset of the elements of this bitset that satisfy `pred`, or that fail
+     *  to satisfy it when `isFlipped` is `true`.
+     *
+     *  `pred` is applied to each element present, and the result is narrowed to the
+     *  empty bitset when no element is left.
+     *
+     *  @param pred the predicate used to test elements
+     *  @param isFlipped if `true`, keeps the elements that do not satisfy `pred`
+     *  @return a bitset of the elements that pass the test
+     */
     override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
       val _elems = BitSetOps.computeWordForFilter(pred, isFlipped, elems, 0)
       if (_elems == 0L) this.empty else new BitSet1(_elems)
     }
   }
 
+  /** An immutable bitset holding the elements `0` to `127` in two words.
+   *
+   *  @param elems0 the word holding the bits of the elements `0` to `63`
+   *  @param elems1 the word holding the bits of the elements `64` to `127`
+   */
   @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
   class BitSet2(val elems0: Long, val elems1: Long) extends BitSet {
     protected[collection] def nwords = 2
@@ -179,6 +313,16 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       else this.fromBitMaskNoCopy(updateArray(Array(elems0, elems1), idx, w))
 
 
+    /** Returns a bitset containing the elements of this bitset that are not in `other`.
+     *
+     *  When `other` is itself a bitset the difference is a bitwise operation on the
+     *  words, and the result is narrowed to one word or to the empty bitset when the
+     *  higher words become zero; any other set falls back to the inherited
+     *  element-by-element implementation.
+     *
+     *  @param other the set of elements to remove
+     *  @return a bitset with the elements of `other` removed
+     */
     override def diff(other: collection.Set[Int]): BitSet = other match {
       case bs: collection.BitSet => bs.nwords match {
         case 0 => this
@@ -201,6 +345,16 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       case _ => super.diff(other)
     }
 
+    /** Returns a bitset of the elements of this bitset that satisfy `pred`, or that fail
+     *  to satisfy it when `isFlipped` is `true`.
+     *
+     *  `pred` is applied to each element present, and the result is narrowed to one word
+     *  or to the empty bitset when the higher words become zero.
+     *
+     *  @param pred the predicate used to test elements
+     *  @param isFlipped if `true`, keeps the elements that do not satisfy `pred`
+     *  @return a bitset of the elements that pass the test
+     */
     override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
       val _elems0 = BitSetOps.computeWordForFilter(pred, isFlipped, elems0, 0)
       val _elems1 = BitSetOps.computeWordForFilter(pred, isFlipped, elems1, 1)
@@ -215,6 +369,11 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     }
   }
 
+  /** An immutable bitset of any size, holding its bits in an array of words.
+   *
+   *  @param elems the array of `Long` words holding the bits of this bitset; it is used
+   *               as is, so it must not be modified afterwards
+   */
   @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
   class BitSetN(val elems: Array[Long]) extends BitSet {
     protected[collection] def nwords = elems.length
@@ -223,6 +382,16 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
     protected[collection] def updateWord(idx: Int, w: Long): BitSet = this.fromBitMaskNoCopy(updateArray(elems, idx, w))
 
+    /** Returns a bitset containing the elements of this bitset that are not in `that`.
+     *
+     *  When `that` is itself a bitset the difference is computed word by word, this
+     *  bitset itself is returned if no word changes, and the result is shrunk to the
+     *  words it actually needs; any other set falls back to the inherited
+     *  element-by-element implementation.
+     *
+     *  @param that the set of elements to remove
+     *  @return a bitset with the elements of `that` removed
+     */
     override def diff(that: collection.Set[Int]): BitSet = that match {
       case bs: collection.BitSet =>
         /*
@@ -323,6 +492,16 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     }
 
 
+    /** Returns a bitset of the elements of this bitset that satisfy `pred`, or that fail
+     *  to satisfy it when `isFlipped` is `true`.
+     *
+     *  `pred` is applied to each element present, this bitset itself is returned if no
+     *  word changes, and the result is shrunk to the words it actually needs.
+     *
+     *  @param pred the predicate used to test elements
+     *  @param isFlipped if `true`, keeps the elements that do not satisfy `pred`
+     *  @return a bitset of the elements that pass the test
+     */
     override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
       // here, we may have opportunity to shrink the size of the array
       // so, track the highest index which is non-zero. That ( + 1 ) will be our new array length
@@ -378,6 +557,9 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       }
     }
 
+    /** Returns the words of this bitset as a fresh array, so that changing it does not
+     *  affect this bitset.
+     */
     override def toBitMask: Array[Long] = elems.clone()
   }
 

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -47,13 +47,39 @@ import IntMapUtils.{Int => _, _}
  *  @define Coll  `IntMap`
  */
 object IntMap {
+  /** Returns the empty map, a single instance shared between all value types.
+   *
+   *  @tparam T the type of the values
+   */
   def empty[T] : IntMap[T]  = IntMap.Nil
 
+  /** Returns a map containing only the given key/value binding.
+   *
+   *  @tparam T the type of the value
+   *  @param key the key of the single binding
+   *  @param value the value associated with `key`
+   */
   def singleton[T](key: Int, value: T): IntMap[T] = IntMap.Tip(key, value)
 
+  /** Returns a map containing the given key/value pairs.
+   *
+   *  If a key occurs more than once in `elems`, the last binding for that key is
+   *  retained.
+   *
+   *  @tparam T the type of the values
+   *  @param elems the key/value pairs of the map
+   */
   def apply[T](elems: (Int, T)*): IntMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+  /** Returns a map containing the key/value pairs of the given collection.
+   *
+   *  If a key occurs more than once in `coll`, the last binding for that key is
+   *  retained.
+   *
+   *  @tparam V the type of the values
+   *  @param coll the collection of key/value pairs
+   */
   def from[V](coll: IterableOnce[(Int, V)]^): IntMap[V] =
     newBuilder[V].addAll(coll).result()
 
@@ -82,11 +108,24 @@ object IntMap {
     }
   }
 
+  /** Returns a new builder that accumulates key/value pairs into an `IntMap`.
+   *
+   *  If a key is added more than once, the last binding for that key is retained.
+   *
+   *  @tparam V the type of the values
+   */
   def newBuilder[V]: Builder[(Int, V), IntMap[V]] =
     new ImmutableBuilder[(Int, V), IntMap[V]](empty) {
       def addOne(elem: (Int, V)): this.type = { elems = elems + elem; this }
     }
 
+  /** Implicitly converts the `IntMap` object to a `Factory`, so that it can be
+   *  passed where a factory of integer-keyed pairs is expected.
+   *
+   *  @tparam V the type of the values
+   *  @param dummy the `IntMap` companion object; never used
+   *  @return a `Factory` building an `IntMap[V]` from `(Int, V)` pairs
+   */
   implicit def toFactory[V](dummy: IntMap.type): Factory[(Int, V), IntMap[V]] = ToFactory.asInstanceOf[Factory[(Int, V), IntMap[V]]]
 
   @SerialVersionUID(3L)
@@ -95,13 +134,30 @@ object IntMap {
     def newBuilder: Builder[(Int, AnyRef), IntMap[AnyRef]] = IntMap.newBuilder[AnyRef]
   }
 
+  /** Implicitly converts the `IntMap` object to a `BuildFrom`, so that it can be
+   *  passed where a `BuildFrom` producing an integer-keyed map is expected.
+   *
+   *  @tparam V the type of the values
+   *  @param factory the `IntMap` companion object; never used
+   *  @return a `BuildFrom` building an `IntMap[V]` from `(Int, V)` pairs, whatever
+   *          the source collection
+   */
   implicit def toBuildFrom[V](factory: IntMap.type): BuildFrom[Any, (Int, V), IntMap[V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (Int, V), IntMap[V]]]
   private object ToBuildFrom extends BuildFrom[Any, (Int, AnyRef), IntMap[AnyRef]] {
     def fromSpecific(from: Any)(it: IterableOnce[(Int, AnyRef)]^) = IntMap.from(it)
     def newBuilder(from: Any) = IntMap.newBuilder[AnyRef]
   }
 
+  /** Returns an implicit `Factory` building an `IntMap[V]` from `(Int, V)` pairs.
+   *
+   *  @tparam V the type of the values
+   */
   implicit def iterableFactory[V]: Factory[(Int, V), IntMap[V]] = toFactory(this)
+  /** Returns an implicit `BuildFrom` building an `IntMap[V]` from `(Int, V)` pairs,
+   *  for transformation methods whose source collection is an `IntMap`.
+   *
+   *  @tparam V the type of the values
+   */
   implicit def buildFromIntMap[V]: BuildFrom[IntMap[?], (Int, V), IntMap[V]] = toBuildFrom(this)
 }
 
@@ -184,21 +240,40 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   with StrictOptimizedMapOps[Int, T, Map, IntMap[T]]
   with Serializable {
 
+  /** Returns an `IntMap` containing the key/value pairs of `coll`.
+   *
+   *  If a key occurs more than once in `coll`, the last binding for that key is
+   *  retained.
+   *
+   *  @param coll the collection of key/value pairs
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(Int, T) @uncheckedVariance]^): IntMap[T] =
     intMapFrom[T](coll)
+  /** Returns an `IntMap` containing the key/value pairs of `coll`, with an
+   *  arbitrary value type.
+   *
+   *  If a key occurs more than once in `coll`, the last binding for that key is
+   *  retained.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param coll the collection of key/value pairs
+   */
   protected def intMapFrom[V2](coll: scala.collection.IterableOnce[(Int, V2)]^): IntMap[V2] = {
     val b = IntMap.newBuilder[V2]
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
+  /** Returns a new builder that accumulates key/value pairs into an `IntMap`. */
   override protected def newSpecificBuilder: Builder[(Int, T), IntMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
       def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
     }
 
+  /** Returns the empty `IntMap`, a single shared instance. */
   override def empty: IntMap[T] = IntMap.Nil
 
+  /** Returns a list of the key/value pairs of this map, in unsigned order of the keys. */
   override def toList = {
     val buffer = new scala.collection.mutable.ListBuffer[(Int, T)]
     foreach(buffer += _)
@@ -225,12 +300,19 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
+  /** Loops over the key, value pairs of the map in unsigned order of the keys,
+   *  passing the key and value as two separate arguments.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key and value in the map
+   */
   override def foreachEntry[U](f: (Int, T) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case IntMap.Tip(key, value) => f(key, value)
     case IntMap.Nil =>
   }
 
+  /** Returns an iterator over the keys of this map, in unsigned order. */
   override def keysIterator: Iterator[Int] = this match {
     case IntMap.Nil => Iterator.empty
     case _ => new IntMapKeyIterator(this)
@@ -248,6 +330,9 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
+  /** Returns an iterator over the values of this map, in unsigned order of the
+   *  corresponding keys.
+   */
   override def valuesIterator: Iterator[T] = this match {
     case IntMap.Nil => Iterator.empty
     case _ => new IntMapValueIterator(this)
@@ -265,10 +350,25 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
+  /** The name `"IntMap"`, used as the prefix in the string representation of this map. */
   override protected def className = "IntMap"
 
+  /** Returns `true` if this map contains no bindings. The only empty `IntMap` is
+   *  the shared `IntMap.Nil` instance, so this is a reference comparison.
+   */
   override def isEmpty = this eq IntMap.Nil
+  /** Returns 0 if this map is empty, otherwise -1, since computing the size
+   *  requires traversing the whole tree.
+   */
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
+  /** Returns a map containing only the key/value pairs of this map that satisfy
+   *  the predicate `f`.
+   *
+   *  Preserves sharing where possible: unchanged subtrees are reused, and if no
+   *  binding is removed the result is this map itself.
+   *
+   *  @param f the predicate applied to each key/value pair
+   */
   override def filter(f: ((Int, T)) => Boolean): IntMap[T] = this match {
     case IntMap.Bin(prefix, mask, left, right) => {
       val (newleft, newright) = (left.filter(f), right.filter(f))
@@ -281,18 +381,35 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Nil
   }
 
+  /** Returns a map with the same keys, where each value is replaced by the result
+   *  of applying `f` to the key and its current value.
+   *
+   *  Unlike `map`, keys and tree structure are unchanged; only values are
+   *  recomputed. Subtrees whose values are unchanged (by reference) are reused.
+   *
+   *  @tparam S the type of the values in the resulting map
+   *  @param f the function computing the new value for each binding
+   */
   override def transform[S](f: (Int, T) => S): IntMap[S] = this match {
     case b@IntMap.Bin(prefix, mask, left, right) => b.bin(left.transform(f), right.transform(f))
     case t@IntMap.Tip(key, value) => t.withValue(f(key, value))
     case IntMap.Nil => IntMap.Nil
   }
 
+  /** Returns the number of bindings in this map, counted by traversing the whole
+   *  tree, in time linear in the size of the map.
+   */
   final override def size: Int = this match {
     case IntMap.Nil => 0
     case IntMap.Tip(_, _) => 1
     case IntMap.Bin(_, _, left, right) => left.size + right.size
   }
 
+  /** Optionally returns the value associated with the given key.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if this map binds `key` to `value`, `None` otherwise
+   */
   @tailrec
   final def get(key: Int): Option[T] = this match {
     case IntMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left.get(key) else right.get(key)
@@ -300,6 +417,14 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => None
   }
 
+  /** Returns the value associated with the given key, or `default` if the key is
+   *  not present.
+   *
+   *  @tparam S the type of the result, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value returned if `key` is not present; evaluated only in
+   *                 that case
+   */
   @tailrec
   final override def getOrElse[S >: T](key: Int, default: => S): S = this match {
     case IntMap.Nil => default
@@ -308,6 +433,14 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
       if (zero(key, mask)) left.getOrElse(key, default) else right.getOrElse(key, default)
   }
 
+  /** Returns the value associated with the given key.
+   *
+   *  @param key the key to look up
+   *  @return the value bound to `key`
+   *  @throws IllegalArgumentException if `key` is not present; note that this
+   *          differs from the `NoSuchElementException` thrown by most map
+   *          implementations
+   */
   @tailrec
   final override def apply(key: Int): T = this match {
     case IntMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left(key) else right(key)
@@ -315,8 +448,26 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => throw new IllegalArgumentException("key not found")
   }
 
+  /** Returns a map with the given key/value pair added, replacing any existing
+   *  binding for that key.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param kv the key/value pair to add
+   *  @return a map containing the bindings of this map and the binding `kv`
+   */
   override def + [S >: T] (kv: (Int, S)): IntMap[S] = updated(kv._1, kv._2)
 
+  /** Returns a map with `key` bound to `value`, replacing any existing binding
+   *  for `key`.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a map containing the bindings of this map and the binding of `key`
+   *          to `value`
+   */
   override def updated[S >: T](key: Int, value: S): IntMap[S] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) join(key, IntMap.Tip(key, value), prefix, this)
@@ -328,15 +479,66 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Tip(key, value)
   }
 
+  /** Returns a map built from the results of applying `f` to each key/value pair
+   *  of this map.
+   *
+   *  Unlike `transform`, `f` may change the keys, so the result is rebuilt from
+   *  the transformed pairs. If `f` produces the same key for different pairs,
+   *  bindings produced later (in unsigned order of the original keys) overwrite
+   *  earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function applied to each key/value pair
+   *  @return an `IntMap` containing the transformed pairs
+   */
   def map[V2](f: ((Int, T)) => (Int, V2)): IntMap[V2] = intMapFrom(new View.Map(this, f))
 
+  /** Returns a map built by applying `f` to each key/value pair of this map and
+   *  collecting all the pairs it produces.
+   *
+   *  If the same key is produced more than once, bindings produced later
+   *  overwrite earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function returning a collection of key/value pairs for each
+   *           pair of this map
+   *  @return an `IntMap` containing all the pairs produced by `f`
+   */
   def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]^): IntMap[V2] = intMapFrom(new View.FlatMap(this, f))
 
+  /** Returns a map containing the bindings of this map and of `that`.
+   *
+   *  Bindings from `that` overwrite bindings of this map with the same key.
+   *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param that the collection of key/value pairs to add
+   *  @return an `IntMap` containing the combined bindings
+   */
   override def concat[V1 >: T](that: collection.IterableOnce[(Int, V1)]^): IntMap[V1] =
     super.concat(that).asInstanceOf[IntMap[V1]] // Already has correct type but not declared as such
 
+  /** Alias for `concat`: returns a map containing the bindings of this map and
+   *  of `that`, where bindings from `that` overwrite bindings of this map with
+   *  the same key.
+   *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param that the collection of key/value pairs to add
+   *  @return an `IntMap` containing the combined bindings
+   */
   override def ++ [V1 >: T](that: collection.IterableOnce[(Int, V1)]^): IntMap[V1] = concat(that)
 
+  /** Returns a map built from the key/value pairs on which `pf` is defined,
+   *  transformed by `pf`.
+   *
+   *  If `pf` produces the same key for different pairs, bindings produced later
+   *  overwrite earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param pf the partial function applied to each pair on which it is defined
+   *  @return an `IntMap` containing the transformed pairs
+   */
   def collect[V2](pf: PartialFunction[(Int, T), (Int, V2)]): IntMap[V2] =
     strictOptimizedCollect(IntMap.newBuilder[V2], pf)
 
@@ -373,6 +575,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Tip(key, value)
   }
 
+  /** Returns a map without any binding for the given key.
+   *
+   *  @param key the key to remove
+   *  @return a map containing the bindings of this map except for `key`
+   */
   def removed (key: Int): IntMap[T] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
@@ -481,6 +688,14 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   def intersection[R](that: IntMap[R]): IntMap[T] =
     this.intersectionWith(that, (_key: Int, value: T, _value2: R) => value)
 
+  /** Returns the union of this map and `that`.
+   *
+   *  If a key is present in both maps, the value from `that` is retained.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param that the map to form a union with
+   */
   def ++[S >: T](that: IntMap[S]) =
     this.unionWith[S](that, (_key, _x, y) => y)
 
@@ -500,5 +715,6 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => throw new IllegalStateException("Empty set")
   }
 
+  /** Replaces this map with a serialization proxy during Java serialization. */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(IntMap.toFactory[T](IntMap), this)
 }

--- a/library/src/scala/collection/immutable/Iterable.scala
+++ b/library/src/scala/collection/immutable/Iterable.scala
@@ -28,11 +28,20 @@ trait Iterable[+A] extends collection.Iterable[A]
                       with collection.IterableOps[A, Iterable, Iterable[A]]
                       with IterableFactoryDefaults[A, Iterable] {
 
+  /** The factory used to build immutable collections, the [[Iterable$ `Iterable`]] companion object, which delegates to [[List]]. */
   override def iterableFactory: IterableFactory[Iterable] = Iterable
 }
 
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](List) {
+  /** Returns an immutable collection containing the elements of `it`.
+   *
+   *  If `it` is already an immutable `Iterable` it is returned unchanged; otherwise
+   *  its elements are copied into a new [[List]].
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   override def from[E](it: IterableOnce[E]^): Iterable[E]^{it} = it match {
     case iterable: Iterable[E @unchecked] => iterable
     case _ => super.from(it)

--- a/library/src/scala/collection/immutable/LazyList.scala
+++ b/library/src/scala/collection/immutable/LazyList.scala
@@ -362,10 +362,18 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
       evaluated
     }
 
+  /** Returns the factory used to build lazy lists, the [[LazyList$ `LazyList`]]
+   *  companion object.
+   */
   override def iterableFactory: SeqFactory[LazyList] = LazyList
 
   // NOTE: `evaluated; this eq Empty` would be wrong. Deserialization of `Empty` creates a new
   // instance with `null` fields, but the `evaluated` method always returns the canonical `Empty`.
+  /** Returns `true` if this lazy list has no elements.
+   *
+   *  Deciding this evaluates the state of this lazy list, that is, its head and the
+   *  identity of its tail, but no element beyond the first.
+   */
   @inline override def isEmpty: Boolean = evaluated eq Empty
 
   /** @inheritdoc
@@ -374,11 +382,23 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    */
   override def knownSize: Int = if (knownIsEmpty) 0 else -1
 
+  /** Returns the first element of this lazy list, evaluating the state of this lazy
+   *  list if it has not been evaluated already.
+   *
+   *  @throws NoSuchElementException if this lazy list is empty
+   */
   override def head: A =
     // inlined `isEmpty` to make it clear that `rawHead` below is initialized
     if (evaluated eq Empty) throw new NoSuchElementException("head of empty lazy list")
     else rawHead.asInstanceOf[A]
 
+  /** Returns a lazy list of all elements of this lazy list except the first.
+   *
+   *  Evaluating the state of this lazy list yields the tail itself; the elements of
+   *  the tail are not evaluated.
+   *
+   *  @throws UnsupportedOperationException if this lazy list is empty
+   */
   override def tail: LazyList[A] =
     // inlined `isEmpty` to make it clear that `rawTail` below is initialized
     if (evaluated eq Empty) throw new UnsupportedOperationException("tail of empty lazy list")
@@ -466,9 +486,17 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else tail.foldLeft(op(z, head))(op)
 
   // LazyList.Empty doesn't use the SerializationProxy
+  /** Replaces this lazy list with a serialization proxy during Java serialization, but
+   *  only if its state is already evaluated and non-empty.
+   *
+   *  An evaluated prefix is written out compactly by the proxy; a lazy list whose state
+   *  is not yet evaluated is serialized as itself, so that its unevaluated thunks are
+   *  stored by standard Java serialization and are not forced by serializing.
+   */
   protected def writeReplace(): AnyRef =
     if (knownNonEmpty) new SerializationProxy[A](this) else this
 
+  /** The prefix of this lazy list's string representation: `"LazyList"`. */
   override protected def className = "LazyList"
 
   /** The lazy list resulting from the concatenation of this lazy list with the argument lazy list.
@@ -1394,8 +1422,18 @@ object LazyList extends SeqFactory[LazyList] {
     def unapply[A](xs: LazyList[A]): Option[(A, LazyList[A])] = #::.unapply(xs)
   }
 
+  /** Provides the `#::` and `#:::` operators on a by-name lazy list, so that the right
+   *  operand of a cons is not evaluated when the cons cell is built.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param l the lazy list to defer, evaluated only when the operator's result is forced
+   */
   implicit def toDeferrer[A](l: => LazyList[A]): Deferrer[A] = new Deferrer[A](() => l)
 
+  /** Holds the deferred right operand of a `#::` or `#:::` operation on lazy lists.
+   *
+   *  @tparam A the element type of the deferred lazy list
+   */
   final class Deferrer[A] private[LazyList] (private val l: () => LazyList[A]) extends AnyVal {
     /** Constructs a `LazyList` consisting of a given first element followed by elements
      *  from another `LazyList`.
@@ -1408,16 +1446,41 @@ object LazyList extends SeqFactory[LazyList] {
   }
 
   object #:: {
+    /** Matches a non-empty lazy list against its head and tail.
+     *
+     *  Matching evaluates the state of `s` and, if it is non-empty, its head; the
+     *  elements of the tail are left unevaluated.
+     *
+     *  @tparam A the element type of the lazy list
+     *  @param s the lazy list to decompose
+     *  @return `Some((head, tail))` if `s` is non-empty, or `None` if it is empty
+     */
     def unapply[A](s: LazyList[A]): Option[(A, LazyList[A])] =
       if (!s.isEmpty) Some((s.head, s.tail)) else None
   }
 
+  /** Returns a lazy list containing the elements of `coll`.
+   *
+   *  If `coll` is already a lazy list it is returned unchanged, and a collection known
+   *  to be empty gives the empty lazy list; otherwise the elements are taken from
+   *  `coll`'s iterator one at a time as the result is forced, the first of them as soon
+   *  as the result's state is evaluated.
+   *
+   *  @tparam A the element type
+   *  @param coll the collection whose elements are to be contained
+   */
   def from[A](coll: collection.IterableOnce[A]): LazyList[A] = coll match {
     case lazyList: LazyList[A]    => lazyList
     case _ if coll.knownSize == 0 => empty[A]
     case _                        => newLL(eagerHeadFromIterator(coll.iterator))
   }
 
+  /** Returns the empty lazy list.
+   *
+   *  All calls return the same instance, which is already evaluated.
+   *
+   *  @tparam A the element type of the lazy list
+   */
   def empty[A]: LazyList[A] = Empty
 
   /** Creates a LazyList with the elements of an iterator followed by a LazyList suffix.
@@ -1442,6 +1505,15 @@ object LazyList extends SeqFactory[LazyList] {
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadFromIterator(it)))
     else Empty
 
+  /** Returns a lazy list of the elements of all the given collections, one collection
+   *  after another.
+   *
+   *  $initiallyLazy Each collection is iterated only as the result is forced past its
+   *  predecessors.
+   *
+   *  @tparam A the element type
+   *  @param xss the collections to concatenate
+   */
   override def concat[A](xss: collection.Iterable[A]*): LazyList[A] =
     if (xss.knownSize == 0) empty
     else newLL(eagerHeadConcatIterators(xss.iterator))
@@ -1489,9 +1561,29 @@ object LazyList extends SeqFactory[LazyList] {
    */
   def continually[A](elem: => A): LazyList[A] = newLL(eagerCons(elem, continually(elem)))
 
+  /** Returns a lazy list of `n` elements, each the result of a separate evaluation of
+   *  `elem`.
+   *
+   *  $initiallyLazy An element is computed only when the lazy list is forced that far,
+   *  so `elem` is evaluated once per element and never more often than that. A
+   *  non-positive `n` gives the empty lazy list.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param elem the element expression, evaluated once for each element
+   */
   override def fill[A](n: Int)(elem: => A): LazyList[A] =
     if (n > 0) newLL(eagerCons(elem, LazyList.fill(n - 1)(elem))) else empty
 
+  /** Returns a lazy list of `n` elements, the element at index `i` being `f(i)`.
+   *
+   *  $initiallyLazy `f` is applied to an index only when the lazy list is forced that
+   *  far. A non-positive `n` gives the empty lazy list.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param f the function computing the element at each index
+   */
   override def tabulate[A](n: Int)(f: Int => A): LazyList[A] = {
     def at(index: Int): LazyList[A] =
       if (index < n) newLL(eagerCons(f(index), at(index + 1))) else empty
@@ -1500,6 +1592,17 @@ object LazyList extends SeqFactory[LazyList] {
   }
 
   // significantly simpler than the iterator returned by Iterator.unfold
+  /** Returns a lazy list produced by repeatedly applying `f` to a state, starting from
+   *  `init`, for as long as it returns an element and the next state.
+   *
+   *  $initiallyLazy `f` is applied to a state only when the lazy list is forced that
+   *  far; the first `None` it returns ends the lazy list.
+   *
+   *  @tparam A the element type
+   *  @tparam S the type of the state
+   *  @param init the initial state
+   *  @param f the function producing the next element and state, or `None` to stop
+   */
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): LazyList[A] =
     newLL {
       f(init) match {

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -362,10 +362,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
       evaluated
     }
 
+  /** Returns the factory used to build lazy lists, the
+   *  [[LazyListIterable$ `LazyListIterable`]] companion object.
+   */
   override def iterableFactory: IterableFactory[LazyListIterable] = LazyListIterable
 
   // NOTE: `evaluated; this eq Empty` would be wrong. Deserialization of `Empty` creates a new
   // instance with `null` fields, but the `evaluated` method always returns the canonical `Empty`.
+  /** Returns `true` if this lazy list has no elements.
+   *
+   *  Deciding this evaluates the state of this lazy list, that is, its head and the
+   *  identity of its tail, but no element beyond the first.
+   */
   @inline override def isEmpty: Boolean = evaluated eq Empty
 
   /** @inheritdoc
@@ -374,17 +382,34 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    */
   override def knownSize: Int = if (knownIsEmpty) 0 else -1
 
+  /** Returns the first element of this lazy list, evaluating the state of this lazy
+   *  list if it has not been evaluated already.
+   *
+   *  @throws NoSuchElementException if this lazy list is empty
+   */
   override def head: A =
     // inlined `isEmpty` to make it clear that `rawHead` below is initialized
     if (evaluated eq Empty) throw new NoSuchElementException("head of empty lazy list")
     else rawHead.asInstanceOf[A]
 
+  /** Returns a lazy list of all elements of this lazy list except the first.
+   *
+   *  Evaluating the state of this lazy list yields the tail itself; the elements of
+   *  the tail are not evaluated.
+   *
+   *  @throws UnsupportedOperationException if this lazy list is empty
+   */
   override def tail: LazyListIterable[A]^{this} =
     // inlined `isEmpty` to make it clear that `rawTail` below is initialized
     if (evaluated eq Empty) throw new UnsupportedOperationException("tail of empty lazy list")
     else rawTail.asInstanceOf[LazyListIterable[A]]
 
   /* Same implementation as of LinearSeq */
+  /** Returns the number of elements in this lazy list.
+   *
+   *  Counting them evaluates all of them, and does not terminate for a lazy list of
+   *  infinite length.
+   */
   override def length: Int = {
     var these: LazyListIterable[A]^{this} = coll
     var len = 0
@@ -398,6 +423,13 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /* Same implementation as of LinearSeq */
   // `apply` is defined in terms of `drop`, which is in turn defined in
   //  terms of `tail`.
+  /** Returns the element at index `n`, counting from `0`.
+   *
+   *  Reaching it evaluates the elements up to and including index `n`, and no further.
+   *
+   *  @param n the index of the element to return
+   *  @throws IndexOutOfBoundsException if `n` is negative or this lazy list holds `n` elements or fewer
+   */
   @throws[IndexOutOfBoundsException]
   override def apply(n: Int): A = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
@@ -488,9 +520,17 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
     else tail.foldLeft(op(z, head))(op)
 
   // LazyListIterable.Empty doesn't use the SerializationProxy
+  /** Replaces this lazy list with a serialization proxy during Java serialization, but
+   *  only if its state is already evaluated and non-empty.
+   *
+   *  An evaluated prefix is written out compactly by the proxy; a lazy list whose state
+   *  is not yet evaluated is serialized as itself, so that its unevaluated thunks are
+   *  stored by standard Java serialization and are not forced by serializing.
+   */
   protected def writeReplace(): AnyRef^{this} =
     if (knownNonEmpty) new SerializationProxy[A](this) else this
 
+  /** The prefix of this lazy list's string representation: `"LazyListIterable"`. */
   override protected def className = "LazyListIterable"
 
   /** The lazy list resulting from the concatenation of this lazy list with the argument lazy list.
@@ -1420,8 +1460,18 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
     def unapply[A](xs: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{xs})] = #::.unapply(xs)
   }
 
+  /** Provides the `#::` and `#:::` operators on a by-name lazy list, so that the right
+   *  operand of a cons is not evaluated when the cons cell is built.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param l the lazy list to defer, evaluated only when the operator's result is forced
+   */
   implicit def toDeferrer[A](l: => LazyListIterable[A]^): Deferrer[A]^{l} = new Deferrer[A](() => l)
 
+  /** Holds the deferred right operand of a `#::` or `#:::` operation on lazy lists.
+   *
+   *  @tparam A the element type of the deferred lazy list
+   */
   final class Deferrer[A] private[LazyListIterable] (private val l: () => LazyListIterable[A]^) extends AnyVal { self: Deferrer[A]^ =>
     /** Constructs a `LazyListIterable` consisting of a given first element followed by elements
      *  from another `LazyListIterable`.
@@ -1434,16 +1484,41 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   }
 
   object #:: {
+    /** Matches a non-empty lazy list against its head and tail.
+     *
+     *  Matching evaluates the state of `s` and, if it is non-empty, its head; the
+     *  elements of the tail are left unevaluated.
+     *
+     *  @tparam A the element type of the lazy list
+     *  @param s the lazy list to decompose
+     *  @return `Some((head, tail))` if `s` is non-empty, or `None` if it is empty
+     */
     def unapply[A](s: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{s})] =
       if (!s.isEmpty) Some((s.head, s.tail)) else None
   }
 
+  /** Returns a lazy list containing the elements of `coll`.
+   *
+   *  If `coll` is already a lazy list it is returned unchanged, and a collection known
+   *  to be empty gives the empty lazy list; otherwise the elements are taken from
+   *  `coll`'s iterator one at a time as the result is forced, the first of them as soon
+   *  as the result's state is evaluated.
+   *
+   *  @tparam A the element type
+   *  @param coll the collection whose elements are to be contained
+   */
   def from[A](coll: collection.IterableOnce[A]^): LazyListIterable[A]^{coll} = coll match {
     case lazyList: LazyListIterable[A]    => lazyList
     case _ if coll.knownSize == 0 => empty[A]
     case _                        => newLL(eagerHeadFromIterator(coll.iterator))
   }
 
+  /** Returns the empty lazy list.
+   *
+   *  All calls return the same instance, which is already evaluated.
+   *
+   *  @tparam A the element type of the lazy list
+   */
   def empty[A]: LazyListIterable[A] = Empty
 
   /** Creates a LazyListIterable with the elements of an iterator followed by a LazyListIterable suffix.
@@ -1469,6 +1544,15 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
     else Empty
 
   // TODO This should be (xss: (collection.Iterable[A]^)*)
+  /** Returns a lazy list of the elements of all the given collections, one collection
+   *  after another.
+   *
+   *  $initiallyLazy Each collection is iterated only as the result is forced past its
+   *  predecessors.
+   *
+   *  @tparam A the element type
+   *  @param xss the collections to concatenate
+   */
   override def concat[A](xss: collection.Iterable[A]*): LazyListIterable[A] =
     if (xss.knownSize == 0) empty
     else newLL(eagerHeadConcatIterators(xss.iterator))
@@ -1528,9 +1612,29 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    */
   def continually[A](elem: => A): LazyListIterable[A]^{elem} = newLL(eagerCons(elem, continually(elem)))
 
+  /** Returns a lazy list of `n` elements, each the result of a separate evaluation of
+   *  `elem`.
+   *
+   *  $initiallyLazy An element is computed only when the lazy list is forced that far,
+   *  so `elem` is evaluated once per element and never more often than that. A
+   *  non-positive `n` gives the empty lazy list.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param elem the element expression, evaluated once for each element
+   */
   override def fill[A](n: Int)(elem: => A): LazyListIterable[A]^{elem} =
     if (n > 0) newLL(eagerCons(elem, LazyListIterable.fill(n - 1)(elem))) else empty
 
+  /** Returns a lazy list of `n` elements, the element at index `i` being `f(i)`.
+   *
+   *  $initiallyLazy `f` is applied to an index only when the lazy list is forced that
+   *  far. A non-positive `n` gives the empty lazy list.
+   *
+   *  @tparam A the element type
+   *  @param n the number of elements
+   *  @param f the function computing the element at each index
+   */
   override def tabulate[A](n: Int)(f: Int => A): LazyListIterable[A]^{f} = {
     def at(index: Int): LazyListIterable[A]^{f} =
       if (index < n) newLL(eagerCons(f(index), at(index + 1))) else empty
@@ -1539,6 +1643,17 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   }
 
   // significantly simpler than the iterator returned by Iterator.unfold
+  /** Returns a lazy list produced by repeatedly applying `f` to a state, starting from
+   *  `init`, for as long as it returns an element and the next state.
+   *
+   *  $initiallyLazy `f` is applied to a state only when the lazy list is forced that
+   *  far; the first `None` it returns ends the lazy list.
+   *
+   *  @tparam A the element type
+   *  @tparam S the type of the state
+   *  @param init the initial state
+   *  @param f the function producing the next element and state, or `None` to stop
+   */
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): LazyListIterable[A]^{f} =
     newLL {
       f(init) match {
@@ -1663,6 +1778,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    */
   @SerialVersionUID(4L)
   final class SerializationProxy[A](of: LazyListIterable[A]^) extends Serializable {
+    /** The lazy list this proxy stands for, restored from the stream when the proxy is read back. */
     @transient protected var coll: LazyListIterable[A]^{this} = of
 
     private def writeObject(out: ObjectOutputStream): Unit = {

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -89,6 +89,7 @@ sealed abstract class List[+A]
     with IterableFactoryDefaults[A, List]
     with DefaultSerializable {
 
+  /** The factory used to build lists, the [[List$ `List`]] companion object. */
   override def iterableFactory: SeqFactory[List] = List
 
   /** Adds an element at the beginning of this list.
@@ -147,10 +148,30 @@ sealed abstract class List[+A]
     these
   }
 
+  /** Returns `true` if this list is `Nil`, which is the only empty list. */
   override final def isEmpty: Boolean = this eq Nil
 
+  /** Returns a list with `elem` at its head and this list as its tail.
+   *
+   *  Only one cons cell is allocated: this list becomes the tail of the result and is
+   *  not copied.
+   *
+   *  @tparam B the element type of the returned list, a supertype of `A`
+   *  @param elem the element to prepend
+   */
   override def prepended[B >: A](elem: B): List[B] = elem :: this
 
+  /** Returns a list consisting of the elements of `prefix` followed by the elements of
+   *  this list.
+   *
+   *  In the general case only `prefix` is copied and this list becomes the tail of the
+   *  result; an empty `prefix` gives this list itself. Nothing at all is copied when
+   *  this list is empty and `prefix` is a `List` or a `ListBuffer`: the prefix, or the
+   *  buffer's list, is then the result.
+   *
+   *  @tparam B the element type of the returned list, a supertype of `A`
+   *  @param prefix the elements to prepend
+   */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): List[B] = (prefix: @unchecked) match {
     case xs: List[B] => xs ::: this
     case _ if prefix.knownSize == 0 => this
@@ -173,11 +194,29 @@ sealed abstract class List[+A]
   }
 
   // When calling appendAll with another list `suffix`, avoid copying `suffix`
+  /** Returns a list consisting of the elements of this list followed by the elements of
+   *  `suffix`.
+   *
+   *  When `suffix` is itself a list, only this list is copied and `suffix` becomes the
+   *  tail of the result; otherwise both are copied into a new list.
+   *
+   *  @tparam B the element type of the returned list, a supertype of `A`
+   *  @param suffix the elements to append
+   */
   override def appendedAll[B >: A](suffix: collection.IterableOnce[B]^): List[B] = suffix match {
     case xs: List[B] => this ::: xs
     case _ => super.appendedAll(suffix)
   }
 
+  /** Returns a list of the first `n` elements of this list, or of all its elements if it
+   *  has fewer than `n`.
+   *
+   *  The elements taken are copied, so the result shares nothing with this list, except
+   *  when the whole list is taken, in which case this list itself is returned. A
+   *  non-positive `n` gives `Nil`.
+   *
+   *  @param n the number of elements to take
+   */
   override def take(n: Int): List[A] = if (isEmpty || n <= 0) Nil else {
     val h = new ::(head, Nil)
     var t = h
@@ -194,12 +233,32 @@ sealed abstract class List[+A]
     h
   }
 
+  /** Returns the elements of this list from `from` up to but not including `until`.
+   *
+   *  A negative `from` is treated as 0 and an `until` past the end is harmless, so no
+   *  exception is thrown for out-of-range values. The elements before `from` are
+   *  dropped without copying. The ones kept are copied unless `until` reaches the end
+   *  of this list, in which case the suffix is shared rather than copied.
+   *
+   *  @param from the index of the first element of the slice
+   *  @param until the index one past the last element of the slice
+   *  @return a list of the elements at the indices in the interval, `Nil` if `until` is
+   *          not greater than `from`
+   */
   override def slice(from: Int, until: Int): List[A] = {
     val lo = scala.math.max(from, 0)
     if (until <= lo || isEmpty) Nil
     else this drop lo take (until - lo)
   }
 
+  /** Returns a list of the last `n` elements of this list, or of all its elements if it
+   *  has fewer than `n`.
+   *
+   *  The result is a suffix of this list and is shared with it, so nothing is copied;
+   *  finding it costs one traversal. A non-positive `n` gives `Nil`.
+   *
+   *  @param n the number of elements to take
+   */
   override def takeRight(n: Int): List[A] = {
     @tailrec
     def loop(lead: List[A], lag: List[A]): List[A] = lead match {
@@ -211,6 +270,15 @@ sealed abstract class List[+A]
 
   // dropRight is inherited from LinearSeq
 
+  /** Returns a pair of lists, the first holding the first `n` elements of this list and
+   *  the second the rest.
+   *
+   *  The first `n` elements are copied; the second list is a suffix of this list and is
+   *  shared with it. A non-positive `n` puts everything in the second list.
+   *
+   *  @param n the index at which to split this list
+   *  @return a pair of the first `n` elements and the remaining ones
+   */
   override def splitAt(n: Int): (List[A], List[A]) = {
     val b = new ListBuffer[A]
     var i = 0
@@ -223,6 +291,18 @@ sealed abstract class List[+A]
     (b.toList, these)
   }
 
+  /** Returns a copy of this list with the element at `index` replaced by `elem`.
+   *
+   *  The elements before `index` are copied and the ones after it are shared with this
+   *  list.
+   *
+   *  @tparam B the element type of the returned list, a supertype of `A`
+   *  @param index the position of the element to replace
+   *  @param elem the replacing element
+   *  @return a list that agrees with this list everywhere except at `index`, where it
+   *          holds `elem`
+   *  @throws IndexOutOfBoundsException if `index` is negative or not less than the length of this list
+   */
   override def updated[B >: A](index: Int, elem: B): List[B] = {
     var i = 0
     var current = this
@@ -239,6 +319,12 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns a list of the results of applying `f` to each element of this list, in
+   *  order.
+   *
+   *  @tparam B the element type of the returned list
+   *  @param f the function to apply to each element
+   */
   final override def map[B](f: A => B): List[B] = {
     if (this eq Nil) Nil else {
       val h = new ::[B](f(head), Nil)
@@ -255,6 +341,15 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns a list of the results of applying `pf` to the elements of this list on
+   *  which it is defined, leaving the others out.
+   *
+   *  `pf` is applied at most once per element, its domain being tested and its result
+   *  taken in one step.
+   *
+   *  @tparam B the element type of the returned list
+   *  @param pf the partial function applied to the elements in its domain
+   */
   final override def collect[B](pf: PartialFunction[A, B]^): List[B] = {
     if (this eq Nil) Nil else {
       var rest = this
@@ -283,6 +378,14 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns a list of the concatenated results of applying `f` to each element of this
+   *  list, in order.
+   *
+   *  @tparam B the element type of the returned list
+   *  @param f the function mapping each element to a collection of results
+   *  @return a list of all elements of the collections returned by `f`, `Nil` if they
+   *          are all empty
+   */
   final override def flatMap[B](f: A => IterableOnce[B]^): List[B] = {
     var rest = this
     var h: ::[B] | Null = null
@@ -303,6 +406,13 @@ sealed abstract class List[+A]
     if (h eq null) Nil else {releaseFence(); h}
   }
 
+  /** Returns the longest prefix of this list whose elements all satisfy `p`.
+   *
+   *  `p` is applied to the elements in order and to at most one element that fails it;
+   *  the elements kept are copied.
+   *
+   *  @param p the predicate the elements of the prefix must satisfy
+   */
   @inline final override def takeWhile(p: A => Boolean): List[A] = {
     val b = new ListBuffer[A]
     var these = this
@@ -313,6 +423,15 @@ sealed abstract class List[+A]
     b.toList
   }
 
+  /** Returns a pair of the longest prefix of this list whose elements all satisfy `p`
+   *  and the rest of this list.
+   *
+   *  The prefix is copied; the second list is a suffix of this list and is shared with
+   *  it.
+   *
+   *  @param p the predicate the elements of the prefix must satisfy
+   *  @return a pair of the longest prefix satisfying `p` and the remaining elements
+   */
   @inline final override def span(p: A => Boolean): (List[A], List[A]) = {
     val b = new ListBuffer[A]
     var these = this
@@ -325,6 +444,11 @@ sealed abstract class List[+A]
 
   // Overridden with an implementation identical to the inherited one (at this time)
   // solely so it can be finalized and thus inlinable.
+  /** Applies `f` to each element of this list, in order.
+   *
+   *  @tparam U the result type of `f`, used only for its side effects
+   *  @param f the function to apply to each element
+   */
   @inline final override def foreach[U](f: A => U): Unit = {
     var these = this
     while (!these.isEmpty) {
@@ -333,6 +457,10 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns a list with the elements of this list in reverse order.
+   *
+   *  Every cons cell is rebuilt, so the result shares nothing with this list.
+   */
   final override def reverse: List[A] = {
     var result: List[A] = Nil
     var these = this
@@ -343,6 +471,17 @@ sealed abstract class List[+A]
     result
   }
 
+  /** Applies `op` to the elements of this list and `z`, going right to left.
+   *
+   *  This list is reversed first and then folded from the left, so the fold uses no
+   *  stack in the length of this list but does allocate a reversed copy of it.
+   *
+   *  @tparam B the result type of the fold
+   *  @param z the start value, combined with the last element first
+   *  @param op the binary operator, applied to an element and the result accumulated so far
+   *  @return the result of inserting `op` between consecutive elements and `z`, or `z`
+   *          itself if this list is empty
+   */
   final override def foldRight[B](z: B)(op: (A, B) => B): B = {
     var acc = z
     var these: List[A] = reverse
@@ -355,6 +494,9 @@ sealed abstract class List[+A]
 
   // Copy/Paste overrides to avoid interface calls inside loops.
 
+  /** Returns the number of elements in this list, counted by traversing it, which costs
+   *  `O(n)`.
+   */
   override final def length: Int = {
     var these = this
     var len = 0
@@ -365,6 +507,14 @@ sealed abstract class List[+A]
     len
   }
 
+  /** Compares the length of this list with `len`, traversing no further than `len`
+   *  elements rather than counting them all.
+   *
+   *  @param len the length to compare against
+   *  @return a negative value if this list is shorter than `len`, `0` if it has exactly
+   *          `len` elements, and a positive value if it is longer, which is also the
+   *          answer for every negative `len`
+   */
   override final def lengthCompare(len: Int): Int = {
     @tailrec def loop(i: Int, xs: List[A]): Int = {
       if (i == len)
@@ -378,6 +528,13 @@ sealed abstract class List[+A]
     else loop(0, coll)
   }
 
+  /** Returns `true` if `p` holds for every element of this list.
+   *
+   *  The traversal stops at the first element that fails `p`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if this list is empty or `p` holds for all of its elements
+   */
   override final def forall(p: A => Boolean): Boolean = {
     var these: List[A] = this
     while (!these.isEmpty) {
@@ -387,6 +544,13 @@ sealed abstract class List[+A]
     true
   }
 
+  /** Returns `true` if `p` holds for at least one element of this list.
+   *
+   *  The traversal stops at the first element that satisfies `p`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if `p` holds for some element, `false` if this list is empty
+   */
   override final def exists(p: A => Boolean): Boolean = {
     var these: List[A] = this
     while (!these.isEmpty) {
@@ -396,6 +560,13 @@ sealed abstract class List[+A]
     false
   }
 
+  /** Returns `true` if this list holds an element that is `==` to `elem`.
+   *
+   *  The traversal stops at the first match.
+   *
+   *  @tparam A1 the type of `elem`, a supertype of `A`
+   *  @param elem the element to look for
+   */
   override final def contains[A1 >: A](elem: A1): Boolean = {
     var these: List[A] = this
     while (!these.isEmpty) {
@@ -405,6 +576,13 @@ sealed abstract class List[+A]
     false
   }
 
+  /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there is
+   *  none.
+   *
+   *  The traversal stops at the first match.
+   *
+   *  @param p the predicate used to test elements
+   */
   override final def find(p: A => Boolean): Option[A] = {
     var these: List[A] = this
     while (!these.isEmpty) {
@@ -414,6 +592,11 @@ sealed abstract class List[+A]
     None
   }
 
+  /** Returns the last element of this list, reached by traversing it, which costs
+   *  `O(n)`.
+   *
+   *  @throws NoSuchElementException if this list is empty
+   */
   override def last: A = {
     if (isEmpty) throw new NoSuchElementException("List.last")
     else {
@@ -427,6 +610,16 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns `true` if this list and `that` have the same length and `p` holds for every
+   *  pair of corresponding elements.
+   *
+   *  When `that` is a linear sequence the two are walked side by side, which avoids
+   *  indexing into it; the traversal stops at the first pair that fails `p`.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the sequence to compare against
+   *  @param p the relation each pair of corresponding elements must satisfy
+   */
   override def corresponds[B](that: collection.Seq[B])(p: (A, B) => Boolean): Boolean = that match {
     case that: LinearSeq[B @unchecked] =>
       var i = this
@@ -442,6 +635,7 @@ sealed abstract class List[+A]
       super.corresponds(that)(p)
   }
 
+  /** The prefix of this list's string representation: `"List"`. */
   override protected def className = "List"
 
   /** Builds a new list by applying a function to all elements of this list.
@@ -497,8 +691,24 @@ sealed abstract class List[+A]
     result
   }
 
+  /** Returns a list of the elements of this list that satisfy `p`, in order.
+   *
+   *  As much of this list as possible is shared with the result: this list itself is
+   *  returned when every element satisfies `p`, and the longest suffix in which nothing
+   *  is dropped is shared rather than copied.
+   *
+   *  @param p the predicate an element must satisfy to be kept
+   */
   override def filter(p: A => Boolean): List[A] = filterCommon(p, isFlipped = false)
 
+  /** Returns a list of the elements of this list that do not satisfy `p`, in order.
+   *
+   *  As much of this list as possible is shared with the result: this list itself is
+   *  returned when no element satisfies `p`, and the longest suffix in which nothing is
+   *  dropped is shared rather than copied.
+   *
+   *  @param p the predicate an element must not satisfy to be kept
+   */
   override def filterNot(p: A => Boolean): List[A] = filterCommon(p, isFlipped = true)
 
   private def filterCommon(p: A => Boolean, isFlipped: Boolean): List[A] = {
@@ -581,6 +791,15 @@ sealed abstract class List[+A]
     result
   }
 
+  /** Returns a pair of lists, the first holding the elements satisfying `p` and the
+   *  second the elements that do not.
+   *
+   *  When all elements fall on one side, this list itself is used for that side rather
+   *  than a copy, and the other side is `Nil`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of the elements satisfying `p` and the elements not satisfying it
+   */
   override def partition(p: A => Boolean): (List[A], List[A]) = {
     if (isEmpty) List.TupleOfNil
     else super.partition(p) match {
@@ -590,9 +809,18 @@ sealed abstract class List[+A]
     }
   }
 
+  /** Returns this list itself; being already a `List`, no copy is made. */
   final override def toList: List[A] = this
 
   // Override for performance
+  /** Returns `true` if `o` is a sequence holding the same elements in the same order.
+   *
+   *  Two lists are compared by walking them side by side, and two lists that are the
+   *  same object are equal without any comparison; against any other value the inherited
+   *  sequence equality is used.
+   *
+   *  @param o the value to compare against
+   */
   override def equals(o: scala.Any): Boolean = {
     @tailrec def listEq(a: List[?], b: List[?]): Boolean =
       (a eq b) || {
@@ -649,10 +877,20 @@ sealed abstract class List[+A]
 
 // Internal code that mutates `next` _must_ call `Statics.releaseFence()` if either immediately, or
 // before a newly-allocated, thread-local :: instance is aliased (e.g. in ListBuffer.toList)
+/** A non-empty list, holding its first element and the list of the remaining ones.
+ *
+ *  @tparam A the element type of this list
+ *  @param head the first element of this list
+ *  @param next the list of all elements after the first
+ */
 final case class :: [+A](override val head: A, private[scala] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally
   extends List[A] {
   releaseFence()
+  /** Returns the first element of this list wrapped in a `Some`, which is never `None`
+   *  for a non-empty list.
+   */
   override def headOption: Some[A] = Some(head)
+  /** Returns the list of all elements of this list after the first. */
   override def tail: List[A] = next
 
   @publicInBinary
@@ -661,13 +899,39 @@ final case class :: [+A](override val head: A, private[scala] var next: List[A @
 }
 
 case object Nil extends List[Nothing] {
+  /** Returns nothing; the empty list has no elements.
+   *
+   *  @throws NoSuchElementException always
+   */
   override def head: Nothing = throw new NoSuchElementException("head of empty list")
+  /** Returns `None`; the empty list has no first element. */
   override def headOption: None.type = None
+  /** Returns nothing; the empty list has no tail.
+   *
+   *  @throws UnsupportedOperationException always
+   */
   override def tail: Nothing = throw new UnsupportedOperationException("tail of empty list")
+  /** Returns nothing; the empty list has no last element.
+   *
+   *  @throws NoSuchElementException always
+   */
   override def last: Nothing = throw new NoSuchElementException("last of empty list")
+  /** Returns nothing; the empty list has no elements to drop the last of.
+   *
+   *  @throws UnsupportedOperationException always
+   */
   override def init: Nothing = throw new UnsupportedOperationException("init of empty list")
+  /** Returns `0`; the size of the empty list is known without traversal. */
   override def knownSize: Int = 0
+  /** Returns the empty iterator. */
   override def iterator: Iterator[Nothing] = Iterator.empty
+  /** Returns a pair of empty lists, the same shared pair on every call.
+   *
+   *  @tparam A1 the element type of the first returned list
+   *  @tparam A2 the element type of the second returned list
+   *  @param asPair evidence that the elements are pairs; never used, since there are no
+   *                elements to split
+   */
   override def unzip[A1, A2](implicit asPair: Nothing -> (A1, A2)): (List[A1], List[A2]) = EmptyUnzip
 
   @transient
@@ -682,10 +946,27 @@ case object Nil extends List[Nothing] {
 object List extends StrictOptimizedSeqFactory[List] {
   private val TupleOfNil = (Nil, Nil)
 
+  /** Returns a list containing the elements of `coll`, in the order `coll` gives them
+   *  out.
+   *
+   *  If `coll` is already a list it is returned unchanged.
+   *
+   *  @tparam B the element type
+   *  @param coll the collection whose elements are to be contained
+   */
   def from[B](coll: collection.IterableOnce[B]^): List[B] = Nil.prependedAll(coll)
 
+  /** Returns a new builder that collects elements into a list, in the order they are
+   *  added, using a `ListBuffer` to append in constant time.
+   *
+   *  @tparam A the element type of the list being built
+   */
   def newBuilder[A]: Builder[A, List[A]] = new ListBuffer()
 
+  /** Returns the empty list, [[Nil]].
+   *
+   *  @tparam A the element type of the list
+   */
   def empty[A]: List[A] = Nil
 
   @transient

--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -49,19 +49,44 @@ sealed class ListMap[K, +V]
     with MapFactoryDefaults[K, V, ListMap, Iterable]
     with DefaultSerializable {
 
+  /** The factory used to build list maps, the [[ListMap$ `ListMap`]] companion object. */
   override def mapFactory: MapFactory[ListMap] = ListMap
 
+  /** Returns `0`; an instance of `ListMap` itself, as opposed to one of its nodes, is empty. */
   override def size: Int = 0
 
+  /** Returns `true`; an instance of `ListMap` itself, as opposed to one of its nodes, is empty. */
   override def isEmpty: Boolean = true
 
+  /** Returns `0`; the size of an empty list map is known without traversal. */
   override def knownSize: Int = 0
+  /** Returns `None`; this map is empty, so it binds no key.
+   *
+   *  @param key the key to look for; never used
+   */
   def get(key: K): Option[V] = None
 
+  /** Returns a map binding `key` to `value` alone, since this map is empty.
+   *
+   *  @tparam V1 the type of the value, a supertype of `V`
+   *  @param key the key to bind
+   *  @param value the value to bind it to
+   *  @return a one-entry list map whose remainder is this empty map
+   */
   def updated[V1 >: V](key: K, value: V1): ListMap[K, V1] = new ListMap.Node[K, V1](key, value, this)
 
+  /** Returns this map itself; an empty map has no binding to remove.
+   *
+   *  @param key the key to remove; never used
+   */
   def removed(key: K): ListMap[K, V] = this
 
+  /** Returns an iterator over the key-value pairs of this map, in the order in which
+   *  their keys were first inserted.
+   *
+   *  The entries are held in reverse insertion order, so the whole chain is walked and
+   *  reversed into a `List` before the iterator is returned; this costs `O(n)`.
+   */
   def iterator: Iterator[(K, V)] = {
     var curr: ListMap[K, V] = this
     var res: List[(K, V)] = Nil
@@ -72,6 +97,11 @@ sealed class ListMap[K, +V]
     res.iterator
   }
 
+  /** Returns the keys of this map, in the order in which they were first inserted.
+   *
+   *  Unlike the inherited implementation this returns a strict [[List]] rather than a
+   *  view, built by walking and reversing the chain in `O(n)`.
+   */
   @nowarn("msg=overriding method keys")
   override def keys: Iterable[K] = {
     var curr: ListMap[K, V] = this
@@ -83,6 +113,12 @@ sealed class ListMap[K, +V]
     res
   }
 
+  /** Returns the hash code of this map, computed from its bindings and independent of
+   *  their order.
+   *
+   *  The chain is traversed in its internal, reversed order, which the order-insensitive
+   *  hash of a map makes harmless and which avoids reversing the entries first.
+   */
   override def hashCode(): Int = {
     if (isEmpty) MurmurHash3.emptyMapHash
     else {
@@ -110,7 +146,20 @@ sealed class ListMap[K, +V]
   private[immutable] def value: V = throw new NoSuchElementException("value of empty map")
   private[immutable] def next: ListMap[K, V] = throw new NoSuchElementException("next of empty map")
 
+  /** Applies `op` to the entries of this map and `z`, going right to left in insertion
+   *  order.
+   *
+   *  Since the entries are held newest first, the fold starts at the head of the chain
+   *  and runs tail recursively, building neither a reversed copy nor a stack.
+   *
+   *  @tparam Z the result type of the fold
+   *  @param z the start value, combined with the last entry first
+   *  @param op the binary operator, applied to an entry and the result accumulated so far
+   *  @return the result of inserting `op` between consecutive entries and `z`, or `z`
+   *          itself if this map is empty
+   */
   override def foldRight[Z](z: Z)(op: ((K, V), Z) => Z): Z = ListMap.foldRightInternal(this, z, op)
+  /** The prefix of this map's string representation: `"ListMap"`. */
   override protected def className = "ListMap"
 
 }
@@ -242,10 +291,29 @@ object ListMap extends MapFactory[ListMap] {
 
   }
 
+  /** Returns the empty list map.
+   *
+   *  All calls return the same instance, cast to the requested key and value types.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   */
   def empty[K, V]: ListMap[K, V] = EmptyListMap.asInstanceOf[ListMap[K, V]]
 
   private object EmptyListMap extends ListMap[Any, Nothing]
 
+  /** Returns a list map containing the bindings of `it`, in the order `it` gives them
+   *  out, with a key that occurs more than once kept at the position of its first
+   *  occurrence and bound to its last value.
+   *
+   *  If `it` is already a `ListMap` it is returned unchanged. A `Map`, `MapView` or
+   *  `LinkedHashMap` cannot repeat a key, so its entries are chained up directly;
+   *  anything else goes through the builder, which costs `O(n^2^)`.
+   *
+   *  @tparam K the key type
+   *  @tparam V the value type
+   *  @param it the collection whose bindings are to be contained
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): ListMap[K, V] =
     (it: @unchecked) match {
       case lm: ListMap[K, V] => lm

--- a/library/src/scala/collection/immutable/ListSet.scala
+++ b/library/src/scala/collection/immutable/ListSet.scala
@@ -45,17 +45,40 @@ sealed class ListSet[A]
     with IterableFactoryDefaults[A, ListSet]
     with DefaultSerializable {
 
+  /** The prefix of this set's string representation: `"ListSet"`. */
   override protected def className: String = "ListSet"
 
+  /** Returns `0`; an instance of `ListSet` itself, as opposed to one of its nodes, is empty. */
   override def size: Int = 0
+  /** Returns `0`; the size of an empty list set is known without traversal. */
   override def knownSize: Int = 0
+  /** Returns `true`; an instance of `ListSet` itself, as opposed to one of its nodes, is empty. */
   override def isEmpty: Boolean = true
 
+  /** Returns `false`; this set is empty, so it contains nothing.
+   *
+   *  @param elem the element to look for; never used
+   */
   def contains(elem: A): Boolean = false
 
+  /** Returns a set holding `elem` alone, since this set is empty.
+   *
+   *  @param elem the element to add
+   *  @return a one-element list set whose remainder is this empty set
+   */
   def incl(elem: A): ListSet[A] = new Node(elem)
+  /** Returns this set itself; an empty set contains nothing to remove.
+   *
+   *  @param elem the element to remove; never used
+   */
   def excl(elem: A): ListSet[A] = this
 
+  /** Returns an iterator over the elements of this set, in the order in which they
+   *  were first inserted.
+   *
+   *  The elements are held in reverse insertion order, so the whole chain is walked
+   *  and reversed into a `List` before the iterator is returned; this costs `O(n)`.
+   */
   def iterator: scala.collection.Iterator[A] = {
     var curr: ListSet[A] = this
     var res: List[A] = Nil
@@ -66,9 +89,18 @@ sealed class ListSet[A]
     res.iterator
   }
 
+  /** The element held by this node of the chain; an empty list set holds none.
+   *
+   *  @throws NoSuchElementException always, since this set is empty
+   */
   protected def elem: A = throw new NoSuchElementException("elem of empty set")
+  /** The remainder of the chain below this node; an empty list set has none.
+   *
+   *  @throws NoSuchElementException always, since this set is empty
+   */
   protected def next: ListSet[A] = throw new NoSuchElementException("next of empty set")
 
+  /** The factory used to build list sets, the [[ListSet$ `ListSet`]] companion object. */
   override def iterableFactory: IterableFactory[ListSet] = ListSet
 
   /** Represents an entry in the `ListSet`.
@@ -77,21 +109,49 @@ sealed class ListSet[A]
    */
   protected class Node(override protected val elem: A) extends ListSet[A] {
 
+    /** Returns the number of elements in this set, counted by walking the chain, which costs `O(n)`. */
     override def size = sizeInternal(this, 0)
+    /** Returns `-1`; the size of a non-empty list set is not known without walking the chain. */
     override def knownSize: Int = -1
     @tailrec private def sizeInternal(n: ListSet[A], acc: Int): Int =
       if (n.isEmpty) acc
       else sizeInternal(n.next, acc + 1)
 
+    /** Returns `false`; a node always holds at least its own element. */
     override def isEmpty: Boolean = false
 
+    /** Returns `true` if this set contains `e`, comparing elements with `==`.
+     *
+     *  The chain is searched from the most recently inserted element towards the
+     *  oldest, which costs `O(n)`.
+     *
+     *  @param e the element to look for
+     */
     override def contains(e: A): Boolean = containsInternal(this, e)
 
     @tailrec private def containsInternal(n: ListSet[A], e: A): Boolean =
       !n.isEmpty && (n.elem == e || containsInternal(n.next, e))
 
+    /** Returns a set that contains `e` and all elements of this set. Returns this set
+     *  itself if it already contains `e`, so that re-inserting an element leaves its
+     *  position in the insertion order untouched; otherwise `e` becomes the most
+     *  recently inserted element and the rest of the chain is shared.
+     *
+     *  The membership test makes this `O(n)`.
+     *
+     *  @param e the element to add
+     *  @return a list set containing all elements of this set plus `e`
+     */
     override def incl(e: A): ListSet[A] = if (contains(e)) this else new Node(e)
 
+    /** Returns a set that contains all elements of this set except `e`, in their
+     *  original insertion order. Returns this set itself if it does not contain `e`;
+     *  otherwise the nodes inserted after `e` are rebuilt and the ones inserted
+     *  before it are shared, which costs `O(n)`.
+     *
+     *  @param e the element to remove
+     *  @return a list set containing all elements of this set except `e`
+     */
     override def excl(e: A): ListSet[A] = removeInternal(e, this, Nil)
 
     @tailrec private def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
@@ -99,10 +159,17 @@ sealed class ListSet[A]
       else if (k == cur.elem) acc.foldLeft(cur.next)((t, h) => new t.Node(h.elem))
       else removeInternal(k, cur.next, cur :: acc)
 
+    /** The set of all elements inserted before this node's element. */
     override protected def next: ListSet[A] = ListSet.this
 
+    /** Returns the most recently inserted element of this set, which is this node's own
+     *  element and therefore costs `O(1)`.
+     */
     override def last: A = elem
 
+    /** Returns this set without its most recently inserted element, which is the chain
+     *  below this node and therefore costs `O(1)`.
+     */
     override def init: ListSet[A] = next
   }
 }
@@ -119,6 +186,16 @@ sealed class ListSet[A]
 @SerialVersionUID(3L)
 object ListSet extends IterableFactory[ListSet] {
 
+  /** Returns a list set containing the elements of `it`, in the order `it` gives them
+   *  out, with any element that occurs more than once kept at the position of its
+   *  first occurrence.
+   *
+   *  If `it` is already a `ListSet` it is returned unchanged; otherwise the elements
+   *  are inserted one by one, which costs `O(n^2^)`.
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   def from[E](it: scala.collection.IterableOnce[E]^): ListSet[E] =
     (it: @unchecked) match {
       case ls: ListSet[E] => ls
@@ -131,8 +208,21 @@ object ListSet extends IterableFactory[ListSet] {
   }
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
+  /** Returns the empty list set.
+   *
+   *  All calls return the same instance, cast to the requested element type.
+   *
+   *  @tparam A the element type of the set
+   */
   def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
 
+  /** Returns a new builder that adds elements to a list set one at a time, keeping the
+   *  first occurrence of each.
+   *
+   *  Since each insertion is `O(n)`, building a set of n elements costs `O(n^2^)`.
+   *
+   *  @tparam A the element type of the set being built
+   */
   def newBuilder[A]: Builder[A, ListSet[A]] =
     new ImmutableBuilder[A, ListSet[A]](empty) {
       def addOne(elem: A): this.type = { elems = elems + elem; this }

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -49,14 +49,46 @@ import LongMapUtils.{Long => _, _}
  *  @define Coll  `LongMap`
  */
 object LongMap {
+  /** Returns the empty map, a single instance shared between all value types.
+   *
+   *  @tparam T the type of the values
+   */
   def empty[T]: LongMap[T]  = LongMap.Nil
+  /** Returns a map containing only the given key/value binding.
+   *
+   *  @tparam T the type of the value
+   *  @param key the key of the single binding
+   *  @param value the value associated with `key`
+   */
   def singleton[T](key: Long, value: T): LongMap[T] = LongMap.Tip(key, value)
+  /** Returns a map containing the given key/value pairs.
+   *
+   *  If a key occurs more than once in `elems`, the last binding for that key is
+   *  retained.
+   *
+   *  @tparam T the type of the values
+   *  @param elems the key/value pairs of the map
+   */
   def apply[T](elems: (Long, T)*): LongMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+  /** Returns a map containing the key/value pairs of the given collection.
+   *
+   *  If a key occurs more than once in `coll`, the last binding for that key is
+   *  retained.
+   *
+   *  @tparam V the type of the values
+   *  @param coll the collection of key/value pairs
+   */
   def from[V](coll: IterableOnce[(Long, V)]^): LongMap[V] =
     newBuilder[V].addAll(coll).result()
 
+  /** Returns a new builder that accumulates key/value pairs into a `LongMap`.
+   *
+   *  If a key is added more than once, the last binding for that key is retained.
+   *
+   *  @tparam V the type of the values
+   */
   def newBuilder[V]: Builder[(Long, V), LongMap[V]] =
     new ImmutableBuilder[(Long, V), LongMap[V]](empty) {
       def addOne(elem: (Long, V)): this.type = { elems = elems + elem; this }
@@ -84,6 +116,13 @@ object LongMap {
     }
   }
 
+  /** Implicitly converts the `LongMap` object to a `Factory`, so that it can be
+   *  passed where a factory of long-keyed pairs is expected.
+   *
+   *  @tparam V the type of the values
+   *  @param dummy the `LongMap` companion object; never used
+   *  @return a `Factory` building a `LongMap[V]` from `(Long, V)` pairs
+   */
   implicit def toFactory[V](dummy: LongMap.type): Factory[(Long, V), LongMap[V]] = ToFactory.asInstanceOf[Factory[(Long, V), LongMap[V]]]
 
   @SerialVersionUID(3L)
@@ -92,13 +131,30 @@ object LongMap {
     def newBuilder: Builder[(Long, AnyRef), LongMap[AnyRef]] = LongMap.newBuilder[AnyRef]
   }
 
+  /** Implicitly converts the `LongMap` object to a `BuildFrom`, so that it can be
+   *  passed where a `BuildFrom` producing a long-keyed map is expected.
+   *
+   *  @tparam V the type of the values
+   *  @param factory the `LongMap` companion object; never used
+   *  @return a `BuildFrom` building a `LongMap[V]` from `(Long, V)` pairs, whatever
+   *          the source collection
+   */
   implicit def toBuildFrom[V](factory: LongMap.type): BuildFrom[Any, (Long, V), LongMap[V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (Long, V), LongMap[V]]]
   private object ToBuildFrom extends BuildFrom[Any, (Long, AnyRef), LongMap[AnyRef]] {
     def fromSpecific(from: Any)(it: IterableOnce[(Long, AnyRef)]^) = LongMap.from(it)
     def newBuilder(from: Any) = LongMap.newBuilder[AnyRef]
   }
 
+  /** Returns an implicit `Factory` building a `LongMap[V]` from `(Long, V)` pairs.
+   *
+   *  @tparam V the type of the values
+   */
   implicit def iterableFactory[V]: Factory[(Long, V), LongMap[V]] = toFactory(this)
+  /** Returns an implicit `BuildFrom` building a `LongMap[V]` from `(Long, V)` pairs,
+   *  for transformation methods whose source collection is a `LongMap`.
+   *
+   *  @tparam V the type of the values
+   */
   implicit def buildFromLongMap[V]: BuildFrom[LongMap[?], (Long, V), LongMap[V]] = toBuildFrom(this)
 }
 
@@ -179,6 +235,13 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   with StrictOptimizedMapOps[Long, T, Map, LongMap[T]]
   with Serializable {
 
+  /** Returns a `LongMap` containing the key/value pairs of `coll`.
+   *
+   *  If a key occurs more than once in `coll`, the last binding for that key is
+   *  retained.
+   *
+   *  @param coll the collection of key/value pairs
+   */
   override protected def fromSpecific(coll: (scala.collection.IterableOnce[(Long, T)]^) @uncheckedVariance): LongMap[T] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder
@@ -186,13 +249,16 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     b.addAll(coll)
     b.result()
   }
+  /** Returns a new builder that accumulates key/value pairs into a `LongMap`. */
   override protected def newSpecificBuilder: Builder[(Long, T), LongMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
       def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
     }
 
+  /** Returns the empty `LongMap`, a single shared instance. */
   override def empty: LongMap[T] = LongMap.Nil
 
+  /** Returns a list of the key/value pairs of this map, in unsigned order of the keys. */
   override def toList = {
     val buffer = new ListBuffer[(Long, T)]
     foreach(buffer += _)
@@ -219,12 +285,19 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil =>
   }
 
+  /** Loops over the key, value pairs of the map in unsigned order of the keys,
+   *  passing the key and value as two separate arguments.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key and value in the map
+   */
   override final def foreachEntry[U](f: (Long, T) => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case LongMap.Tip(key, value) => f(key, value)
     case LongMap.Nil =>
   }
 
+  /** Returns an iterator over the keys of this map, in unsigned order. */
   override def keysIterator: Iterator[Long] = this match {
     case LongMap.Nil => Iterator.empty
     case _ => new LongMapKeyIterator(this)
@@ -242,6 +315,9 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil =>
   }
 
+  /** Returns an iterator over the values of this map, in unsigned order of the
+   *  corresponding keys.
+   */
   override def valuesIterator: Iterator[T] = this match {
     case LongMap.Nil => Iterator.empty
     case _ => new LongMapValueIterator(this)
@@ -259,10 +335,25 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil =>
   }
 
+  /** The name `"LongMap"`, used as the prefix in the string representation of this map. */
   override protected def className = "LongMap"
 
+  /** Returns `true` if this map contains no bindings. The only empty `LongMap` is
+   *  the shared `LongMap.Nil` instance, so this is a reference comparison.
+   */
   override def isEmpty = this eq LongMap.Nil
+  /** Returns 0 if this map is empty, otherwise -1, since computing the size
+   *  requires traversing the whole tree.
+   */
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
+  /** Returns a map containing only the key/value pairs of this map that satisfy
+   *  the predicate `f`.
+   *
+   *  Preserves sharing where possible: unchanged subtrees are reused, and if no
+   *  binding is removed the result is this map itself.
+   *
+   *  @param f the predicate applied to each key/value pair
+   */
   override def filter(f: ((Long, T)) => Boolean): LongMap[T] = this match {
     case LongMap.Bin(prefix, mask, left, right) => {
       val (newleft, newright) = (left.filter(f), right.filter(f))
@@ -275,18 +366,35 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Nil
   }
 
+  /** Returns a map with the same keys, where each value is replaced by the result
+   *  of applying `f` to the key and its current value.
+   *
+   *  Unlike `map`, keys and tree structure are unchanged; only values are
+   *  recomputed. Subtrees whose values are unchanged (by reference) are reused.
+   *
+   *  @tparam S the type of the values in the resulting map
+   *  @param f the function computing the new value for each binding
+   */
   override def transform[S](f: (Long, T) => S): LongMap[S] = this match {
     case b@LongMap.Bin(prefix, mask, left, right) => b.bin(left.transform(f), right.transform(f))
     case t@LongMap.Tip(key, value) => t.withValue(f(key, value))
     case LongMap.Nil => LongMap.Nil
   }
 
+  /** Returns the number of bindings in this map, counted by traversing the whole
+   *  tree, in time linear in the size of the map.
+   */
   final override def size: Int = this match {
     case LongMap.Nil => 0
     case LongMap.Tip(_, _) => 1
     case LongMap.Bin(_, _, left, right) => left.size + right.size
   }
 
+  /** Optionally returns the value associated with the given key.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if this map binds `key` to `value`, `None` otherwise
+   */
   @tailrec
   final def get(key: Long): Option[T] = this match {
     case LongMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left.get(key) else right.get(key)
@@ -294,6 +402,14 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => None
   }
 
+  /** Returns the value associated with the given key, or `default` if the key is
+   *  not present.
+   *
+   *  @tparam S the type of the result, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value returned if `key` is not present; evaluated only in
+   *                 that case
+   */
   @tailrec
   final override def getOrElse[S >: T](key: Long, default: => S): S = this match {
     case LongMap.Nil => default
@@ -302,6 +418,14 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
       if (zero(key, mask)) left.getOrElse(key, default) else right.getOrElse(key, default)
   }
 
+  /** Returns the value associated with the given key.
+   *
+   *  @param key the key to look up
+   *  @return the value bound to `key`
+   *  @throws IllegalArgumentException if `key` is not present; note that this
+   *          differs from the `NoSuchElementException` thrown by most map
+   *          implementations
+   */
   @tailrec
   final override def apply(key: Long): T = this match {
     case LongMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left(key) else right(key)
@@ -309,8 +433,26 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => throw new IllegalArgumentException("key not found")
   }
 
+  /** Returns a map with the given key/value pair added, replacing any existing
+   *  binding for that key.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param kv the key/value pair to add
+   *  @return a map containing the bindings of this map and the binding `kv`
+   */
   override def + [S >: T] (kv: (Long, S)): LongMap[S] = updated(kv._1, kv._2)
 
+  /** Returns a map with `key` bound to `value`, replacing any existing binding
+   *  for `key`.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a map containing the bindings of this map and the binding of `key`
+   *          to `value`
+   */
   override def updated[S >: T](key: Long, value: S): LongMap[S] = this match {
     case LongMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) join(key, LongMap.Tip(key, value), prefix, this)
@@ -355,6 +497,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Tip(key, value)
   }
 
+  /** Returns a map without any binding for the given key.
+   *
+   *  @param key the key to remove
+   *  @return a map containing the bindings of this map except for `key`
+   */
   def removed(key: Long): LongMap[T] = this match {
     case LongMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
@@ -462,9 +609,21 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   def intersection[R](that: LongMap[R]): LongMap[T] =
     this.intersectionWith(that, (_key: Long, value: T, _value2: R) => value)
 
+  /** Returns a map containing the bindings of this map and of `that`.
+   *
+   *  If a key is present in both maps, the value from `that` is retained.
+   *
+   *  @tparam S the type of the values in the resulting map, a supertype of this
+   *            map's value type
+   *  @param that the map to form a union with
+   */
   def ++[S >: T](that: LongMap[S]) =
     this.unionWith[S](that, (_key, _x, y) => y)
 
+  /** Returns the lowest key of this map in unsigned order.
+   *
+   *  @throws IllegalStateException if this map is empty
+   */
   @tailrec
   final def firstKey: Long = this match {
     case LongMap.Bin(_, _, l, r) => l.firstKey
@@ -472,6 +631,10 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => throw new IllegalStateException("Empty set")
   }
 
+  /** Returns the highest key of this map in unsigned order.
+   *
+   *  @throws IllegalStateException if this map is empty
+   */
   @tailrec
   final def lastKey: Long = this match {
     case LongMap.Bin(_, _, l, r) => r.lastKey
@@ -479,17 +642,69 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => throw new IllegalStateException("Empty set")
   }
 
+  /** Returns a map built from the results of applying `f` to each key/value pair
+   *  of this map.
+   *
+   *  Unlike `transform`, `f` may change the keys, so the result is rebuilt from
+   *  the transformed pairs. If `f` produces the same key for different pairs,
+   *  bindings produced later (in unsigned order of the original keys) overwrite
+   *  earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function applied to each key/value pair
+   *  @return a `LongMap` containing the transformed pairs
+   */
   def map[V2](f: ((Long, T)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
+  /** Returns a map built by applying `f` to each key/value pair of this map and
+   *  collecting all the pairs it produces.
+   *
+   *  If the same key is produced more than once, bindings produced later
+   *  overwrite earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function returning a collection of key/value pairs for each
+   *           pair of this map
+   *  @return a `LongMap` containing all the pairs produced by `f`
+   */
   def flatMap[V2](f: ((Long, T)) => IterableOnce[(Long, V2)]^): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
+  /** Returns a map containing the bindings of this map and of `that`.
+   *
+   *  Bindings from `that` overwrite bindings of this map with the same key.
+   *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param that the collection of key/value pairs to add
+   *  @return a `LongMap` containing the combined bindings
+   */
   override def concat[V1 >: T](that: scala.collection.IterableOnce[(Long, V1)]^): LongMap[V1] =
     super.concat(that).asInstanceOf[LongMap[V1]] // Already has correct type but not declared as such
 
+  /** Alias for `concat`: returns a map containing the bindings of this map and
+   *  of `that`, where bindings from `that` overwrite bindings of this map with
+   *  the same key.
+   *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param that the collection of key/value pairs to add
+   *  @return a `LongMap` containing the combined bindings
+   */
   override def ++ [V1 >: T](that: scala.collection.IterableOnce[(Long, V1)]^): LongMap[V1] = concat(that)
 
+  /** Returns a map built from the key/value pairs on which `pf` is defined,
+   *  transformed by `pf`.
+   *
+   *  If `pf` produces the same key for different pairs, bindings produced later
+   *  overwrite earlier ones.
+   *
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param pf the partial function applied to each pair on which it is defined
+   *  @return a `LongMap` containing the transformed pairs
+   */
   def collect[V2](pf: PartialFunction[(Long, T), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
 
+  /** Replaces this map with a serialization proxy during Java serialization. */
   protected def writeReplace(): AnyRef = new DefaultSerializationProxy(LongMap.toFactory[T](LongMap), this)
 }

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -43,9 +43,15 @@ import scala.annotation.compileTimeOnly
  */
 @SerialVersionUID(3L)
 sealed class NumericRange[T](
+  /** The start value of the range; its first element when the range is non-empty. */
   val start: T,
+  /** The end value of the range, a bound that is not necessarily an element itself. */
   val end: T,
+  /** The increment between successive elements; may be negative, must not be zero. */
   val step: T,
+  /** Whether `end` may be an element: an inclusive range contains `end` when it
+   *  is a whole number of steps from `start`; an exclusive range never contains it.
+   */
   val isInclusive: Boolean
 )(implicit
   num: Integral[T]
@@ -57,8 +63,19 @@ sealed class NumericRange[T](
     with IterableFactoryDefaults[T, IndexedSeq]
     with Serializable { self =>
 
+  /** Returns a new iterator over all elements of this range in order. */
   override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
 
+  /** Returns a stepper for the elements of this range.
+   *
+   *  Uses a stepper specialized for `Int` or `Long` elements when `shape` has
+   *  one of those shapes, and a generic stepper otherwise.
+   *
+   *  @tparam S the type of the returned stepper, determined by `shape`
+   *  @param shape the shape of the stepper for elements of type `T`
+   *  @return a stepper over the elements of this range, supporting efficient
+   *          splitting for parallel processing
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[T, S]): S & EfficientSplit = {
     import scala.collection.convert._
     import impl._
@@ -77,20 +94,49 @@ sealed class NumericRange[T](
   import num._
 
   // See comment in Range for why this must be lazy.
+  /** The number of elements in this range, computed on first access and cached.
+   *
+   *  @throws IllegalArgumentException if `step` is zero, if the range has more than
+   *          `Int.MaxValue` elements, or, for a `BigDecimal` range, if the endpoints
+   *          cannot represent the step accurately enough to count the elements
+   */
   override lazy val length: Int     = NumericRange.count(start, end, step, isInclusive)
+  /** Whether this range has no elements.
+   *
+   *  Determined from `start`, `end`, the sign of `step`, and `isInclusive`
+   *  alone, so this is safe even on ranges whose `length` would overflow an
+   *  `Int`.
+   */
   override lazy val isEmpty: Boolean = (
     (num.gt(start, end) && num.gt(step, num.zero))
       || (num.lt(start, end) && num.lt(step, num.zero))
       || (num.equiv(start, end) && !isInclusive)
     )
+  /** Returns the last element of this range: the element nearest `end` that
+   *  the range contains, which is not necessarily `end` itself.
+   *
+   *  @throws NoSuchElementException if this range is empty
+   */
   override def last: T =
     if (isEmpty) Nil.head
     else locationAfterN(length - 1)
+  /** Returns a new range with all elements of this range except the last.
+   *
+   *  @throws UnsupportedOperationException if this range is empty
+   */
   override def init: NumericRange[T] =
     if (isEmpty) Nil.init
     else new NumericRange(start, end - step, step, isInclusive)
 
+  /** Returns the first element of this range, which is `start`.
+   *
+   *  @throws NoSuchElementException if this range is empty
+   */
   override def head: T = if (isEmpty) Nil.head else start
+  /** Returns a new range with all elements of this range except the first.
+   *
+   *  @throws UnsupportedOperationException if this range is empty
+   */
   override def tail: NumericRange[T] =
     if (isEmpty) Nil.tail
     else if(isInclusive) new NumericRange.Inclusive(start + step, end, step)
@@ -115,6 +161,12 @@ sealed class NumericRange[T](
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
+  /** Returns the element at the given index, computed as `start + idx * step`.
+   *
+   *  @param idx the zero-based index of the element
+   *  @return the element at index `idx`
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   */
   @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
     if (idx < 0 || idx >= length)
@@ -122,6 +174,10 @@ sealed class NumericRange[T](
     else locationAfterN(idx)
   }
 
+  /** Applies `f` to every element of this range in order.
+   *
+   *  @param f the function applied to each element; its result is discarded
+   */
   override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
@@ -151,6 +207,18 @@ sealed class NumericRange[T](
       case _                  => -1
     }
 
+  /** Returns the index of the first occurrence of `elem` at or after index
+   *  `from`, or -1 if `elem` does not occur at such an index.
+   *
+   *  When `elem` is a value of this range's element type, its index is
+   *  computed arithmetically from `start` and `step` instead of by scanning
+   *  the elements; otherwise this falls back to the linear search of the
+   *  superclass.
+   *
+   *  @tparam B the type of the value to search for, a supertype of `T`
+   *  @param elem the value to search for
+   *  @param from the lowest index to consider
+   */
   final override def indexOf[B >: T](elem: B, from: Int): Int =
     try indexOfTyped(elem.asInstanceOf[T], from)
     catch { case _: ClassCastException => super.indexOf(elem, from) }
@@ -161,6 +229,19 @@ sealed class NumericRange[T](
       case _                 => -1
     }
 
+  /** Returns the index of the last occurrence of `elem` at or before index
+   *  `end`, or -1 if `elem` does not occur at such an index.
+   *
+   *  A value occurs at most once in a range, so this differs from `indexOf`
+   *  only in bounding the accepted index from above rather than from below.
+   *  When `elem` is a value of this range's element type, its index is
+   *  computed arithmetically from `start` and `step`; otherwise this falls
+   *  back to the linear search of the superclass.
+   *
+   *  @tparam B the type of the value to search for, a supertype of `T`
+   *  @param elem the value to search for
+   *  @param end the highest index to consider
+   */
   final override def lastIndexOf[B >: T](elem: B, end: Int = length - 1): Int =
     try lastIndexOfTyped(elem.asInstanceOf[T], end)
     catch { case _: ClassCastException => super.lastIndexOf(elem, end) }
@@ -266,20 +347,48 @@ sealed class NumericRange[T](
   // based on the given value.
   private def newEmptyRange(value: T) = NumericRange(value, value, step)
 
+  /** Returns a range with the first `n` elements of this range.
+   *
+   *  @param n the number of elements to take
+   *  @return a range of the first `n` elements of this range, this whole
+   *          range if `n` is greater than or equal to `length`, or an empty
+   *          range if `n <= 0`
+   */
   override def take(n: Int): NumericRange[T] = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (crossesTheEndAfterN(n)) this
     else new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
   }
 
+  /** Returns a range with all elements of this range except the first `n`.
+   *
+   *  @param n the number of elements to drop
+   *  @return a range of the elements of this range after the first `n`, this
+   *          whole range if `n <= 0`, or an empty range if `n` is greater
+   *          than or equal to `length`
+   */
   override def drop(n: Int): NumericRange[T] = {
     if (n <= 0 || isEmpty) this
     else if (crossesTheEndAfterN(n)) newEmptyRange(end)
     else copy(locationAfterN(n), end, step)
   }
 
+  /** Splits this range at a given index.
+   *
+   *  @param n the index at which to split
+   *  @return a pair of ranges `(take(n), drop(n))`
+   */
   override def splitAt(n: Int): (NumericRange[T], NumericRange[T]) = (take(n), drop(n))
 
+  /** Returns a new range with the same elements as this range in reverse
+   *  order: an inclusive range from `last` to `start` with step `-step`.
+   *  Returns this range itself if it is empty.
+   *
+   *  @throws ArithmeticException if this range is non-empty and negating its step
+   *          cannot change the step's sign, either because the element type is
+   *          unsigned or because the step is the minimum value of a signed
+   *          fixed-width type
+   */
   override def reverse: NumericRange[T] =
     if (isEmpty) this
     else {
@@ -291,6 +400,21 @@ sealed class NumericRange[T](
 
   import NumericRange.defaultOrdering
 
+  /** Returns the smallest element of this range under the ordering `ord`.
+   *
+   *  When `ord` is this range's own `Integral` instance, or the default
+   *  ordering of one of the standard numeric types, the result is taken
+   *  directly from an endpoint: the first element for a positive step, the
+   *  last element otherwise. Any other ordering falls back to a linear scan.
+   *
+   *  @tparam T1 the type on which `ord` orders values, a supertype of `T`
+   *  @param ord the ordering used to compare elements
+   *  @return the smallest element of this range according to `ord`
+   *  @throws NoSuchElementException if this range is empty and the endpoint
+   *          shortcut applies
+   *  @throws UnsupportedOperationException if this range is empty and the
+   *          linear scan applies
+   */
   override def min[T1 >: T](implicit ord: Ordering[T1]): T =
   // We can take the fast path:
   // - If the Integral of this NumericRange is also the requested Ordering
@@ -301,6 +425,21 @@ sealed class NumericRange[T](
       else last
     } else super.min(using ord)
 
+  /** Returns the largest element of this range under the ordering `ord`.
+   *
+   *  When `ord` is this range's own `Integral` instance, or the default
+   *  ordering of one of the standard numeric types, the result is taken
+   *  directly from an endpoint: the last element for a positive step, the
+   *  first element otherwise. Any other ordering falls back to a linear scan.
+   *
+   *  @tparam T1 the type on which `ord` orders values, a supertype of `T`
+   *  @param ord the ordering used to compare elements
+   *  @return the largest element of this range according to `ord`
+   *  @throws NoSuchElementException if this range is empty and the endpoint
+   *          shortcut applies
+   *  @throws UnsupportedOperationException if this range is empty and the
+   *          linear scan applies
+   */
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
   // See comment for fast path in min().
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
@@ -309,13 +448,42 @@ sealed class NumericRange[T](
     } else super.max(using ord)
 
   // a well-typed contains method.
+  /** Returns `true` if `x` is an element of this range, `false` otherwise.
+   *
+   *  Computed arithmetically, without examining elements: `x` must lie
+   *  between `start` and `last` and be a whole number of steps from `start`.
+   *
+   *  @param x the value to test
+   */
   def containsTyped(x: T): Boolean =
     isWithinBoundaries(x) && (((x - start) % step) == zero)
 
+  /** Returns `true` if `x` is an element of this range, `false` otherwise.
+   *
+   *  Returns `false` if `x` is not a value of this range's element type;
+   *  otherwise the answer is computed arithmetically as in `containsTyped`,
+   *  without examining elements.
+   *
+   *  @tparam A1 the type of the value to test, a supertype of `T`
+   *  @param x the value to test
+   */
   override def contains[A1 >: T](x: A1): Boolean =
     try containsTyped(x.asInstanceOf[T])
     catch { case _: ClassCastException => false }
 
+  /** Returns the sum of all elements of this range.
+   *
+   *  For the standard integral types (`Byte`, `Short`, `Char`, `Int`, `Long`,
+   *  `BigInt`, and `BigDecimal`) the sum is computed in constant time using
+   *  the arithmetic series formula `n * (head + last) / 2`, with care taken
+   *  not to overflow intermediate results for the fixed-width types. For any
+   *  other `Numeric` instance the elements are added one by one.
+   *
+   *  @tparam B the type in which the sum is computed, a supertype of `T`
+   *  @param num the `Numeric` instance used to add elements; its identity
+   *         selects the constant-time specializations
+   *  @return the sum of all elements, or `num.zero` if this range is empty
+   */
   override def sum[B >: T](implicit num: Numeric[B]): B = {
     if (isEmpty) num.zero
     else if (size == 1) head
@@ -371,9 +539,29 @@ sealed class NumericRange[T](
     }
   }
 
+  /** The hash code of this range, computed on first access and cached.
+   *  Consistent with `equals`: equal to the hash code of any sequence with
+   *  the same elements.
+   */
   override lazy val hashCode: Int = super.hashCode()
+  /** Returns `Int.MaxValue`: indexed access via `apply` is cheap at every
+   *  length, so element scans (as in `sameElements`) never need to switch to
+   *  an iterator.
+   */
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
+  /** Compares this range to `other` for equality.
+   *
+   *  Two numeric ranges are equal if they have the same length and, when
+   *  non-empty, the same `start` and the same last element; the elements in
+   *  between are then necessarily the same. Comparison with any other kind
+   *  of sequence falls back to the element-by-element comparison of the
+   *  superclass.
+   *
+   *  @param other the value to compare this range with
+   *  @return `true` if `other` is a sequence with the same elements in the
+   *          same order as this range
+   */
   override def equals(other: Any): Boolean = other match {
     case x: NumericRange[?] =>
       (x canEqual this) && (length == x.length) && (
@@ -384,6 +572,11 @@ sealed class NumericRange[T](
       super.equals(other)
   }
 
+  /** Returns a string representation of this range, such as
+   *  `NumericRange 1 until 10 by 2`: `to` for an inclusive range, `until`
+   *  for an exclusive one, prefixed with `empty ` if the range is empty.
+   *  The `by` clause is omitted when `step` is 1.
+   */
   override def toString(): String = {
     val empty = if (isEmpty) "empty " else ""
     val preposition = if (isInclusive) "to" else "until"
@@ -391,6 +584,9 @@ sealed class NumericRange[T](
     s"${empty}NumericRange $start $preposition $end$stepped"
   }
 
+  /** The name `"NumericRange"`, used as the collection-name prefix in string
+   *  representations.
+   */
   override protected def className = "NumericRange"
 }
 
@@ -521,26 +717,82 @@ object NumericRange {
     }
   }
 
+  /** A numeric range that includes its `end` value, when `end` is a whole
+   *  number of steps from `start`.
+   *
+   *  @tparam T the element type of the range
+   *  @param start the start value of the range
+   *  @param end the end value, an element of the range when it is a whole
+   *         number of steps from `start`
+   *  @param step the increment between successive elements; must not be zero
+   *  @param num the `Integral` instance providing arithmetic on `T`
+   */
   @SerialVersionUID(3L)
   class Inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
     extends NumericRange(start, end, step, isInclusive = true) {
+    /** Creates an inclusive range with the given start, end, and step.
+     *
+     *  @param start the start value of the new range
+     *  @param end the end value of the new range, included when it is a whole
+     *         number of steps from `start`
+     *  @param step the step value of the new range
+     *  @return a new inclusive range with the given `start`, `end`, and `step`
+     */
     override def copy(start: T, end: T, step: T): Inclusive[T] =
       NumericRange.inclusive(start, end, step)
 
+    /** Returns an exclusive range with the same `start`, `end`, and `step` as this range. */
     def exclusive: Exclusive[T] = NumericRange(start, end, step)
   }
 
+  /** A numeric range that excludes its `end` value.
+   *
+   *  @tparam T the element type of the range
+   *  @param start the start value of the range
+   *  @param end the end value, never an element of the range itself
+   *  @param step the increment between successive elements; must not be zero
+   *  @param num the `Integral` instance providing arithmetic on `T`
+   */
   @SerialVersionUID(3L)
   class Exclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
     extends NumericRange(start, end, step, isInclusive = false) {
+    /** Creates an exclusive range with the given start, end, and step.
+     *
+     *  @param start the start value of the new range
+     *  @param end the end value of the new range, excluded from it
+     *  @param step the step value of the new range
+     *  @return a new exclusive range with the given `start`, `end`, and `step`
+     */
     override def copy(start: T, end: T, step: T): Exclusive[T] =
       NumericRange(start, end, step)
 
+    /** Returns an inclusive range with the same `start`, `end`, and `step` as this range. */
     def inclusive: Inclusive[T] = NumericRange.inclusive(start, end, step)
   }
 
+  /** Creates an exclusive numeric range, from `start` until `end` (excluded)
+   *  in increments of `step`.
+   *
+   *  @tparam T the element type of the range
+   *  @param start the start value of the range
+   *  @param end the end value, excluded from the range
+   *  @param step the increment between successive elements; must not be zero
+   *  @param num the `Integral` instance providing arithmetic on `T`
+   *  @return a new exclusive range with the given `start`, `end`, and `step`
+   */
   def apply[T](start: T, end: T, step: T)(implicit num: Integral[T]): Exclusive[T] =
     new Exclusive(start, end, step)
+  /** Creates an inclusive numeric range, from `start` to `end` in increments
+   *  of `step`.
+   *
+   *  @tparam T the element type of the range
+   *  @param start the start value of the range
+   *  @param end the end value, an element of the range when it is a whole
+   *         number of steps from `start`
+   *  @param step the increment between successive elements; must not be zero
+   *  @param num the `Integral` instance providing arithmetic on `T`
+   *  @return a new inclusive range with the given `start`, `end`, and `step`
+   */
   def inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T]): Inclusive[T] =
     new Inclusive(start, end, step)
 

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -50,6 +50,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     with IterableFactoryDefaults[A, Queue]
     with DefaultSerializable {
 
+  /** The factory used to build queues, the [[Queue$ `Queue`]] companion object. */
   override def iterableFactory: SeqFactory[Queue] = Queue
 
   /** Returns the `n`-th element of this queue.
@@ -91,38 +92,107 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
    */
   override def isEmpty: Boolean = in.isEmpty && out.isEmpty
 
+  /** Returns the first element of this queue, the one that `dequeue` would remove.
+   *
+   *  This costs `O(1)` unless the *out* list has run dry, in which case the last
+   *  element of the *in* list is found in `O(n)`; no pivot is performed.
+   *
+   *  @throws NoSuchElementException if this queue is empty
+   */
   override def head: A =
     if (out.nonEmpty) out.head
     else if (in.nonEmpty) in.last
     else throw new NoSuchElementException("head on empty queue")
 
+  /** Returns a queue holding all elements of this queue except the first.
+   *
+   *  This costs `O(1)` unless the *out* list has run dry, in which case the queue is
+   *  pivoted at a cost of `O(n)`.
+   *
+   *  @throws NoSuchElementException if this queue is empty
+   */
   override def tail: Queue[A] =
     if (out.nonEmpty) new Queue(in, out.tail)
     else if (in.nonEmpty) new Queue(Nil, in.reverse.tail)
     else throw new NoSuchElementException("tail on empty queue")
 
+  /** Returns the last element of this queue, the one enqueued most recently.
+   *
+   *  This costs `O(1)` unless nothing has been enqueued since the last pivot, in
+   *  which case the last element of the *out* list is found in `O(n)`.
+   *
+   *  @throws NoSuchElementException if this queue is empty
+   */
   override def last: A =
     if (in.nonEmpty) in.head
     else if (out.nonEmpty) out.last
     else throw new NoSuchElementException("last on empty queue")
 
   /* This is made to avoid inefficient implementation of iterator. */
+  /** Returns `true` if `p` holds for every element of this queue.
+   *
+   *  Tests the two underlying lists directly instead of going through the iterator,
+   *  which would have to reverse the *in* list.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if this queue is empty or `p` holds for all of its elements
+   */
   override def forall(p: A => Boolean): Boolean =
     in.forall(p) && out.forall(p)
 
   /* This is made to avoid inefficient implementation of iterator. */
+  /** Returns `true` if `p` holds for at least one element of this queue.
+   *
+   *  Tests the two underlying lists directly instead of going through the iterator,
+   *  which would have to reverse the *in* list; the elements are therefore not
+   *  necessarily tested in queue order.
+   *
+   *  @param p the predicate used to test elements
+   *  @return `true` if `p` holds for some element of this queue, `false` if this
+   *          queue is empty
+   */
   override def exists(p: A => Boolean): Boolean =
     in.exists(p) || out.exists(p)
 
+  /** The prefix of this queue's string representation: `"Queue"`. */
   override protected def className = "Queue"
 
   /** Returns the length of the queue. */
   override def length: Int = in.length + out.length
 
+  /** Returns a queue with `elem` at its front, so that `elem` is the next element to
+   *  be dequeued, followed by all elements of this queue.
+   *
+   *  This costs `O(1)`.
+   *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
+   *  @param elem the element to place at the front
+   *  @return a new queue consisting of `elem` followed by the elements of this queue
+   */
   override def prepended[B >: A](elem: B): Queue[B] = new Queue(in, elem :: out)
 
+  /** Returns a queue with `elem` at its end, the same queue that `enqueue` returns.
+   *
+   *  This costs `O(1)`.
+   *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
+   *  @param elem the element to place at the end
+   *  @return a new queue consisting of the elements of this queue followed by `elem`
+   */
   override def appended[B >: A](elem: B): Queue[B] = enqueue(elem)
 
+  /** Returns a queue consisting of the elements of this queue followed by the
+   *  elements of `that`, in the order `that` gives them out.
+   *
+   *  The elements of `that` are pushed onto the *in* list, which costs `O(m)` in the
+   *  size of `that` and leaves this queue's *out* list untouched. If `that` is empty
+   *  this queue is returned as is.
+   *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
+   *  @param that the collection of elements to append
+   *  @return a new queue with the elements of `that` appended, or this queue itself
+   *          if `that` is empty
+   */
   override def appendedAll[B >: A](that: scala.collection.IterableOnce[B]^): Queue[B] = {
     val newIn = that match {
       case that: Queue[B] => that.in ++ (that.out reverse_::: this.in)
@@ -207,8 +277,23 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
  */
 @SerialVersionUID(3L)
 object Queue extends StrictOptimizedSeqFactory[Queue] {
+  /** Returns a new builder that collects elements into a queue, in the order they
+   *  are added.
+   *
+   *  @tparam A the element type of the queue being built
+   *  @return a builder backed by a `ListBuffer` whose result is a queue ready to be
+   *          dequeued without a pivot
+   */
   def newBuilder[A]: Builder[A, Queue[A]] = new ListBuffer[A] mapResult (x => new Queue[A](Nil, x))
 
+  /** Returns a queue containing the elements of `source`, in the order `source`
+   *  gives them out, so that its first element is the first to be dequeued.
+   *
+   *  If `source` is already a queue it is returned unchanged.
+   *
+   *  @tparam A the element type
+   *  @param source the collection whose elements are to be contained
+   */
   def from[A](source: IterableOnce[A]^): Queue[A] = source match {
     case q: Queue[A] => q
     case _ =>
@@ -217,7 +302,19 @@ object Queue extends StrictOptimizedSeqFactory[Queue] {
       else new Queue(Nil, list)
   }
 
+  /** Returns the empty queue.
+   *
+   *  All calls return the same instance, which is shared across element types.
+   *
+   *  @tparam A the element type of the queue
+   */
   def empty[A]: Queue[A] = EmptyQueue
+  /** Returns a queue containing the given elements, the first of which is the first
+   *  to be dequeued.
+   *
+   *  @tparam A the element type of the queue
+   *  @param xs the elements of the new queue, in dequeuing order
+   */
   override def apply[A](xs: A*): Queue[A] = new Queue[A](Nil, xs.toList)
 
   private object EmptyQueue extends Queue[Nothing](Nil, Nil) { }

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -62,8 +62,11 @@ import scala.util.hashing.MurmurHash3
  */
 @SerialVersionUID(4L)
 sealed abstract class Range(
+  /** The start value of this range; its first element when this range is non-empty. */
   val start: Int,
+  /** The end value of this range; not necessarily an element of it (see `last` for the last actual element). */
   val end: Int,
+  /** The difference between successive elements of this range; never zero. */
   val step: Int
 )
   extends AbstractSeq[Int]
@@ -73,8 +76,19 @@ sealed abstract class Range(
     with IterableFactoryDefaults[Int, IndexedSeq]
     with Serializable { range =>
 
+  /** Returns a new iterator over all elements of this range, from first to last. */
   final override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
+  /** Returns a [[scala.collection.Stepper]] for the elements of this range.
+   *
+   *  @tparam S the type of the stepper, determined by `shape`
+   *  @param shape an implicit value determining the type of stepper to create:
+   *         an `IntStepper` for the primitive `Int` shape, or a boxing
+   *         `AnyStepper` for the reference shape
+   *  @return a stepper over the elements of this range; it supports efficient splitting
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override final def stepper[S <: Stepper[?]](implicit shape: StepperShape[Int, S]): S & EfficientSplit = {
     val st = new RangeStepper(start, step, 0, length)
     val r =
@@ -86,8 +100,21 @@ sealed abstract class Range(
     r.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns `true` if this range is inclusive (built with `to` or
+   *  `Range.inclusive`), `false` if it is exclusive (built with `until` or
+   *  `Range.apply`).
+   *
+   *  Even in an inclusive range, `end` is an element only if it is reachable
+   *  from `start` in `step` increments.
+   */
   def isInclusive: Boolean
 
+  /** Whether this range contains no elements.
+   *
+   *  A range is empty when `step` leads from `start` away from `end`, or when
+   *  it is exclusive with `start == end`. This value is computed once at
+   *  construction.
+   */
   final override val isEmpty: Boolean = (
     if (isInclusive)
       (if (step >= 0) start > end else start < end)
@@ -127,6 +154,11 @@ sealed abstract class Range(
     if (isInclusive || (absStep * div != gap)) div + 1 else div
   }
 
+  /** Returns the number of elements in this range, in constant time.
+   *
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   final def length: Int =
     if (isEmpty) 0
     else if (numRangeElements > 0) numRangeElements
@@ -189,6 +221,10 @@ sealed abstract class Range(
    */
   final override def last: Int =
     if (isEmpty) throw Range.emptyRangeError("last") else lastElement
+  /** Returns the first element of this range, which is always `start`.
+   *
+   *  @throws NoSuchElementException if this range is empty
+   */
   final override def head: Int =
     if (isEmpty) throw Range.emptyRangeError("head") else start
 
@@ -214,11 +250,31 @@ sealed abstract class Range(
     else new Range.Exclusive(start + step, end, step)
   }
 
+  /** Builds a new indexed sequence by applying a function to all elements of
+   *  this range.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param f the function to apply to each element
+   *  @return a new indexed sequence containing the results of applying `f` to
+   *          each element of this range, in order
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override def map[B](f: Int => B): IndexedSeq[B] = {
     validateMaxLength()
     super.map(f)
   }
 
+  /** Creates a new range from the given values, each of which defaults to the
+   *  corresponding value of this range.
+   *
+   *  @param start the start value of the new range
+   *  @param end the end value of the new range
+   *  @param step the step of the new range; must be non-zero
+   *  @param isInclusive whether the new range includes its `end` value
+   *  @return a new `Range.Inclusive` if `isInclusive` is `true`, otherwise
+   *          a new `Range.Exclusive`
+   */
   final protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
@@ -242,6 +298,14 @@ sealed abstract class Range(
   private def description = s"$start ${if (isInclusive) "to" else "until"} $end by $step"
   private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
 
+  /** Returns the element at index `idx`, that is, `start + step * idx`, in
+   *  constant time.
+   *
+   *  @param idx the index of the element to return
+   *  @throws IndexOutOfBoundsException if `idx` is negative or not less than `length`
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   @throws[IndexOutOfBoundsException]
   final def apply(idx: Int): Int = {
     /* If length is not valid, numRangeElements <= 0, so the condition is always true.
@@ -267,6 +331,16 @@ sealed abstract class Range(
     }
   }
 
+  /** Returns the index of the first occurrence of `elem` at or after index
+   *  `from`, or `-1` if `elem` does not occur at or after that index.
+   *
+   *  When `elem` is an `Int`, its position is computed arithmetically in
+   *  constant time instead of by searching; this is possible because each
+   *  value occurs at most once in a range.
+   *
+   *  @param elem the element to search for
+   *  @param from the start index for the search
+   */
   override final def indexOf[@specialized(Int) B >: Int](elem: B, from: Int = 0): Int =
     elem match {
       case i: Int =>
@@ -275,6 +349,18 @@ sealed abstract class Range(
       case _ => super.indexOf(elem, from)
     }
 
+  /** Returns the index of the last occurrence of `elem` at or before index
+   *  `end`, or `-1` if `elem` does not occur at or before that index.
+   *
+   *  When `elem` is an `Int`, its position is computed arithmetically in
+   *  constant time instead of by searching; this is possible because each
+   *  value occurs at most once in a range.
+   *
+   *  @param elem the element to search for
+   *  @param end the end index for the search
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override final def lastIndexOf[@specialized(Int) B >: Int](elem: B, end: Int = length - 1): Int =
     elem match {
       case i: Int =>
@@ -286,6 +372,17 @@ sealed abstract class Range(
   private def posOf(i: Int): Int =
     if (contains(i)) (i - start) / step else -1
 
+  /** Returns `true` if this range contains the same elements as `that`, in
+   *  the same order.
+   *
+   *  When `that` is also a `Range`, the answer is computed in constant time
+   *  from the two ranges' lengths, starts, and steps, without iterating.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection to compare with
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override def sameElements[B >: Int](that: IterableOnce[B]^): Boolean = that match {
     case other: Range =>
       (this.length : @annotation.switch) match {
@@ -368,6 +465,13 @@ sealed abstract class Range(
     }
   }
 
+  /** Returns the longest prefix of this range whose elements all satisfy `p`.
+   *
+   *  The result is itself a range; the predicate is evaluated on successive
+   *  elements until it first fails.
+   *
+   *  @param p the predicate used to test elements
+   */
   final override def takeWhile(p: Int => Boolean): Range = {
     val stop = argTakeWhile(p)
     if (stop==start) newEmptyRange(start)
@@ -378,6 +482,14 @@ sealed abstract class Range(
     }
   }
 
+  /** Returns the remainder of this range after the longest prefix whose
+   *  elements all satisfy `p`.
+   *
+   *  The result is itself a range; the predicate is evaluated on successive
+   *  elements until it first fails.
+   *
+   *  @param p the predicate used to test elements
+   */
   final override def dropWhile(p: Int => Boolean): Range = {
     val stop = argTakeWhile(p)
     if (stop == start) this
@@ -388,6 +500,15 @@ sealed abstract class Range(
     }
   }
 
+  /** Splits this range into the longest prefix whose elements all satisfy `p`
+   *  and the remainder.
+   *
+   *  Equivalent to `(takeWhile(p), dropWhile(p))`, but more efficient: the
+   *  predicate is evaluated at most once per element.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of ranges `(this.takeWhile(p), this.dropWhile(p))`
+   */
   final override def span(p: Int => Boolean): (Range, Range) = {
     val border = argTakeWhile(p)
     if (border == start) (newEmptyRange(start), this)
@@ -417,6 +538,13 @@ sealed abstract class Range(
     }
 
   // Overridden only to refine the return type
+  /** Splits this range into a prefix/suffix pair at a given index.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param n the index at which to split
+   *  @return a pair of ranges `(this.take(n), this.drop(n))`
+   */
   final override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
 
   // When one drops everything.  Can't ever have unchecked operations
@@ -435,6 +563,13 @@ sealed abstract class Range(
     if (isInclusive) this
     else new Range.Inclusive(start, end, step)
 
+  /** Returns `true` if `x` is an element of this range.
+   *
+   *  This is a constant-time operation: membership is decided with a bounds
+   *  check and a divisibility test rather than a search.
+   *
+   *  @param x the value to test for membership
+   */
   final def contains(x: Int): Boolean = {
     if (isEmpty) false
     else if (step > 0) {
@@ -447,11 +582,33 @@ sealed abstract class Range(
     }
   }
   /* Seq#contains has a type parameter so the optimised contains above doesn't override it */
+  /** Returns `true` if `elem` is an element of this range.
+   *
+   *  When `elem` is an `Int`, this delegates to the constant-time
+   *  `contains(x: Int)` overload; otherwise it falls back to a linear search.
+   *
+   *  @tparam B the type of `elem`
+   *  @param elem the value to test for membership
+   */
   override final def contains[B >: Int](elem: B): Boolean = elem match {
     case i: Int => this.contains(i)
     case _      => super.contains(elem)
   }
 
+  /** Returns the sum of the elements of this range.
+   *
+   *  For the default `Int` numeric, the sum is computed in constant time with
+   *  the arithmetic-series formula, and the result wraps around on overflow
+   *  exactly as repeated `Int` addition would. For any other `Numeric`, the
+   *  elements are added one by one and the result is converted back to `Int`
+   *  with `num.toInt`.
+   *
+   *  @tparam B a supertype of `Int` for which the addition is defined
+   *  @param num the numeric instance used to add elements
+   *  @return the sum of all elements, or zero if this range is empty
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
     if (num eq scala.math.Numeric.IntIsIntegral) {
       // this is normal integer range with usual addition. arithmetic series formula can be used
@@ -474,6 +631,20 @@ sealed abstract class Range(
     }
   }
 
+  /** Returns the smallest element of this range.
+   *
+   *  For the standard `Int` ordering or its reverse, the result is `head` or
+   *  `last`, depending on the ordering and the sign of `step`, found in
+   *  constant time; for any other ordering, the elements are scanned.
+   *
+   *  @tparam A1 a supertype of `Int` over which `ord` compares
+   *  @param ord the ordering used to compare elements
+   *  @return the smallest element of this range with respect to `ord`
+   *  @throws NoSuchElementException if this range is empty and `ord` is the
+   *          `Int` ordering or its reverse
+   *  @throws UnsupportedOperationException if this range is empty and `ord` is
+   *          any other ordering
+   */
   final override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
       if (step > 0) head
@@ -483,6 +654,20 @@ sealed abstract class Range(
       else head
     } else super.min(using ord)
 
+  /** Returns the largest element of this range.
+   *
+   *  For the standard `Int` ordering or its reverse, the result is `head` or
+   *  `last`, depending on the ordering and the sign of `step`, found in
+   *  constant time; for any other ordering, the elements are scanned.
+   *
+   *  @tparam A1 a supertype of `Int` over which `ord` compares
+   *  @param ord the ordering used to compare elements
+   *  @return the largest element of this range with respect to `ord`
+   *  @throws NoSuchElementException if this range is empty and `ord` is the
+   *          `Int` ordering or its reverse
+   *  @throws UnsupportedOperationException if this range is empty and `ord` is
+   *          any other ordering
+   */
   final override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
       if (step > 0) last
@@ -492,6 +677,13 @@ sealed abstract class Range(
       else last
     } else super.max(using ord)
 
+  /** Returns an iterator over all the tails of this range, starting with this
+   *  range itself and ending with an empty range.
+   *
+   *  Each tail is itself a range, produced in constant time by `drop`.
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override def tails: Iterator[Range] =
     new AbstractIterator[Range] {
       private var i = 0
@@ -507,6 +699,13 @@ sealed abstract class Range(
       }
     }
 
+  /** Returns an iterator over all the inits of this range, starting with this
+   *  range itself and ending with an empty range.
+   *
+   *  Each init is itself a range, produced in constant time by `dropRight`.
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override def inits: Iterator[Range] =
     new AbstractIterator[Range] {
       private var i = 0
@@ -521,8 +720,22 @@ sealed abstract class Range(
         }
       }
     }
+  /** The maximum length below which indexed access via `apply` is preferred
+   *  over `iterator` when scanning elements; always `Int.MaxValue` because
+   *  `apply` is constant-time for ranges.
+   */
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
+  /** Returns `true` if `other` is equal to this range.
+   *
+   *  Another `Range` is equal to this one if both are empty, or if both have
+   *  the same `start` and last element and, unless they contain a single
+   *  element, the same `step`; this is decided in constant time and works even
+   *  for ranges of more than `Int.MaxValue` elements. Any other object is
+   *  compared with generic sequence equality.
+   *
+   *  @param other the object to compare with
+   */
   final override def equals(other: Any): Boolean = other match {
     case x: Range =>
       // Note: this must succeed for overfull ranges (length > Int.MaxValue)
@@ -538,10 +751,26 @@ sealed abstract class Range(
       super.equals(other)
   }
 
+  /** Returns a hash code value consistent with `equals`.
+   *
+   *  For ranges of two or more elements, the hash is computed directly from
+   *  `start`, `step`, and the last element; smaller ranges use the generic
+   *  sequence hash.
+   *
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   final override def hashCode(): Int =
     if(length >= 2) MurmurHash3.rangeHash(start, step, lastElement)
     else super.hashCode
 
+  /** Returns a string representation of this range, such as
+   *  `Range 0 until 10` or `Range 1 to 9 by 2`.
+   *
+   *  The `by` clause is omitted when `step` is `1`. The prefix `empty ` marks
+   *  an empty range, and the prefix `inexact ` marks a non-empty range whose
+   *  `end` is not an exact multiple of `step` away from `start`.
+   */
   final override def toString(): String = {
     val preposition = if (isInclusive) "to" else "until"
     val stepped = if (step == 1) "" else s" by $step"
@@ -554,10 +783,23 @@ sealed abstract class Range(
     s"${prefix}Range $start $preposition $end$stepped"
   }
 
+  /** The name of this collection type, `"Range"`, used in string representations. */
   override protected def className = "Range"
 
+  /** Returns this range: the elements of a range are always pairwise distinct. */
   override def distinct: Range = this
 
+  /** Partitions the elements of this range into fixed-size groups.
+   *
+   *  Each group is itself a range, produced in constant time by `slice`.
+   *
+   *  @param size the number of elements per group
+   *  @return an iterator over the groups; every group has `size` elements,
+   *          except possibly the last, which may have fewer
+   *  @throws IllegalArgumentException if `size` is less than `1`
+   *  @throws IllegalArgumentException if this range contains more than
+   *          `Int.MaxValue` elements
+   */
   override def grouped(size: Int): Iterator[Range] = {
     require(size >= 1, s"size=$size, but size must be positive")
     if (isEmpty) {
@@ -579,6 +821,17 @@ sealed abstract class Range(
     }
   }
 
+  /** Returns the elements of this range in sorted order according to an
+   *  ordering.
+   *
+   *  For the standard `Int` ordering, the result is this range itself when
+   *  `step` is positive, or its `reverse` when `step` is negative, computed in
+   *  constant time; for any other ordering, a generic sort is performed.
+   *
+   *  @tparam B a supertype of `Int` over which `ord` compares
+   *  @param ord the ordering used to compare elements
+   *  @return an indexed sequence containing the elements of this range, sorted
+   */
   override def sorted[B >: Int](implicit ord: Ordering[B]): IndexedSeq[Int] =
     if (ord eq Ordering.Int) {
       if (step > 0) {
@@ -631,6 +884,18 @@ object Range {
       }
     }
   }
+  /** Counts the number of elements of an exclusive range with the given
+   *  start, end, and step.
+   *
+   *  Equivalent to `count(start, end, step, isInclusive = false)`.
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
+   *  @return the number of elements in the range, `0` if the range is empty,
+   *          or a negative value (modular wrap) if the count exceeds `Int.MaxValue`
+   *  @throws IllegalArgumentException if `step` is `0`
+   */
   def count(start: Int, end: Int, step: Int): Int =
     count(start, end, step, isInclusive = false)
 
@@ -670,24 +935,73 @@ object Range {
    */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
+  /** A `Range` that includes its `end` value, as built by `to` or
+   *  `Range.inclusive`.
+   *
+   *  `end` is an element of the range only if it is reachable from `start` in
+   *  `step` increments.
+   *
+   *  @param start the start value of the range
+   *  @param end the inclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
+   */
   @SerialVersionUID(4L)
   final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+    /** Returns `true`: this range is inclusive, so `end` is one of its elements if it
+     *  is reachable from `start` in `step` increments.
+     */
     def isInclusive: Boolean = true
   }
 
+  /** A `Range` that excludes its `end` value, as built by `until` or
+   *  `Range.apply`.
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
+   */
   @SerialVersionUID(4L)
   final class Exclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+    /** Returns `false`: this range excludes its `end` value. */
     def isInclusive: Boolean = false
   }
 
   // BigInt and Long are straightforward generic ranges.
   object BigInt {
+    /** Creates an exclusive range of `BigInt` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the exclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an exclusive `NumericRange` from `start` until `end` in increments of `step`
+     */
     def apply(start: BigInt, end: BigInt, step: BigInt): NumericRange.Exclusive[BigInt] = NumericRange(start, end, step)
+    /** Creates an inclusive range of `BigInt` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the inclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an inclusive `NumericRange` from `start` to `end` in increments of `step`
+     */
     def inclusive(start: BigInt, end: BigInt, step: BigInt): NumericRange.Inclusive[BigInt] = NumericRange.inclusive(start, end, step)
   }
 
   object Long {
+    /** Creates an exclusive range of `Long` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the exclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an exclusive `NumericRange` from `start` until `end` in increments of `step`
+     */
     def apply(start: Long, end: Long, step: Long): NumericRange.Exclusive[Long] = NumericRange(start, end, step)
+    /** Creates an inclusive range of `Long` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the inclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an inclusive `NumericRange` from `start` to `end` in increments of `step`
+     */
     def inclusive(start: Long, end: Long, step: Long): NumericRange.Inclusive[Long] = NumericRange.inclusive(start, end, step)
   }
 
@@ -697,18 +1011,52 @@ object Range {
   // imprecision or surprises might result from anything, although this may
   // not yet be fully implemented.
   object BigDecimal {
+    /** The implicit numeric instance used to build `BigDecimal` ranges; it
+     *  treats `BigDecimal` as if it were an integral type (see
+     *  `scala.math.Numeric.BigDecimalAsIfIntegral`).
+     */
     implicit val bigDecAsIntegral: Numeric.BigDecimalAsIfIntegral = Numeric.BigDecimalAsIfIntegral
 
+    /** Creates an exclusive range of `BigDecimal` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the exclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an exclusive `NumericRange` from `start` until `end` in increments of `step`
+     */
     def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal): NumericRange.Exclusive[BigDecimal] =
       NumericRange(start, end, step)
+    /** Creates an inclusive range of `BigDecimal` values.
+     *
+     *  @param start the start value of the range
+     *  @param end the inclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an inclusive `NumericRange` from `start` to `end` in increments of `step`
+     */
     def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal): NumericRange.Inclusive[BigDecimal] =
       NumericRange.inclusive(start, end, step)
   }
 
   // As there is no appealing default step size for not-really-integral ranges,
   // we offer a partially constructed object.
+  /** A partially constructed range that still lacks its step value.
+   *
+   *  Range constructions with no sensible default step, such as `until` and
+   *  `to` on `BigDecimal`, return a `Partial`; calling `by` supplies the step
+   *  and yields the finished range.
+   *
+   *  @tparam T the type of the step
+   *  @tparam U the type of the completed range
+   *  @param f the function that builds the completed range from a step value
+   */
   class Partial[T, U](private val f: T => U) extends AnyVal { self: Partial[T, U]^ =>
+    /** Completes this partially constructed range with the given step value.
+     *
+     *  @param x the step value
+     *  @return the completed range, `f(x)`
+     */
     def by(x: T): U = f(x)
+    /** Returns the string `"Range requires step"`, indicating that this is not yet a complete range. */
     override def toString() = "Range requires step"
   }
 
@@ -717,7 +1065,31 @@ object Range {
   // indefinitely, for performance and because the compiler seems to bootstrap
   // off it and won't do so with our parameterized version without modifications.
   object Int {
+    /** Creates an exclusive `NumericRange` of `Int` values, a generic alternative
+     *  to `Range` that produces the same elements.
+     *
+     *  It is not a drop-in replacement: it renders differently as a string, and its
+     *  `equals` forces `length`, so it cannot compare a range of more than
+     *  `Int.MaxValue` elements without throwing.
+     *
+     *  @param start the start value of the range
+     *  @param end the exclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an exclusive `NumericRange` from `start` until `end` in increments of `step`
+     */
     def apply(start: Int, end: Int, step: Int): NumericRange.Exclusive[Int] = NumericRange(start, end, step)
+    /** Creates an inclusive `NumericRange` of `Int` values, a generic alternative
+     *  to `Range` that produces the same elements.
+     *
+     *  It is not a drop-in replacement: it renders differently as a string, and its
+     *  `equals` forces `length`, so it cannot compare a range of more than
+     *  `Int.MaxValue` elements without throwing.
+     *
+     *  @param start the start value of the range
+     *  @param end the inclusive end value of the range
+     *  @param step the step value between consecutive elements, must be non-zero
+     *  @return an inclusive `NumericRange` from `start` to `end` in increments of `step`
+     */
     def inclusive(start: Int, end: Int, step: Int): NumericRange.Inclusive[Int] = NumericRange.inclusive(start, end, step)
   }
 

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -17,13 +17,20 @@ package immutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
+/** Base trait for immutable sequences: ordered collections whose elements can be
+ *  reached by their position and which are guaranteed never to change.
+ *
+ *  @tparam A the element type of the sequence
+ */
 trait Seq[+A] extends Iterable[A]
                  with collection.Seq[A]
                  with SeqOps[A, Seq, Seq[A]]
                  with IterableFactoryDefaults[A, Seq] {
 
+  /** Returns this sequence itself; being already an immutable `Seq`, no copy is made. */
   override final def toSeq: this.type = this
 
+  /** The factory used to build immutable sequences, the [[Seq$ `Seq`]] companion object, which delegates to [[List]]. */
   override def iterableFactory: SeqFactory[Seq] = Seq
 }
 
@@ -43,6 +50,14 @@ transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collectio
  */
 @SerialVersionUID(3L)
 object Seq extends SeqFactory.Delegate[Seq](List) {
+  /** Returns an immutable sequence containing the elements of `it`.
+   *
+   *  If `it` is already an immutable `Seq` it is returned unchanged; otherwise its
+   *  elements are copied into a new [[List]].
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   override def from[E](it: IterableOnce[E]^): Seq[E] = it match {
     case s: Seq[E @unchecked] => s
     case _ => super.from(it)
@@ -58,14 +73,39 @@ trait IndexedSeq[+A] extends Seq[A]
                         with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
                         with IterableFactoryDefaults[A, IndexedSeq] {
 
+  /** Returns this sequence itself; being already an immutable `IndexedSeq`, no copy is made. */
   final override def toIndexedSeq: IndexedSeq[A] = this
 
+  /** Returns `true` if this sequence can possibly equal `that`.
+   *
+   *  Two indexed sequences of different length can never be equal, so the length
+   *  is compared first when `that` is itself an `IndexedSeq`; otherwise the
+   *  inherited test is used.
+   *
+   *  @param that the value being compared for possible equality
+   *  @return `true` if `that` is not an `IndexedSeq` of a different length and the
+   *          inherited test also succeeds
+   */
   override def canEqual(that: Any): Boolean = that match {
     case otherIndexedSeq: IndexedSeq[?] => length == otherIndexedSeq.length && super.canEqual(that)
     case _ => super.canEqual(that)
   }
 
 
+  /** Returns `true` if this sequence and `o` contain the same elements in the same order.
+   *
+   *  When `o` is another `IndexedSeq`, the two are known to be equal at once if they
+   *  are the same object, and known to differ at once if their lengths differ.
+   *  Otherwise the elements are compared by index for as long as indexed access is
+   *  the cheaper of the two (see `applyPreferredMaxLength`) and by iterator
+   *  thereafter. For any other collection the inherited iterator-based comparison
+   *  is used.
+   *
+   *  @tparam B the element type of `o`
+   *  @param o the collection to compare against
+   *  @return `true` if both sequences have the same length and their corresponding
+   *          elements are equal
+   */
   override def sameElements[B >: A](o: IterableOnce[B]^): Boolean = o match {
     case that: IndexedSeq[?] =>
       (this eq that) || {
@@ -105,10 +145,19 @@ trait IndexedSeq[+A] extends Seq[A]
    */
   protected def applyPreferredMaxLength: Int = IndexedSeqDefaults.defaultApplyPreferredMaxLength
 
+  /** The factory used to build immutable indexed sequences, the [[IndexedSeq$ `IndexedSeq`]] companion object, which delegates to [[Vector]]. */
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
 }
 
 object IndexedSeqDefaults {
+  /** The default value of `IndexedSeq.applyPreferredMaxLength`, the length below
+   *  which indexed access is preferred to iteration when scanning an immutable
+   *  indexed sequence.
+   *
+   *  It is read from the system property
+   *  `scala.collection.immutable.IndexedSeq.defaultApplyPreferredMaxLength` and is
+   *  `64` when that property is unset or cannot be read.
+   */
   val defaultApplyPreferredMaxLength: Int =
     try System.getProperty(
       "scala.collection.immutable.IndexedSeq.defaultApplyPreferredMaxLength", "64").toInt
@@ -119,6 +168,14 @@ object IndexedSeqDefaults {
 
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
+  /** Returns an immutable indexed sequence containing the elements of `it`.
+   *
+   *  If `it` is already an immutable `IndexedSeq` it is returned unchanged; otherwise
+   *  its elements are copied into a new [[Vector]].
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   override def from[E](it: IterableOnce[E]^): IndexedSeq[E] = it match {
     case is: IndexedSeq[E @unchecked] => is
     case _ => super.from(it)
@@ -135,6 +192,16 @@ transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends SeqOps[A, CC, C]
     with collection.IndexedSeqOps[A, CC, C] {
 
+  /** Returns the elements of this sequence from `from` up to but not including `until`.
+   *
+   *  Indices outside the bounds of this sequence are clamped, so a slice that covers
+   *  the whole sequence returns this sequence itself rather than a copy.
+   *
+   *  @param from the index of the first element of the slice
+   *  @param until the index one past the last element of the slice
+   *  @return a sequence of the elements at the indices in the interval, empty if
+   *          `until` is not greater than `from`
+   */
   override def slice(from: Int, until: Int): C = {
     // since we are immutable we can just share the same collection
     if (from <= 0 && until >= length) coll
@@ -153,11 +220,20 @@ trait LinearSeq[+A]
     with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
     with IterableFactoryDefaults[A, LinearSeq] {
 
+  /** The factory used to build immutable linear sequences, the [[LinearSeq$ `LinearSeq`]] companion object, which delegates to [[List]]. */
   override def iterableFactory: SeqFactory[LinearSeq] = LinearSeq
 }
 
 @SerialVersionUID(3L)
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](List) {
+  /** Returns an immutable linear sequence containing the elements of `it`.
+   *
+   *  If `it` is already an immutable `LinearSeq` it is returned unchanged; otherwise
+   *  its elements are copied into a new [[List]].
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   override def from[E](it: IterableOnce[E]^): LinearSeq[E] = it match {
     case ls: LinearSeq[E @unchecked] => ls
     case _ => super.from(it)

--- a/library/src/scala/collection/immutable/SeqMap.scala
+++ b/library/src/scala/collection/immutable/SeqMap.scala
@@ -40,13 +40,32 @@ trait SeqMap[K, +V]
     with collection.SeqMap[K, V]
     with MapOps[K, V, SeqMap, SeqMap[K, V]]
     with MapFactoryDefaults[K, V, SeqMap, Iterable] {
+  /** Returns the [[SeqMap$ SeqMap]] companion object as the factory for maps of this kind. */
   override def mapFactory: MapFactory[SeqMap] = SeqMap
 }
 
 
 object SeqMap extends MapFactory[SeqMap] {
+  /** An empty [[SeqMap]].
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return the empty `SeqMap` (a single cached instance)
+   */
   def empty[K, V]: SeqMap[K, V] = EmptySeqMap.asInstanceOf[SeqMap[K, V]]
 
+  /** Returns a [[SeqMap]] containing the key-value pairs of `it`, in its iteration order.
+   *
+   *  If `it` is already one of the `SeqMap` implementations ([[ListMap]],
+   *  [[TreeSeqMap]], [[VectorMap]], or a small `SeqMap`), it is returned unchanged.
+   *  Otherwise a new map is built; if a key occurs more than once in `it`, its first
+   *  occurrence determines its position and its last occurrence determines its value.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the source collection of key-value pairs
+   *  @return a `SeqMap[K, V]` with the bindings of `it`
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): SeqMap[K, V] =
     (it: @unchecked) match {
       //case sm: SeqMap[K, V] => sm
@@ -61,6 +80,16 @@ object SeqMap extends MapFactory[SeqMap] {
       case _ => (newBuilder[K, V] ++= it).result()
     }
 
+  /** Returns a new builder for a [[SeqMap]].
+   *
+   *  The builder uses the compact one- to four-entry representations while at most
+   *  four distinct keys have been added, and switches to a [[VectorMap]] builder
+   *  beyond that.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return a `Builder` that accepts key-value pairs and produces a `SeqMap[K, V]`
+   */
   def newBuilder[K, V]: Builder[(K, V), SeqMap[K, V]] = new SeqMapBuilderImpl
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -28,6 +28,9 @@ trait Set[A] extends Iterable[A]
     with collection.Set[A]
     with SetOps[A, Set, Set[A]]
     with IterableFactoryDefaults[A, Set] {
+  /** The factory used to build immutable sets, the [[Set$ `Set`]] companion object, which
+   *  creates the specialized small sets for up to four elements and a [[HashSet]] beyond that.
+   */
   override def iterableFactory: IterableFactory[Set] = Set
 }
 
@@ -72,6 +75,14 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   @`inline` final override def - (elem: A): C = excl(elem)
 
+  /** Returns a set with the elements of this set that are not in `that`.
+   *
+   *  The result is built up from the empty set one element at a time, so the concrete
+   *  types of the sets involved need not agree.
+   *
+   *  @param that the set of elements to remove
+   *  @return a set with the elements of this set that `that` does not contain
+   */
   def diff(that: collection.Set[A]): C =
     foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
@@ -95,6 +106,14 @@ transparent trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     with collection.StrictOptimizedSetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 
+  /** Returns a set with the elements of this set and those of `that`.
+   *
+   *  The elements of `that` are added to this set one at a time rather than through a
+   *  builder, so nothing is copied when `that` is empty.
+   *
+   *  @param that the elements to add
+   *  @return a set containing the elements of both collections
+   */
   override def concat(that: collection.IterableOnce[A]^): C = {
     var result: C = coll
     val it = that.iterator
@@ -110,8 +129,26 @@ transparent trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 @SerialVersionUID(3L)
 object Set extends IterableFactory[Set] {
 
+  /** Returns the empty immutable set.
+   *
+   *  All calls return the same instance, cast to the requested element type.
+   *
+   *  @tparam A the element type of the set
+   */
   def empty[A]: Set[A] = EmptySet.asInstanceOf[Set[A]]
 
+  /** Returns an immutable set containing the elements of `it`, with duplicates left out.
+   *
+   *  A collection that is already one of the immutable set implementations reached by
+   *  this factory is returned unchanged. Those are the unordered sets and the key sets
+   *  of immutable maps, so a key set of an insertion-ordered map such as `ListMap` or
+   *  `VectorMap` keeps that map's iteration order. Anything else, including a sorted
+   *  set, is copied into a new set, so that the result cannot keep an ordering that its
+   *  static element type no longer justifies.
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   def from[E](it: collection.IterableOnce[E]^): Set[E] =
     (it: @unchecked) match {
       case _ if it.knownSize == 0 => empty[E]
@@ -131,6 +168,12 @@ object Set extends IterableFactory[Set] {
       case _ => newBuilder[E].addAll(it).result()
     }
 
+  /** Returns a new builder for an immutable set.
+   *
+   *  @tparam A the element type of the set being built
+   *  @return a builder that produces the specialized small sets for up to four distinct
+   *          elements, and a `HashSet` beyond that
+   */
   def newBuilder[A]: Builder[A, Set[A]] = new SetBuilderImpl[A]
 
   /** An optimized representation for immutable empty sets. */
@@ -181,55 +224,147 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable sets of size 1. */
   @SerialVersionUID(3L)
   final class Set1[A] private[collection] (elem1: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
+    /** Returns `1`: this set has exactly one element. */
     override def size: Int = 1
+    /** Returns `false`: this set always has one element. */
     override def isEmpty = false
+    /** Returns `1`: the size is always known. */
     override def knownSize: Int = size
+    /** Returns `true` if `elem` is the element of this set, comparing with `==`.
+     *
+     *  @param elem the element to look for
+     */
     def contains(elem: A): Boolean = elem == elem1
+    /** Returns a set containing `elem` and the element of this set.
+     *
+     *  Returns this set itself if it already contains `elem`; otherwise a `Set2` with
+     *  `elem` after the element already present.
+     *
+     *  @param elem the element to add
+     */
     def incl(elem: A): Set[A] =
       if (contains(elem)) this
       else new Set2(elem1, elem)
+    /** Returns a set containing the element of this set except `elem`.
+     *
+     *  Returns the empty set if `elem` is the element of this set, and this set itself
+     *  otherwise.
+     *
+     *  @param elem the element to remove
+     */
     def excl(elem: A): Set[A] =
       if (elem == elem1) Set.empty
       else this
+    /** Returns an iterator over the single element of this set. */
     def iterator: Iterator[A] = Iterator.single(elem1)
+    /** Applies `f` to each element of this set, in the order they are held.
+     *
+     *  @tparam U the result type of `f`, used only for its side effects
+     *  @param f the function to apply to each element
+     */
     override def foreach[U](f: A => U): Unit = f(elem1)
+    /** Returns `true` if `p` holds for at least one element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that satisfies `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def exists(p: A => Boolean): Boolean = p(elem1)
+    /** Returns `true` if `p` holds for every element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that fails `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def forall(p: A => Boolean): Boolean = p(elem1)
     override protected[collection] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Set[A] =
       if (pred(elem1) != isFlipped) this else Set.empty
 
+    /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there
+     *  is none.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first match.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def find(p: A => Boolean): Option[A] =
       if (p(elem1)) Some(elem1)
       else None
+    /** Returns the first element this set holds, which is the first its iterator gives out. */
     override def head: A = elem1
+    /** Returns this set without its first element, the empty set. */
     override def tail: Set[A] = Set.empty
   }
 
   /** An optimized representation for immutable sets of size 2. */
   @SerialVersionUID(3L)
   final class Set2[A] private[collection] (elem1: A, elem2: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
+    /** Returns `2`: this set has exactly two elements. */
     override def size: Int = 2
+    /** Returns `false`: this set always has two elements. */
     override def isEmpty = false
+    /** Returns `2`: the size is always known. */
     override def knownSize: Int = size
+    /** Returns `true` if `elem` is one of the elements of this set, comparing with `==`.
+     *
+     *  @param elem the element to look for
+     */
     def contains(elem: A): Boolean = elem == elem1 || elem == elem2
+    /** Returns a set containing `elem` and the elements of this set.
+     *
+     *  Returns this set itself if it already contains `elem`; otherwise a `Set3` with
+     *  `elem` after the elements already present.
+     *
+     *  @param elem the element to add
+     */
     def incl(elem: A): Set[A] =
       if (contains(elem)) this
       else new Set3(elem1, elem2, elem)
+    /** Returns a set containing the elements of this set except `elem`.
+     *
+     *  Returns a `Set1` with the remaining elements in their current order if `elem` is
+     *  one of them, and this set itself otherwise.
+     *
+     *  @param elem the element to remove
+     */
     def excl(elem: A): Set[A] =
       if (elem == elem1) new Set1(elem2)
       else if (elem == elem2) new Set1(elem1)
       else this
+    /** Returns an iterator over the two elements of this set, in the order they are held. */
     def iterator: Iterator[A] = new SetNIterator[A](size) {
       def apply(i: Int) = getElem(i)
     }
     private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 }
 
+    /** Applies `f` to each element of this set, in the order they are held.
+     *
+     *  @tparam U the result type of `f`, used only for its side effects
+     *  @param f the function to apply to each element
+     */
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2)
     }
+    /** Returns `true` if `p` holds for at least one element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that satisfies `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2)
     }
+    /** Returns `true` if `p` holds for every element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that fails `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def forall(p: A => Boolean): Boolean = {
       p(elem1) && p(elem2)
     }
@@ -245,42 +380,93 @@ object Set extends IterableFactory[Set] {
         case 2 => this
       }
     }
+    /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there
+     *  is none.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first match.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
       else None
     }
+    /** Returns the first element this set holds, which is the first its iterator gives out. */
     override def head: A = elem1
+    /** Returns this set without its first element, a `Set1` of the remaining element. */
     override def tail: Set[A] = new Set1(elem2)
   }
 
   /** An optimized representation for immutable sets of size 3. */
   @SerialVersionUID(3L)
   final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
+    /** Returns `3`: this set has exactly three elements. */
     override def size: Int = 3
+    /** Returns `false`: this set always has three elements. */
     override def isEmpty = false
+    /** Returns `3`: the size is always known. */
     override def knownSize: Int = size
+    /** Returns `true` if `elem` is one of the elements of this set, comparing with `==`.
+     *
+     *  @param elem the element to look for
+     */
     def contains(elem: A): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3
+    /** Returns a set containing `elem` and the elements of this set.
+     *
+     *  Returns this set itself if it already contains `elem`; otherwise a `Set4` with
+     *  `elem` after the elements already present.
+     *
+     *  @param elem the element to add
+     */
     def incl(elem: A): Set[A] =
       if (contains(elem)) this
       else new Set4(elem1, elem2, elem3, elem)
+    /** Returns a set containing the elements of this set except `elem`.
+     *
+     *  Returns a `Set2` with the remaining elements in their current order if `elem` is
+     *  one of them, and this set itself otherwise.
+     *
+     *  @param elem the element to remove
+     */
     def excl(elem: A): Set[A] =
       if (elem == elem1) new Set2(elem2, elem3)
       else if (elem == elem2) new Set2(elem1, elem3)
       else if (elem == elem3) new Set2(elem1, elem2)
       else this
+    /** Returns an iterator over the three elements of this set, in the order they are held. */
     def iterator: Iterator[A] = new SetNIterator[A](size) {
       def apply(i: Int) = getElem(i)
     }
     private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 case 2 => elem3 }
 
+    /** Applies `f` to each element of this set, in the order they are held.
+     *
+     *  @tparam U the result type of `f`, used only for its side effects
+     *  @param f the function to apply to each element
+     */
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
+    /** Returns `true` if `p` holds for at least one element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that satisfies `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3)
     }
+    /** Returns `true` if `p` holds for every element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that fails `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def forall(p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3)
     }
@@ -298,44 +484,96 @@ object Set extends IterableFactory[Set] {
         case 3 => this
       }
     }
+    /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there
+     *  is none.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first match.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
       else if (p(elem3)) Some(elem3)
       else None
     }
+    /** Returns the first element this set holds, which is the first its iterator gives out. */
     override def head: A = elem1
+    /** Returns this set without its first element, a `Set2` of the remaining elements. */
     override def tail: Set[A] = new Set2(elem2, elem3)
   }
 
   /** An optimized representation for immutable sets of size 4. */
   @SerialVersionUID(3L)
   final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
+    /** Returns `4`: this set has exactly four elements. */
     override def size: Int = 4
+    /** Returns `false`: this set always has four elements. */
     override def isEmpty = false
+    /** Returns `4`: the size is always known. */
     override def knownSize: Int = size
+    /** Returns `true` if `elem` is one of the elements of this set, comparing with `==`.
+     *
+     *  @param elem the element to look for
+     */
     def contains(elem: A): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3 || elem == elem4
+    /** Returns a set containing `elem` and the elements of this set.
+     *
+     *  Returns this set itself if it already contains `elem`; otherwise a [[HashSet]],
+     *  since the specialized small sets stop at four elements. The order in which the
+     *  elements are iterated is then the one the hash set gives them, not this one.
+     *
+     *  @param elem the element to add
+     */
     def incl(elem: A): Set[A] =
       if (contains(elem)) this
       else HashSet.empty[A] + elem1 + elem2 + elem3 + elem4 + elem
+    /** Returns a set containing the elements of this set except `elem`.
+     *
+     *  Returns a `Set3` with the remaining elements in their current order if `elem` is
+     *  one of them, and this set itself otherwise.
+     *
+     *  @param elem the element to remove
+     */
     def excl(elem: A): Set[A] =
       if (elem == elem1) new Set3(elem2, elem3, elem4)
       else if (elem == elem2) new Set3(elem1, elem3, elem4)
       else if (elem == elem3) new Set3(elem1, elem2, elem4)
       else if (elem == elem4) new Set3(elem1, elem2, elem3)
       else this
+    /** Returns an iterator over the four elements of this set, in the order they are held. */
     def iterator: Iterator[A] = new SetNIterator[A](size) {
       def apply(i: Int) = getElem(i)
     }
     private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 case 2 => elem3 case 3 => elem4 }
 
+    /** Applies `f` to each element of this set, in the order they are held.
+     *
+     *  @tparam U the result type of `f`, used only for its side effects
+     *  @param f the function to apply to each element
+     */
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
+    /** Returns `true` if `p` holds for at least one element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that satisfies `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3) || p(elem4)
     }
+    /** Returns `true` if `p` holds for every element of this set.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first one that fails `p`.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def forall(p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3) && p(elem4)
     }
@@ -356,6 +594,14 @@ object Set extends IterableFactory[Set] {
       }
     }
 
+    /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there
+     *  is none.
+     *
+     *  The elements are tested in the order they are held, and testing stops at the
+     *  first match.
+     *
+     *  @param p the predicate used to test elements
+     */
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
@@ -363,7 +609,9 @@ object Set extends IterableFactory[Set] {
       else if (p(elem4)) Some(elem4)
       else None
     }
+    /** Returns the first element this set holds, which is the first its iterator gives out. */
     override def head: A = elem1
+    /** Returns this set without its first element, a `Set3` of the remaining elements. */
     override def tail: Set[A] = new Set3(elem2, elem3, elem4)
 
     private[immutable] def buildTo(builder: Builder[A, Set[A]]): builder.type =

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -59,8 +59,10 @@ trait SortedMap[K, +V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
     with SortedMapFactoryDefaults[K, V, SortedMap, Iterable, Map] {
 
+  /** Returns this map itself, with its static type widened to its unsorted counterpart `Map` */
   override def unsorted: Map[K, V] = this
 
+  /** Returns the [[SortedMap$ `SortedMap`]] object, the default factory for immutable sorted maps, which creates `TreeMap`s */
   override def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
   /** The same map with a given default function.
@@ -91,10 +93,19 @@ trait SortedMap[K, +V]
 transparent trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & SortedMapOps[X, Y, CC, ?], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C] with collection.SortedMapOps[K, V, CC, C] { self =>
 
+  /** Returns this map, typed as both the concrete map type `C` and `CC[K, V]`,
+   *  so that it can be used where either type is required.
+   */
   protected def coll: C & CC[K, V]
 
+  /** Widens the type of this map to its unsorted counterpart. */
   def unsorted: Map[K, V]
 
+  /** Returns a sorted set of the keys of this map, sorted by this map's ordering.
+   *
+   *  The set is backed by this map: it holds a reference to the map rather than
+   *  copying the keys.
+   */
   override def keySet: SortedSet[K] = new LazyImmutableKeySortedSet
 
   /** The implementation class of the set returned by `keySet`. */
@@ -111,17 +122,60 @@ transparent trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & SortedMapOps[X, 
   /** The implementation class of the set returned by `keySet` */
   @deprecated("ImmutableKeySortedSet is no longer used by the .keySet implementation", since = "3.8.0")
   protected class ImmutableKeySortedSet extends AbstractSet[K] with SortedSet[K] with GenKeySet with GenKeySortedSet {
+    /** Creates a ranged projection of this key set, backed by the corresponding ranged
+     *  projection of the underlying map.
+     *
+     *  @param from the lower bound (inclusive) of the projection, `None` if there is no lower bound
+     *  @param until the upper bound (exclusive) of the projection, `None` if there is no upper bound
+     *  @return the key set of the underlying map restricted to the given range
+     */
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
       val map = self.rangeImpl(from, until)
       new map.ImmutableKeySortedSet
     }
+    /** Returns a sorted set containing `elem` and the keys of the underlying map.
+     *
+     *  The keys are first copied out of the map, so the result no longer tracks it.
+     *
+     *  @param elem the element to add
+     */
     def incl(elem: K): SortedSet[K] = fromSpecific(this).incl(elem)
+    /** Returns a sorted set containing the keys of the underlying map except `elem`.
+     *
+     *  The keys are first copied out of the map, so the result no longer tracks it.
+     *
+     *  @param elem the element to remove
+     */
     def excl(elem: K): SortedSet[K] = fromSpecific(this).excl(elem)
   }
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
+  /** Returns a sorted map with `key` bound to `value` and otherwise the bindings of
+   *  this map, replacing any existing binding for `key`.
+   *
+   *  @tparam V1 the type of the added value, a supertype of `V`
+   *  @param key the key
+   *  @param value the value
+   *  @return a sorted map with the new binding added
+   */
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
   @`inline` final override def +[V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+  /** Updates the binding for `key` from its current optional value, `Some` if the key
+   *  is bound and `None` if it is not.
+   *
+   *  If `remappingFunction` returns `Some(v)` the key is bound to `v`; if it returns
+   *  `None` the binding is removed, or stays absent. An exception thrown by the
+   *  function is rethrown and this map is left unchanged; so is a result that is the
+   *  very same object the key is already bound to, in which case this map is returned.
+   *
+   *  The override serves only to give the result the sorted map type `CC`; the body is
+   *  the one inherited from `MapOps`.
+   *
+   *  @tparam V1 the type of the values in the returned map, a supertype of `V`
+   *  @param key the key whose binding is to be updated
+   *  @param remappingFunction a function from the current optional value to the new one
+   *  @return a sorted map with the updated binding for `key`
+   */
   override def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): CC[K, V1] = {
     // Implementation has been copied from `MapOps`
     val previousValue = this.get(key)
@@ -132,6 +186,15 @@ transparent trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & SortedMapOps[X, 
         else coll.updated(key, nextValue)
     }
   }
+  /** Returns a sorted map with the same keys as this map, each bound to the result of
+   *  applying `f` to that key and its value.
+   *
+   *  The keys are unchanged, so the result keeps this map's ordering.
+   *
+   *  @tparam W the type of the values in the resulting map
+   *  @param f the function applied to each key and its value
+   *  @return a sorted map with `f` applied to every binding
+   */
   override def transform[W](f: (K, V) => W): CC[K, W] = map({ case (k, v) => (k, f(k, v)) })(using ordering)
 }
 
@@ -140,6 +203,16 @@ transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & S
     with collection.StrictOptimizedSortedMapOps[K, V, CC, C]
     with StrictOptimizedMapOps[K, V, Map, C] {
 
+  /** Returns a sorted map containing the bindings of this map and those of `xs`, with a
+   *  binding from `xs` replacing one for an equal key in this map.
+   *
+   *  The bindings of `xs` are added one at a time to this map rather than through a
+   *  builder, so nothing is copied when `xs` is empty.
+   *
+   *  @tparam V2 the type of the values of the resulting map, a supertype of `V`
+   *  @param xs the bindings to add
+   *  @return a sorted map with the combined bindings
+   */
   override def concat[V2 >: V](xs: collection.IterableOnce[(K, V2)]^): CC[K, V2] = {
     var result: CC[K, V2] = coll
     val it = xs.iterator
@@ -151,43 +224,110 @@ transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & S
 @SerialVersionUID(3L)
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
+  /** Returns an immutable sorted map containing the bindings of `it`, ordered by the
+   *  given `Ordering` on the keys.
+   *
+   *  If `it` is already a sorted map whose ordering is equal to the requested one it is
+   *  returned unchanged; otherwise its bindings are copied into a new [[TreeMap]].
+   *
+   *  @tparam K the key type
+   *  @tparam V the value type
+   *  @param it the collection whose bindings are to be contained
+   */
   override def from[K: Ordering, V](it: IterableOnce[(K, V)]^): SortedMap[K, V] = (it: @unchecked) match {
     case sm: SortedMap[K, V] if Ordering[K] == sm.ordering => sm
     case _ => super.from(it)
   }
 
+  /** An immutable sorted map whose `apply` returns `defaultValue(key)` for keys that are
+   *  not present instead of throwing an exception. All operations are delegated to the
+   *  underlying sorted map; methods such as `get`, `contains`, `iterator`, and `keys`
+   *  are not affected by the default.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param underlying the sorted map to which all operations are delegated
+   *  @param defaultValue the function computing a default value for keys that are not present
+   */
   final class WithDefault[K, +V](underlying: SortedMap[K, V], defaultValue: K -> V)
     extends Map.WithDefault[K, V](underlying, defaultValue)
       with SortedMap[K, V]
       with SortedMapOps[K, V, SortedMap, WithDefault[K, V]] with Serializable {
 
+    /** Returns the key ordering of the underlying sorted map */
     implicit def ordering: Ordering[K] = underlying.ordering
 
+    /** Returns the sorted map factory of the underlying map; maps created by that factory do not have this map's default */
     override def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
 
+    /** Returns an iterator over the key-value pairs of the underlying map whose keys are
+     *  greater than or equal to `start`, in the map's key ordering.
+     *
+     *  @param start the lower bound (inclusive) on the keys of the entries to return
+     */
     def iteratorFrom(start: K): scala.collection.Iterator[(K, V)] = underlying.iteratorFrom(start)
 
+    /** Returns an iterator over the keys of the underlying map that are greater than or
+     *  equal to `start`, in the map's key ordering.
+     *
+     *  @param start the lower bound (inclusive) on the keys to return
+     */
     def keysIteratorFrom(start: K): scala.collection.Iterator[K] = underlying.keysIteratorFrom(start)
 
+    /** Returns a ranged projection of the underlying map, wrapped in a new `WithDefault`
+     *  with the same default function.
+     *
+     *  @param from the lower bound (inclusive) of the projection wrapped in a `Some`, or `None` if there is no lower bound
+     *  @param until the upper bound (exclusive) of the projection wrapped in a `Some`, or `None` if there is no upper bound
+     *  @return a `WithDefault` wrapper around the ranged projection of the underlying map
+     */
     def rangeImpl(from: Option[K], until: Option[K]): WithDefault[K, V] =
       new WithDefault[K, V](underlying.rangeImpl(from, until), defaultValue)
 
     // Need to override following methods to match type signatures of `SortedMap.WithDefault`
     // for operations preserving default value
 
+    /** Returns a new `WithDefault` with `key` bound to `value` in the underlying map,
+     *  replacing any existing binding, and with the same default function as this map.
+     *
+     *  @tparam V1 the type of the added value, a supertype of `V`
+     *  @param key the key
+     *  @param value the value
+     *  @return a new `WithDefault` with the binding added and this map's default
+     */
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
+    /** Returns a new `WithDefault` wrapping the bindings of the underlying map together
+     *  with those of `xs`, with the same default function as this map.
+     *
+     *  @tparam V2 the type of the values of the resulting map, a supertype of `V`
+     *  @param xs the bindings to add
+     *  @return a new `WithDefault` with the combined bindings and this map's default
+     */
     override def concat [V2 >: V](xs: collection.IterableOnce[(K, V2)]^): WithDefault[K, V2] =
       new WithDefault( underlying.concat(xs) , defaultValue)
 
+    /** Returns a new `WithDefault` without a binding for `key`, wrapping the underlying
+     *  map with that key removed and keeping this map's default function.
+     *
+     *  @param key the key to remove
+     */
     override def removed(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.removed(key), defaultValue)
 
+    /** Returns a new `WithDefault` with the same default function, wrapping an empty map of the same type as the underlying map */
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
+    /** Returns a new `WithDefault` with the same default function, wrapping a map that is
+     *  built from the key-value pairs of `coll` with the underlying map's factory.
+     *
+     *  @param coll the key-value pairs of the new map
+     *  @return a new `WithDefault` containing the bindings of `coll`
+     */
     override protected def fromSpecific(coll: (scala.collection.IterableOnce[(K, V)]^) @uncheckedVariance): WithDefault[K, V] =
       new WithDefault[K, V](sortedMapFactory.from(coll), defaultValue)
 
+    /** Returns a builder that collects key-value pairs into a new sorted map and wraps the result in a `WithDefault` with the same default function */
     override protected def newSpecificBuilder: Builder[(K, V), WithDefault[K, V]] @uncheckedVariance =
       SortedMap.newBuilder.mapResult((p: SortedMap[K, V]) => new WithDefault[K, V](p, defaultValue))
   }

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -27,8 +27,10 @@ trait SortedSet[A]
      with SortedSetOps[A, SortedSet, SortedSet[A]]
      with SortedSetFactoryDefaults[A, SortedSet, Set] {
 
+  /** Returns this set itself, with its static type widened to its unsorted counterpart `Set` */
   override def unsorted: Set[A] = this
 
+  /** Returns the [[SortedSet$ `SortedSet`]] object, the default factory for immutable sorted sets, which creates `TreeSet`s */
   override def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
 }
 
@@ -44,6 +46,7 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C] {
 
+  /** Widens the type of this set to its unsorted counterpart. */
   def unsorted: Set[A]
 }
 
@@ -59,6 +62,14 @@ transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: S
  */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet) {
+  /** Returns an immutable sorted set containing the elements of `it`, ordered by the given `Ordering`.
+   *
+   *  If `it` is already a sorted set whose ordering is equal to the requested one it is returned
+   *  unchanged; otherwise its elements are copied into a new [[TreeSet]].
+   *
+   *  @tparam E the element type
+   *  @param it the collection whose elements are to be contained
+   */
   override def from[E: Ordering](it: IterableOnce[E]^): SortedSet[E] = (it: @unchecked) match {
     case ss: SortedSet[E] if Ordering[E] == ss.ordering => ss
     case _ => super.from(it)

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -25,6 +25,30 @@ import scala.collection.mutable.{ArrayBuffer, StringBuilder}
 import scala.language.implicitConversions
 import scala.runtime.ScalaRunTime.nullForGC
 
+/** A sequence whose elements are computed as they are needed, one cons cell at a time.
+ *
+ *  A non-empty stream holds its head as an already computed value and its tail as an
+ *  expression that is evaluated the first time the tail is asked for and remembered
+ *  afterwards, so no element is ever computed twice. Building a cons cell therefore
+ *  computes one element and nothing beyond it, which lets a stream stand for a series
+ *  that has no end:
+ *
+ *  ```scala sc:compile
+ *  val naturals: Stream[Int] = Stream.from(0)
+ *  naturals.take(3).force // Stream(0, 1, 2)
+ *  ```
+ *
+ *  Because the head is strict, an operation that produces a stream computes the first
+ *  element of its result right away; only the rest is deferred. Because the elements
+ *  are memoized, a stream that is still referenced from its head keeps every element
+ *  it has produced, which is what makes traversing one twice cheap and what makes a
+ *  long one expensive to hold on to.
+ *
+ *  @tparam A the type of the elements contained in this stream
+ *
+ *  @define coll stream
+ *  @define Coll `Stream`
+ */
 @deprecated("Use LazyListIterable (which is fully lazy) instead of Stream (which has a lazy tail only)", "2.13.0")
 @SerialVersionUID(3L)
 sealed abstract class Stream[+A] extends AbstractSeq[A]
@@ -32,6 +56,12 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   with LinearSeqOps[A, Stream, Stream[A]]
   with IterableFactoryDefaults[A, Stream]
   with Serializable {
+  /** Returns a stream of all elements of this stream except the first.
+   *
+   *  The tail is computed the first time it is asked for and remembered afterwards.
+   *
+   *  @throws UnsupportedOperationException if this stream is empty
+   */
   def tail: Stream[A]
 
   /** Forces evaluation of the whole `Stream` and returns it.
@@ -45,8 +75,10 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
    */
   def force: this.type
 
+  /** The factory used to build streams, the [[Stream$ `Stream`]] companion object. */
   override def iterableFactory: SeqFactory[Stream] = Stream
 
+  /** The prefix of this stream's string representation: `"Stream"`. */
   override protected def className: String = "Stream"
 
   /** Applies the given function `f` to each element of this linear sequence
@@ -69,6 +101,15 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     }
   }
 
+  /** Returns the first element satisfying `p` wrapped in a `Some`, or `None` if there
+   *  is none.
+   *
+   *  The elements up to and including the first match are computed, and no others.
+   *  Overridden here as final to trigger tail-call optimization, so that the elements
+   *  already tested can be collected while the search goes on.
+   *
+   *  @param p the predicate used to test elements
+   */
   @tailrec
   override final def find(p: A => Boolean): Option[A] = {
     if(isEmpty) None
@@ -76,6 +117,14 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     else tail.find(p)
   }
 
+  /** Returns a stream of the first `n` elements of this stream, or of all its elements
+   *  if it has fewer than `n`.
+   *
+   *  Only the first element of the result is computed; the rest is computed as the
+   *  result is forced. A non-positive `n` gives the empty stream.
+   *
+   *  @param n the number of elements to take
+   */
   override def take(n: Int): Stream[A] = {
     if (n <= 0 || isEmpty) Stream.empty
     else if (n == 1) new Stream.Cons(head, Stream.empty)
@@ -103,6 +152,13 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   @deprecated("The `append` operation has been renamed `lazyAppendedAll`", "2.13.0")
   @inline final def append[B >: A](rest: => IterableOnce[B]): Stream[B] = lazyAppendedAll(rest)
 
+  /** Replaces this stream with a serialization proxy during Java serialization, but only
+   *  if it is non-empty and its tail has already been computed.
+   *
+   *  The proxy writes out the computed prefix compactly; a stream whose tail is not yet
+   *  computed is serialized as itself, so that its unevaluated thunk is stored by
+   *  standard Java serialization and is not forced by serializing.
+   */
   protected def writeReplace(): AnyRef =
     if(nonEmpty && tailDefined) new Stream.SerializationProxy[A](this) else this
 
@@ -125,6 +181,17 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   def lazyAppendedAll[B >: A](suffix: => collection.IterableOnce[B]): Stream[B] =
     if (isEmpty) iterableFactory.from(suffix) else Stream.cons[B](head, tail.lazyAppendedAll(suffix))
 
+  /** Returns a stream of the intermediate results of folding this stream from the left
+   *  with `op`, starting with `z`.
+   *
+   *  The result begins with `z`; each further element is computed only as the result is
+   *  forced that far.
+   *
+   *  @tparam B the type of the accumulated value
+   *  @param z the start value, which is the first element of the result
+   *  @param op the operation applied to the accumulated value and the next element
+   *  @return a stream of the successive results of `op`, of length one more than this stream
+   */
   override def scanLeft[B](z: B)(op: (B, A) => B): Stream[B] =
     if (isEmpty) z +: iterableFactory.empty
     else Stream.cons(z, tail.scanLeft(op(z, head))(op))
@@ -149,10 +216,35 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     }
   }
 
+  /** Returns a pair of streams, the first holding the elements satisfying `p` and the
+   *  second the elements that do not.
+   *
+   *  This traverses the elements twice, once for each side of the pair, and applies `p`
+   *  to every element it passes; both traversals stop at the first element they keep.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of the elements satisfying `p` and the elements not satisfying it
+   */
   override def partition(p: A => Boolean): (Stream[A], Stream[A]) = (filter(p(_)), filterNot(p(_)))
 
+  /** Returns a stream of the elements of this stream that satisfy `pred`.
+   *
+   *  The leading elements that do not satisfy `pred` are computed and dropped at once,
+   *  so this returns only when a first matching element has been found or the stream has
+   *  been exhausted; the remaining elements are filtered as the result is forced.
+   *
+   *  @param pred the predicate an element must satisfy to be kept
+   */
   override def filter(pred: A => Boolean): Stream[A] = filterImpl(pred, isFlipped = false)
 
+  /** Returns a stream of the elements of this stream that do not satisfy `pred`.
+   *
+   *  The leading elements that satisfy `pred` are computed and dropped at once, so this
+   *  returns only when a first non-matching element has been found or the stream has
+   *  been exhausted; the remaining elements are filtered as the result is forced.
+   *
+   *  @param pred the predicate an element must not satisfy to be kept
+   */
   override def filterNot(pred: A => Boolean): Stream[A] = filterImpl(pred, isFlipped = true)
 
   private[immutable] def filterImpl(p: A => Boolean, isFlipped: Boolean): Stream[A] = {
@@ -173,12 +265,37 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, Stream] =
     Stream.withFilter(coll, p)
 
+  /** Returns a stream consisting of `elem` followed by the elements of this stream.
+   *
+   *  Nothing of this stream is computed; it becomes the deferred tail of the result.
+   *
+   *  @tparam B the element type of the returned stream, a supertype of `A`
+   *  @param elem the element to prepend
+   */
   override final def prepended[B >: A](elem: B): Stream[B] = Stream.cons(elem, coll)
 
+  /** Returns a stream of the results of applying `f` to each element of this stream.
+   *
+   *  `f` is applied to the head at once, and to each further element only as the result
+   *  is forced that far.
+   *
+   *  @tparam B the element type of the returned stream
+   *  @param f the function to apply to each element
+   */
   override final def map[B](f: A => B): Stream[B] =
     if (isEmpty) iterableFactory.empty
     else Stream.cons(f(head), tail.map(f))
 
+  /** Returns a stream of the results of applying `pf` to the elements on which it is
+   *  defined, leaving the others out.
+   *
+   *  The leading elements on which `pf` is not defined are computed and dropped at once,
+   *  so this returns only when a first element in the domain of `pf` has been found or
+   *  the stream has been exhausted; `pf` is applied to each element at most once.
+   *
+   *  @tparam B the element type of the returned stream
+   *  @param pf the partial function applied to the elements in its domain
+   */
   @tailrec override final def collect[B](pf: PartialFunction[A, B]): Stream[B] =
     if(isEmpty) Stream.empty
     else {
@@ -188,6 +305,15 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
       else tail.collect(pf)
     }
 
+  /** Returns the result of applying `pf` to the first element in its domain wrapped in
+   *  a `Some`, or `None` if there is no such element.
+   *
+   *  The elements up to and including the first match are computed, and no others; `pf`
+   *  is applied to each of them at most once.
+   *
+   *  @tparam B the result type of `pf`
+   *  @param pf the partial function applied to the elements in its domain
+   */
   @tailrec override final def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
     if(isEmpty) None
     else {
@@ -199,6 +325,16 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
 
   // optimisations are not for speed, but for functionality
   // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)
+  /** Returns a stream of the concatenated results of applying `f` to each element of
+   *  this stream.
+   *
+   *  `f` is applied to leading elements until one of them yields a non-empty collection,
+   *  so an element whose image is empty is passed over at once; the rest is computed as
+   *  the result is forced.
+   *
+   *  @tparam B the element type of the returned stream
+   *  @param f the function mapping each element to a collection of results
+   */
   override final def flatMap[B](f: A => IterableOnce[B]): Stream[B] =
     if (isEmpty) iterableFactory.empty
     else {
@@ -215,6 +351,15 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
       else prefix.lazyAppendedAll(nonEmptyPrefix.tail.flatMap(f))
     }
 
+  /** Returns a stream of pairs of corresponding elements of this stream and `that`,
+   *  as long as both have elements left.
+   *
+   *  Only the first pair is computed; the rest is computed as the result is forced. The
+   *  length of the result is the smaller of the two lengths.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection to zip with this stream
+   */
   override final def zip[B](that: collection.IterableOnce[B]): Stream[(A, B)] =
     if (this.isEmpty || that.isEmpty) iterableFactory.empty
     else {
@@ -225,8 +370,12 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
       Stream.cons[(A, B)]((this.head, thatIterable.head), this.tail.zip(thatIterable.tail))
     }
 
+  /** Returns a stream of pairs of the elements of this stream and their indices,
+   *  counting from `0`; only the first pair is computed.
+   */
   override final def zipWithIndex: Stream[(A, Int)] = this.zip(LazyList.from(0))
 
+  /** Returns `true` if the tail of this stream has already been computed. */
   protected def tailDefined: Boolean
 
   /** Appends all elements of this $coll to a string builder using start, end, and separator strings.
@@ -336,6 +485,13 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
    */
   override def toString() = addStringNoForce(new JStringBuilder(className), "(", ", ", ")").toString
 
+  /** Returns `true` if this stream is known to be finite, which is decided without
+   *  computing anything that has not been computed already.
+   *
+   *  An empty stream qualifies, and so does one whose tails have all been computed down
+   *  to the empty stream. A stream that ends in an uncomputed tail, and a cyclic one,
+   *  both give `false`, the latter because its tails never reach the empty stream.
+   */
   @deprecated("Check .knownSize instead of .hasDefiniteSize for more actionable information (see scaladoc for details)", "2.13.0")
   override def hasDefiniteSize: Boolean = isEmpty || {
     if (!tailDefined) false
@@ -387,8 +543,17 @@ object Stream extends SeqFactory[Stream] {
 
   //@SerialVersionUID(3L) //TODO Putting an annotation on Stream.empty causes a cyclic dependency in unpickling
   object Empty extends Stream[Nothing] {
+    /** Returns `true`; this is the empty stream. */
     override def isEmpty: Boolean = true
+    /** Returns nothing; the empty stream has no elements.
+     *
+     *  @throws NoSuchElementException always
+     */
     override def head: Nothing = throw new NoSuchElementException("head of empty stream")
+    /** Returns nothing; the empty stream has no tail.
+     *
+     *  @throws UnsupportedOperationException always
+     */
     override def tail: Stream[Nothing] = throw new UnsupportedOperationException("tail of empty stream")
     /** Forces evaluation of the whole `Stream` and returns it.
      *
@@ -400,16 +565,35 @@ object Stream extends SeqFactory[Stream] {
      *  @return The fully realized `Stream`.
      */
     def force: this.type = this
+    /** Returns `0`; the size of the empty stream is known without computing anything. */
     override def knownSize: Int = 0
+    /** Returns `false`; the empty stream has no tail to compute. */
     protected def tailDefined: Boolean = false
   }
 
+  /** A non-empty stream, holding a computed head and a tail that is computed on first
+   *  access and remembered afterwards.
+   *
+   *  @tparam A the element type of the stream
+   *  @param head the first element of this stream
+   *  @param tl the expression producing the rest of this stream, evaluated once if it
+   *            returns normally and retried on the next access if it throws
+   */
   @SerialVersionUID(3L)
   final class Cons[A](override val head: A, tl: => Stream[A]) extends Stream[A] {
+    /** Returns `false`; a cons cell always holds at least its head. */
     override def isEmpty: Boolean = false
     @volatile private var tlVal: Stream[A] = compiletime.uninitialized
     @volatile private var tlGen: (() => Stream[A]) | Null = () => tl
+    /** Returns `true` once the tail of this stream has been computed. */
     protected def tailDefined: Boolean = tlGen eq null
+    /** Returns the rest of this stream, evaluating the tail expression on the first call
+     *  and returning the remembered result on every call after that.
+     *
+     *  The evaluation is synchronized, so that concurrent callers agree on one tail and
+     *  the expression is evaluated once. Nothing is remembered if it throws, so the next
+     *  access evaluates it again.
+     */
     override def tail: Stream[A] = {
       if (!tailDefined)
         synchronized {
@@ -447,8 +631,19 @@ object Stream extends SeqFactory[Stream] {
 
   }
 
+  /** Provides the `#::` and `#:::` operators on a by-name stream, so that the right
+   *  operand of a cons is not evaluated when the cons cell is built.
+   *
+   *  @tparam A the element type of the stream
+   *  @param l the stream to defer, evaluated when the operator's result asks for its tail,
+   *           or at once by `#:::` when its left operand turns out to be empty
+   */
   implicit def toDeferrer[A](l: => Stream[A]): Deferrer[A] = new Deferrer[A](() => l)
 
+  /** Holds the deferred right operand of a `#::` or `#:::` operation on streams.
+   *
+   *  @tparam A the element type of the deferred stream
+   */
   final class Deferrer[A] private[Stream] (private val l: () => Stream[A]) extends AnyVal {
     /** Constructs a `Stream` consisting of a given first element followed by elements
      *  from another `Stream`.
@@ -461,10 +656,26 @@ object Stream extends SeqFactory[Stream] {
   }
 
   object #:: {
+    /** Matches a non-empty stream against its head and tail.
+     *
+     *  Matching computes the tail of `s`, but nothing beyond it.
+     *
+     *  @tparam A the element type of the stream
+     *  @param s the stream to decompose
+     *  @return `Some((head, tail))` if `s` is non-empty, or `None` if it is empty
+     */
     def unapply[A](s: Stream[A]): Option[(A, Stream[A])] =
       if (s.nonEmpty) Some((s.head, s.tail)) else None
   }
 
+  /** Returns a stream containing the elements of `coll`.
+   *
+   *  If `coll` is already a stream it is returned unchanged; otherwise its iterator is
+   *  drained one element at a time as the result is forced, the first element at once.
+   *
+   *  @tparam A the element type
+   *  @param coll the collection whose elements are to be contained
+   */
   def from[A](coll: collection.IterableOnce[A]): Stream[A] = coll match {
     case coll: Stream[A] => coll
     case _ => fromIterator(coll.iterator)
@@ -483,8 +694,21 @@ object Stream extends SeqFactory[Stream] {
       new Stream.Cons(it.next(), fromIterator(it))
     } else Stream.Empty
 
+  /** Returns the empty stream.
+   *
+   *  All calls return the same instance, which is shared across element types.
+   *
+   *  @tparam A the element type of the stream
+   */
   def empty[A]: Stream[A] = Empty
 
+  /** Returns a new builder that collects elements into a stream.
+   *
+   *  The elements are collected strictly, in an `ArrayBuffer`, and turned into a stream
+   *  when the result is asked for; this builder defers nothing.
+   *
+   *  @tparam A the element type of the stream being built
+   */
   override def newBuilder[A]: mutable.Builder[A, Stream[A]] = ArrayBuffer.newBuilder[A].mapResult(array => from(array))
 
   private[immutable] def withFilter[A](l: Stream[A] @uncheckedVariance, p: A => Boolean): collection.WithFilter[A, Stream] =
@@ -576,6 +800,9 @@ object Stream extends SeqFactory[Stream] {
       coll = (init ++: tail)
     }
 
+    /** Returns the stream rebuilt from the stream contents, replacing this proxy when the
+     *  object is read back.
+     */
     protected def readResolve(): Any = coll
   }
 }

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -31,6 +31,21 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     with collection.StrictOptimizedSeqOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 
+  /** Selects all the elements of this sequence ignoring duplicates as
+   *  determined by `==` after applying the transforming function `f`.
+   *
+   *  Fills a strict builder in a single traversal, keeping the first of each
+   *  group of elements on which `f` agrees. Since this sequence is immutable it
+   *  can be returned as is when it has at most one element, or when the traversal
+   *  found no duplicate; in the latter case the builder was still filled, and its
+   *  result is discarded.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f the transforming function whose result is used to determine the
+   *           uniqueness of each element
+   *  @return a sequence consisting of all the elements of this sequence
+   *          without duplicates, or this sequence itself if it has none
+   */
   override def distinctBy[B](f: A -> B): C = {
     if (lengthCompare(1) <= 0) coll
     else {
@@ -46,6 +61,18 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     }
   }
 
+  /** Returns a copy of this sequence with the element at `index` replaced by `elem`.
+   *
+   *  Fills a size-hinted strict builder in a single traversal rather than
+   *  building a view.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param index the position of the element to replace
+   *  @param elem the replacing element
+   *  @return a new sequence that agrees with this sequence everywhere except at
+   *          `index`, where it holds `elem`
+   *  @throws IndexOutOfBoundsException if `index` is negative or not less than the length of this sequence
+   */
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
     if (index < 0)
       throw (
@@ -68,6 +95,23 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Returns a copy of this sequence with `replaced` elements from `from` onwards
+   *  replaced by the elements of `other`.
+   *
+   *  Fills a strict builder in a single traversal rather than building a view.
+   *  A negative `from` is treated as `0` and a `from` beyond the end of this
+   *  sequence appends `other` at the end; a negative `replaced` removes nothing,
+   *  and one larger than the number of remaining elements removes all of them.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param from the index of the first replaced element
+   *  @param other the replacement elements
+   *  @param replaced the number of elements to drop from this sequence at `from`
+   *  @return a new sequence consisting of the elements of this sequence before
+   *          `from`, then the elements of `other`, then the elements of this
+   *          sequence from `from + replaced` onwards, where a negative `from`
+   *          counts as 0 and a negative `replaced` as 0
+   */
   override def patch[B >: A](from: Int, other: IterableOnce[B]^, replaced: Int): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     var i = 0
@@ -86,6 +130,15 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     b.result()
   }
 
+  /** Returns the elements of this sequence sorted according to `ord`.
+   *
+   *  Forwards to the inherited implementation, which sorts stably; the override
+   *  serves only to refine the result type for immutable sequences.
+   *
+   *  @tparam B the element type used for ordering (a supertype of `A`)
+   *  @param ord the ordering used to compare elements
+   *  @return a sequence with the same elements as this sequence, ordered by `ord`
+   */
   override def sorted[B >: A](implicit ord: Ordering[B]): C = super.sorted(using ord)
 
 }

--- a/library/src/scala/collection/immutable/TreeMap.scala
+++ b/library/src/scala/collection/immutable/TreeMap.scala
@@ -80,23 +80,56 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     with SortedMapFactoryDefaults[K, V, TreeMap, Iterable, Map]
     with DefaultSerializable {
 
+  /** Creates an empty tree map.
+   *
+   *  @param ordering the ordering used to compare keys
+   */
   def this()(implicit ordering: Ordering[K]) = this(null)(using ordering)
   private[immutable] def tree0: RB.Tree[K, V] | Null = tree
 
   private def newMapOrSelf[V1 >: V](t: RB.Tree[K, V1] | Null): TreeMap[K, V1] = if(t eq tree) this else new TreeMap[K, V1](t)
 
+  /** Returns the `TreeMap` companion object, the factory used by transformation methods to build new tree maps. */
   override def sortedMapFactory: SortedMapFactory[TreeMap] = TreeMap
 
+  /** Returns an iterator over the key-value pairs of this tree map, in ascending order of keys. */
   def iterator: Iterator[(K, V)] = RB.iterator(tree)
 
+  /** Returns an iterator over the keys of this tree map that are greater than or equal to `start`,
+   *  in ascending order.
+   *
+   *  @param start the lower bound (inclusive) on the keys to return
+   */
   def keysIteratorFrom(start: K): Iterator[K] = RB.keysIterator(tree, Some(start))
 
+  /** Returns the keys of this tree map as an immutable [[scala.collection.immutable.TreeSet]].
+   *
+   *  The returned set uses the same ordering as this map and shares this map's underlying
+   *  red-black tree, so this operation takes constant time and space.
+   */
   override def keySet: TreeSet[K] = new TreeSet(tree)(using ordering)
 
+  /** Returns an iterator over the key-value pairs of this tree map whose keys are greater than
+   *  or equal to `start`, in ascending order of keys.
+   *
+   *  @param start the lower bound (inclusive) on the keys of the entries to return
+   */
   def iteratorFrom(start: K): Iterator[(K, V)] = RB.iterator(tree, Some(start))
 
+  /** Returns an iterator over the values of the entries of this tree map whose keys are greater
+   *  than or equal to `start`, in ascending order of the associated keys.
+   *
+   *  @param start the lower bound (inclusive) on the keys of the entries whose values are returned
+   */
   override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
 
+  /** Returns a stepper over the key-value pairs of this tree map, in ascending order of keys.
+   *
+   *  The returned stepper supports efficient splitting for parallel processing.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape an implicit witness selecting the stepper type for element type `(K, V)`
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[(K, V), S]): S & EfficientSplit =
     shape.parUnbox(
       scala.collection.convert.impl.AnyBinaryTreeStepper.from[(K, V), RB.Tree[K, V]](
@@ -104,6 +137,15 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
       )
     )
 
+  /** Returns a stepper over the keys of this tree map, in ascending order.
+   *
+   *  The returned stepper supports efficient splitting for parallel processing. If `shape`
+   *  indicates `Int`, `Long` or `Double` keys, the stepper is a primitive stepper of the
+   *  corresponding type, avoiding boxing.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape an implicit witness selecting the stepper type for key type `K`
+   */
   override def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Tree[K, V]
@@ -116,6 +158,15 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns a stepper over the values of this tree map, in ascending order of the associated keys.
+   *
+   *  The returned stepper supports efficient splitting for parallel processing. If `shape`
+   *  indicates `Int`, `Long` or `Double` values, the stepper is a primitive stepper of the
+   *  corresponding type, avoiding boxing.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape an implicit witness selecting the stepper type for value type `V`
+   */
   override def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Tree[K, V]
@@ -128,7 +179,21 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     s.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns the value associated with `key` in this tree map, wrapped in a `Some`, or `None`
+   *  if `key` is not present.
+   *
+   *  @param key the key to look up
+   */
   def get(key: K): Option[V] = RB.get(tree, key)
+  /** Returns the value associated with `key` in this tree map, or `default` if `key` is not
+   *  present.
+   *
+   *  Overridden to avoid allocating an intermediate `Option`.
+   *
+   *  @tparam V1 the result type, a supertype of this map's value type
+   *  @param key the key to look up
+   *  @param default the value to return if `key` is not present; only evaluated in that case
+   */
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val resultOrNull = RB.lookup(tree, key)
     if (resultOrNull eq null) default
@@ -136,6 +201,14 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
   }
 
   // override for performance -- no Some allocation
+  /** Returns the value associated with `key` in this tree map.
+   *
+   *  Overridden to avoid allocating an intermediate `Option`.
+   *
+   *  @param key the key to look up
+   *  @return the value bound to `key`
+   *  @throws NoSuchElementException if `key` is not present in this tree map
+   */
   override def apply(key: K): V = {
     val resultOrNull = RB.lookup(tree, key)
     if (resultOrNull eq null) default(key)
@@ -143,14 +216,42 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
   }
 
   // override for performance -- no Some allocation
+  /** Returns `true` if this tree map contains a binding for `key`.
+   *
+   *  @param key the key to test for membership
+   */
   override def contains(key: K): Boolean = RB.contains(tree, key)
 
+  /** Returns a tree map containing all entries of this map except the one with key `key`.
+   *
+   *  @param key the key to remove
+   *  @return a tree map without a binding for `key`; this map itself if it contains no such binding
+   */
   def removed(key: K): TreeMap[K,V] =
     newMapOrSelf(RB.delete(tree, key))
 
+  /** Returns a tree map containing all entries of this map as well as a binding of `key` to
+   *  `value`, replacing the current value if `key` is already present.
+   *
+   *  @tparam V1 the type of the added value, a supertype of this map's value type
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a tree map with the updated binding; this map itself if `key` is already bound to
+   *          the very same (referentially identical) value
+   */
   def updated[V1 >: V](key: K, value: V1): TreeMap[K, V1] =
     newMapOrSelf(RB.update(tree, key, value, overwrite = true))
 
+  /** Returns a tree map containing all entries of this map and all key-value pairs of `that`.
+   *
+   *  If a key occurs in both, the value from `that` is retained. If `that` is a `TreeMap` with
+   *  the same ordering, the result is computed by an efficient tree union; otherwise the pairs
+   *  of `that` are added one by one.
+   *
+   *  @tparam V1 the value type of the result, a supertype of this map's value type
+   *  @param that the key-value pairs to add
+   *  @return a tree map with the combined entries
+   */
   override def concat[V1 >: V](that: collection.IterableOnce[(K, V1)]^): TreeMap[K, V1] =
     newMapOrSelf(that match {
       case tm: TreeMap[K, V] @unchecked if ordering == tm.ordering =>
@@ -171,6 +272,14 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
         adder.finalTree
     })
 
+  /** Returns a tree map containing all entries of this map whose keys are not in `keys`.
+   *
+   *  If `keys` is a `TreeSet` with the same ordering, the result is computed by an efficient
+   *  tree difference; otherwise the keys are removed one by one.
+   *
+   *  @param keys the keys to remove
+   *  @return a tree map without bindings for the given keys
+   */
   override def removedAll(keys: IterableOnce[K]^): TreeMap[K, V] = (keys: @unchecked) match {
     case ts: TreeSet[K] if ordering == ts.ordering =>
       newMapOrSelf(RB.difference(tree, ts.tree))
@@ -191,57 +300,148 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     updated(key, value)
   }
 
+  /** Returns a tree map containing exactly those entries of this map whose keys lie within the
+   *  given optional bounds.
+   *
+   *  Unlike the ranged projection of a mutable `TreeMap`, the result is an independent map,
+   *  built by extracting the requested range from the underlying tree.
+   *
+   *  @param from the lower bound (inclusive) on keys wrapped in a `Some`, or `None` if there is
+   *              no lower bound
+   *  @param until the upper bound (exclusive) on keys wrapped in a `Some`, or `None` if there is
+   *               no upper bound
+   *  @return a tree map with the entries in the given key range; this map itself if neither
+   *          bound is given
+   */
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = newMapOrSelf(RB.rangeImpl(tree, from, until))
 
+  /** Returns the entry with the smallest key greater than or equal to `key`, if any.
+   *
+   *  @param key the lower bound (inclusive) for the key lookup
+   *  @return a `Some` containing the entry with the smallest key greater than or equal to `key`,
+   *          or `None` if no such entry exists
+   */
   override def minAfter(key: K): Option[(K, V)] = RB.minAfter(tree, key) match {
     case null => Option.empty
     case x => Some((x.key, x.value))
   }
 
+  /** Returns the entry with the largest key strictly less than `key`, if any.
+   *
+   *  @param key the upper bound (exclusive) for the key lookup
+   *  @return a `Some` containing the entry with the largest key strictly less than `key`,
+   *          or `None` if no such entry exists
+   */
   override def maxBefore(key: K): Option[(K, V)] = RB.maxBefore(tree, key) match {
     case null => Option.empty
     case x => Some((x.key, x.value))
   }
 
+  /** Returns a tree map containing exactly those entries of this map whose keys are greater
+   *  than or equal to `from` and less than `until`.
+   *
+   *  @param from the lower bound (inclusive) on the keys of the entries to keep
+   *  @param until the upper bound (exclusive) on the keys of the entries to keep
+   *  @return a tree map with the entries in the given key range
+   */
   override def range(from: K, until: K): TreeMap[K,V] = newMapOrSelf(RB.range(tree, from, until))
 
+  /** Applies `f` to each key-value pair of this tree map, in ascending order of keys.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function to apply to each key-value pair
+   */
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
+  /** Applies the two-argument function `f` to each key and associated value of this tree map,
+   *  in ascending order of keys.
+   *
+   *  Unlike `foreach`, does not allocate a tuple per entry.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function to apply to each key and value
+   */
   override def foreachEntry[U](f: (K, V) => U): Unit = RB.foreachEntry(tree, f)
+  /** Returns the number of entries in this tree map. Takes constant time: subtree sizes are cached. */
   override def size: Int = RB.count(tree)
+  /** Returns the number of entries in this tree map; never `-1`, since the size is known in constant time. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this tree map contains no entries. */
   override def isEmpty = size == 0
 
+  /** Returns the smallest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def firstKey: K = RB.smallest(tree).key
 
+  /** Returns the largest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def lastKey: K = RB.greatest(tree).key
 
+  /** Returns the entry with the smallest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def head: (K, V) = {
     val smallest = RB.smallest(tree)
     (smallest.key, smallest.value)
   }
 
+  /** Returns the entry with the largest key of this tree map.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def last: (K, V) = {
     val greatest = RB.greatest(tree)
     (greatest.key, greatest.value)
   }
 
+  /** Returns a tree map containing all entries of this map except the one with the smallest key.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def tail: TreeMap[K, V] = new TreeMap(RB.tail(tree))
 
+  /** Returns a tree map containing all entries of this map except the one with the largest key.
+   *
+   *  @throws NoSuchElementException if this tree map is empty
+   */
   override def init: TreeMap[K, V] = new TreeMap(RB.init(tree))
 
+  /** Returns a tree map containing all entries of this map except the `n` entries with the
+   *  smallest keys.
+   *
+   *  @param n the number of entries to drop
+   *  @return a tree map without the first `n` entries in key order; this map itself if
+   *          `n <= 0`, or the empty map if `n >= size`
+   */
   override def drop(n: Int): TreeMap[K, V] = {
     if (n <= 0) this
     else if (n >= size) empty
     else new TreeMap(RB.drop(tree, n))
   }
 
+  /** Returns a tree map containing only the `n` entries of this map with the smallest keys.
+   *
+   *  @param n the number of entries to take
+   *  @return a tree map with the first `n` entries in key order; the empty map if `n <= 0`,
+   *          or this map itself if `n >= size`
+   */
   override def take(n: Int): TreeMap[K, V] = {
     if (n <= 0) empty
     else if (n >= size) this
     else new TreeMap(RB.take(tree, n))
   }
 
+  /** Returns a tree map containing the entries of this map at indices `from` until `until`,
+   *  where indices count entries in ascending order of keys, starting from zero.
+   *
+   *  @param from the index of the first entry to keep
+   *  @param until the index one past the last entry to keep
+   */
   override def slice(from: Int, until: Int) = {
     if (until <= from) empty
     else if (from <= 0) take(until)
@@ -249,8 +449,19 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     else new TreeMap(RB.slice(tree, from, until))
   }
 
+  /** Returns a tree map containing all entries of this map except the `n` entries with the
+   *  largest keys.
+   *
+   *  @param n the number of entries to drop; treated as `0` if negative
+   *  @return a tree map without the last `n` entries in key order
+   */
   override def dropRight(n: Int): TreeMap[K, V] = take(size - math.max(n, 0))
 
+  /** Returns a tree map containing only the `n` entries of this map with the largest keys.
+   *
+   *  @param n the number of entries to take; treated as `0` if negative
+   *  @return a tree map with the last `n` entries in key order
+   */
   override def takeRight(n: Int): TreeMap[K, V] = drop(size - math.max(n, 0))
 
   private def countWhile(p: ((K, V)) => Boolean): Int = {
@@ -260,20 +471,59 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     result
   }
 
+  /** Returns a tree map containing all entries of this map except its longest prefix, in
+   *  ascending order of keys, of entries that satisfy `p`.
+   *
+   *  @param p the predicate used to test entries
+   *  @return a tree map without the longest prefix of entries satisfying `p`
+   */
   override def dropWhile(p: ((K, V)) => Boolean): TreeMap[K, V] = drop(countWhile(p))
 
+  /** Returns a tree map containing the longest prefix of this map, in ascending order of keys,
+   *  of entries that satisfy `p`.
+   *
+   *  @param p the predicate used to test entries
+   *  @return a tree map with the longest prefix of entries satisfying `p`
+   */
   override def takeWhile(p: ((K, V)) => Boolean): TreeMap[K, V] = take(countWhile(p))
 
+  /** Returns a pair of tree maps: the longest prefix of this map, in ascending order of keys,
+   *  of entries that satisfy `p`, and the rest of this map.
+   *
+   *  @param p the predicate used to test entries
+   *  @return a pair of the longest prefix of entries satisfying `p` and the remaining entries
+   */
   override def span(p: ((K, V)) => Boolean): (TreeMap[K, V], TreeMap[K, V]) = splitAt(countWhile(p))
 
+  /** Returns a tree map containing exactly those entries of this map that satisfy the
+   *  predicate `f`.
+   *
+   *  @param f the predicate used to test entries
+   *  @return a tree map with the entries satisfying `f`; this map itself if every entry
+   *          satisfies it
+   */
   override def filter(f: ((K, V)) => Boolean): TreeMap[K, V] =
     newMapOrSelf(RB.filterEntries[K, V](tree, (k, v) => f((k, v))))
 
+  /** Returns a pair of tree maps: the entries of this map that satisfy the predicate `p`, and
+   *  those that do not.
+   *
+   *  @param p the predicate used to test entries
+   *  @return a pair of tree maps with the entries that satisfy `p` and those that do not
+   */
   override def partition(p: ((K, V)) => Boolean): (TreeMap[K, V], TreeMap[K, V]) = {
     val (l, r) = RB.partitionEntries[K, V](tree, (k, v) => p((k, v)))
     (newMapOrSelf(l), newMapOrSelf(r))
   }
 
+  /** Returns a tree map with the same keys as this map, where each value is replaced by the
+   *  result of applying `f` to the key and the current value.
+   *
+   *  @tparam W the value type of the resulting map
+   *  @param f the transformation to apply to each key-value pair
+   *  @return a tree map with transformed values; this map itself if `f` returns the very same
+   *          (referentially identical) value for every entry
+   */
   override def transform[W](f: (K, V) => W): TreeMap[K, W] = {
     val t2 = RB.transform[K, V, W](tree, f)
     if(t2 eq tree) this.asInstanceOf[TreeMap[K, W]]
@@ -295,11 +545,23 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
       }
     }
   }
+  /** Returns `true` if `obj` is a map containing the same key-value pairs as this map.
+   *
+   *  If `obj` is a `TreeMap` with the same ordering, this is decided by an efficient structural
+   *  comparison in which keys are compared with the ordering and values with `==`; otherwise
+   *  falls back to the general map equality, which tests the sizes and then looks each key of
+   *  this map up in `obj`. That lookup uses whatever notion of key equality `obj` implements,
+   *  so comparing against a `TreeMap` with a different ordering compares by that ordering, and
+   *  the result need not be symmetric.
+   *
+   *  @param obj the object to compare with
+   */
   override def equals(obj: Any): Boolean = obj match {
     case that: TreeMap[K @unchecked, ?] if ordering == that.ordering => RB.entriesEqual(tree, that.tree)
     case _ => super.equals(obj)
   }
 
+  /** The prefix of this map's string representation: `"TreeMap"`. */
   override protected def className = "TreeMap"
 }
 
@@ -310,8 +572,26 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
 @SerialVersionUID(3L)
 object TreeMap extends SortedMapFactory[TreeMap] {
 
+  /** Returns an empty tree map, using the implicit ordering on keys.
+   *
+   *  @tparam K the key type of the map, which must have an implicit `Ordering`
+   *  @tparam V the value type of the map
+   */
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap()
 
+  /** Returns a tree map containing the key-value pairs of `it`, ordered by `ordering`.
+   *
+   *  If `it` is already a `TreeMap` with the same ordering, `it` itself is returned. If it is
+   *  another sorted map with the same ordering, the tree is built directly from its iterator in
+   *  linear time. Otherwise the pairs are inserted one by one; if `it` contains several pairs
+   *  with the same key, the value of the last one is retained.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param it the collection of key-value pairs
+   *  @param ordering the ordering used to compare keys
+   *  @return a tree map with the entries of `it`
+   */
   def from[K, V](it: IterableOnce[(K, V)]^)(implicit ordering: Ordering[K]): TreeMap[K, V] =
     (it: @unchecked) match {
       case tm: TreeMap[K, V] if ordering == tm.ordering => tm
@@ -327,6 +607,15 @@ object TreeMap extends SortedMapFactory[TreeMap] {
         new TreeMap[K, V](t)
     }
 
+  /** Returns a new builder for tree maps ordered by `ordering`.
+   *
+   *  The builder can be reused after calling `result()`.
+   *
+   *  @tparam K the key type of the maps built
+   *  @tparam V the value type of the maps built
+   *  @param ordering the ordering used to compare keys
+   *  @return a reusable builder producing a `TreeMap[K, V]`
+   */
   def newBuilder[K, V](implicit ordering: Ordering[K]): ReusableBuilder[(K, V), TreeMap[K, V]] = new TreeMapBuilder[K, V]
 
   private class TreeMapBuilder[K, V](implicit ordering: Ordering[K])

--- a/library/src/scala/collection/immutable/TreeSeqMap.scala
+++ b/library/src/scala/collection/immutable/TreeSeqMap.scala
@@ -49,6 +49,7 @@ final class TreeSeqMap[K, +V] private (
     private val ordering: TreeSeqMap.Ordering[K],
     private val mapping: TreeSeqMap.Mapping[K, V],
     private val ordinal: Int,
+    /** The ordering this map maintains for traversal: by insertion or by modification. */
     val orderedBy: TreeSeqMap.OrderBy)
   extends AbstractMap[K, V]
     with SeqMap[K, V]
@@ -59,14 +60,19 @@ final class TreeSeqMap[K, +V] private (
 
   import TreeSeqMap._
 
+  /** The name of this collection class, used as the prefix in its `toString` representation. */
   override protected def className: String = "TreeSeqMap"
 
+  /** Returns the [[TreeSeqMap$ TreeSeqMap]] companion object as the factory for maps of this kind. */
   override def mapFactory: MapFactory[TreeSeqMap] = TreeSeqMap
 
+  /** The number of key-value pairs in this map. */
   override val size = mapping.size
 
+  /** Returns the size of this map: the size is always known. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this map contains no key-value pairs, `false` otherwise. */
   override def isEmpty = size == 0
 
   /*
@@ -75,12 +81,38 @@ final class TreeSeqMap[K, +V] private (
   override def empty = TreeSeqMap.empty[K, V](orderedBy)
   */
 
+  /** Returns a map with the same bindings that maintains the given ordering.
+   *
+   *  Positions already assigned to the existing bindings are kept; only the
+   *  policy for future updates changes. Returns this map itself if it is
+   *  already ordered by `orderBy`.
+   *
+   *  @param orderBy whether the returned map orders its entries by insertion or
+   *                 by modification
+   *  @return a map with the same bindings, ordered by `orderBy`
+   */
   def orderingBy(orderBy: OrderBy): TreeSeqMap[K, V] = {
     if (orderBy == this.orderedBy) this
     else if (isEmpty) TreeSeqMap.empty(orderBy)
     else new TreeSeqMap(ordering, mapping, ordinal, orderBy)
   }
 
+  /** Returns a map with `key` bound to `value`, replacing any existing binding
+   *  for `key`.
+   *
+   *  Under insertion ordering an already-present key keeps its position; under
+   *  modification ordering it moves to the end. A new key is placed at the end
+   *  in either mode. When the ordinal counter is exhausted (after 2^32
+   *  insertions/modifications) and a fresh position is needed, the whole map is
+   *  rebuilt first, which is expensive but rare.
+   *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a map containing the bindings of this map and the binding of `key`
+   *          to `value`
+   */
   def updated[V1 >: V](key: K, value: V1): TreeSeqMap[K, V1] = {
     mapping.get(key) match {
       case e if ordinal == -1 && (orderedBy == OrderBy.Modification || e.isEmpty) =>
@@ -109,6 +141,14 @@ final class TreeSeqMap[K, +V] private (
     }
   }
 
+  /** Returns a map without any binding for the given key, or this map itself if
+   *  the key is not present.
+   *
+   *  The relative order of the remaining entries is unchanged.
+   *
+   *  @param key the key to remove
+   *  @return a map containing the bindings of this map except for `key`
+   */
   def removed(key: K): TreeSeqMap[K, V] = {
     mapping.get(key) match {
       case Some((o, _)) =>
@@ -122,6 +162,14 @@ final class TreeSeqMap[K, +V] private (
     }
   }
 
+  /** Returns a map in which the given key is moved to the end of the traversal
+   *  order, keeping its value, regardless of the ordering mode in use.
+   *
+   *  Returns this map itself if the key is not present.
+   *
+   *  @param key the key to move to the end
+   *  @return a map with the same bindings, with `key` traversed last
+   */
   def refresh(key: K): TreeSeqMap[K, V] = {
     mapping.get(key) match {
       case Some((o, _)) =>
@@ -136,8 +184,17 @@ final class TreeSeqMap[K, +V] private (
     }
   }
 
+  /** Optionally returns the value associated with the given key, looked up in
+   *  the underlying hash map without traversing the ordering.
+   *
+   *  @param key the key to look up
+   *  @return `Some(value)` if this map binds `key` to `value`, `None` otherwise
+   */
   def get(key: K): Option[V] = mapping.get(key).map(value)
 
+  /** Returns an iterator over the key/value pairs of this map in traversal
+   *  (insertion or modification) order.
+   */
   def iterator: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
     private val iter = ordering.iterator
 
@@ -146,6 +203,9 @@ final class TreeSeqMap[K, +V] private (
     override def next(): (K, V) = binding(iter.next())
   }
 
+  /** Returns an iterator over the keys of this map in traversal (insertion or
+   *  modification) order.
+   */
   override def keysIterator: Iterator[K] = new AbstractIterator[K] {
     private val iter = ordering.iterator
 
@@ -154,6 +214,9 @@ final class TreeSeqMap[K, +V] private (
     override def next(): K = iter.next()
   }
 
+  /** Returns an iterator over the values of this map in traversal (insertion or
+   *  modification) order of their keys.
+   */
   override def valuesIterator: Iterator[V] = new AbstractIterator[V] {
     private val iter = ordering.iterator
 
@@ -162,26 +225,64 @@ final class TreeSeqMap[K, +V] private (
     override def next(): V = value(binding(iter.next()))
   }
 
+  /** Returns `true` if this map has a binding for the given key, checked in the
+   *  underlying hash map without traversing the ordering.
+   *
+   *  @param key the key to test
+   *  @return `true` if `key` is bound in this map, `false` otherwise
+   */
   override def contains(key: K): Boolean = mapping.contains(key)
 
+  /** Returns the first key/value pair in traversal order.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def head: (K, V) = binding(ordering.head)
 
+  /** Optionally returns the first key/value pair in traversal order, or `None`
+   *  if this map is empty.
+   */
   override def headOption = ordering.headOption.map(binding)
 
+  /** Returns the last key/value pair in traversal order.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def last: (K, V) = binding(ordering.last)
 
+  /** Optionally returns the last key/value pair in traversal order, or `None`
+   *  if this map is empty.
+   */
   override def lastOption: Option[(K, V)] = ordering.lastOption.map(binding)
 
+  /** Returns a map without the first entry in traversal order.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def tail: TreeSeqMap[K, V] = {
     val (head, tail) = ordering.headTail
     new TreeSeqMap(tail, mapping.removed(head), ordinal, orderedBy)
   }
 
+  /** Returns a map without the last entry in traversal order.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def init: TreeSeqMap[K, V] = {
     val (init, last) = ordering.initLast
     new TreeSeqMap(init, mapping.removed(last), ordinal, orderedBy)
   }
 
+  /** Returns a map with the entries at positions `from` until `until` (in
+   *  traversal order), keeping their relative order.
+   *
+   *  Out-of-range arguments are clamped: a negative `from` counts as 0 and an
+   *  `until` beyond the size as the size; an empty range yields an empty map.
+   *
+   *  @param from the position of the first entry to keep
+   *  @param until the position one past the last entry to keep
+   *  @return a map containing the entries in the given position range
+   */
   override def slice(from: Int, until: Int): TreeSeqMap[K, V] = {
     val sz = size
     if (sz == 0 || from >= until) TreeSeqMap.empty[K, V](orderedBy)
@@ -224,6 +325,17 @@ final class TreeSeqMap[K, +V] private (
     }
   }
 
+  /** Returns a map built by applying `f` to each key/value pair of this map, in
+   *  traversal order.
+   *
+   *  The result keeps this map's ordering mode; if `f` produces the same key
+   *  more than once, the binding produced later overwrites the earlier one.
+   *
+   *  @tparam K2 the type of the keys in the resulting map
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function applied to each key/value pair
+   *  @return a map containing the transformed pairs
+   */
   override def map[K2, V2](f: ((K, V)) => (K2, V2)): TreeSeqMap[K2, V2] = {
     val bdr = newBuilder[K2, V2](orderedBy)
     val iter = ordering.iterator
@@ -236,6 +348,18 @@ final class TreeSeqMap[K, +V] private (
     bdr.result()
   }
 
+  /** Returns a map built by applying `f` to each key/value pair of this map, in
+   *  traversal order, and collecting all the pairs it produces.
+   *
+   *  The result keeps this map's ordering mode; if the same key is produced
+   *  more than once, the binding produced later overwrites the earlier one.
+   *
+   *  @tparam K2 the type of the keys in the resulting map
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param f the function returning a collection of key/value pairs for each
+   *           pair of this map
+   *  @return a map containing all the pairs produced by `f`
+   */
   override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^): TreeSeqMap[K2, V2] = {
     val bdr = newBuilder[K2, V2](orderedBy)
     val iter = ordering.iterator
@@ -251,6 +375,17 @@ final class TreeSeqMap[K, +V] private (
     bdr.result()
   }
 
+  /** Returns a map built from the key/value pairs on which `pf` is defined,
+   *  transformed by `pf`, in traversal order.
+   *
+   *  The result keeps this map's ordering mode; if `pf` produces the same key
+   *  more than once, the binding produced later overwrites the earlier one.
+   *
+   *  @tparam K2 the type of the keys in the resulting map
+   *  @tparam V2 the type of the values in the resulting map
+   *  @param pf the partial function applied to each pair on which it is defined
+   *  @return a map containing the transformed pairs
+   */
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^): TreeSeqMap[K2, V2] = {
     val bdr = newBuilder[K2, V2](orderedBy)
     val iter = ordering.iterator
@@ -262,6 +397,19 @@ final class TreeSeqMap[K, +V] private (
     bdr.result()
   }
 
+  /** Returns a map containing the bindings of this map followed by those of
+   *  `suffix`.
+   *
+   *  Pairs of `suffix` are added under this map's ordering mode: a key already
+   *  present keeps its position under insertion ordering (its value updated) and
+   *  moves to the end under modification ordering; new keys are appended in the
+   *  order produced by `suffix`.
+   *
+   *  @tparam V2 the type of the values in the resulting map, a supertype of this
+   *             map's value type
+   *  @param suffix the collection of key/value pairs to add
+   *  @return a map containing the combined bindings
+   */
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): TreeSeqMap[K, V2] = {
     var ong: Ordering[K] = ordering
     var mng: Mapping[K, V2] = mapping
@@ -290,6 +438,10 @@ final class TreeSeqMap[K, +V] private (
   @`inline` private def binding(k: K) = mapping(k).copy(_1 = k)
 }
 object TreeSeqMap extends MapFactory[TreeSeqMap] {
+  /** The ordering modes a [[TreeSeqMap]] can maintain: [[OrderBy.Insertion]]
+   *  keeps a key at its original position when it is updated, while
+   *  [[OrderBy.Modification]] moves an updated key to the end.
+   */
   sealed trait OrderBy
   object OrderBy {
     case object Insertion extends OrderBy
@@ -298,13 +450,40 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
 
   private val EmptyByInsertion = new TreeSeqMap[Nothing, Nothing](Ordering.empty, HashMap.empty, 0, OrderBy.Insertion)
   private val EmptyByModification = new TreeSeqMap[Nothing, Nothing](Ordering.empty, HashMap.empty, 0, OrderBy.Modification)
+  /** The empty map, ordered by insertion. */
   val Empty = EmptyByInsertion
+  /** Returns the empty map, ordered by insertion.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return the empty `TreeSeqMap`
+   */
   def empty[K, V]: TreeSeqMap[K, V] = empty(OrderBy.Insertion)
+  /** Returns the empty map with the given ordering mode.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param orderBy whether the map orders its entries by insertion or by
+   *                 modification
+   *  @return the empty `TreeSeqMap` ordered by `orderBy`
+   */
   def empty[K, V](orderBy: OrderBy): TreeSeqMap[K, V] = {
     if (orderBy == OrderBy.Modification) EmptyByModification
     else EmptyByInsertion
   }.asInstanceOf[TreeSeqMap[K, V]]
 
+  /** Returns a `TreeSeqMap`, ordered by insertion, containing the key/value
+   *  pairs of the given collection.
+   *
+   *  Returns the collection itself if it is already a `TreeSeqMap`; otherwise
+   *  the pairs are inserted in iteration order, later pairs overwriting earlier
+   *  ones with the same key.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the collection of key/value pairs
+   *  @return a `TreeSeqMap` containing the pairs of `it`
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): TreeSeqMap[K, V] =
     (it: @unchecked) match {
       case om: TreeSeqMap[K, V] => om
@@ -313,9 +492,34 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
 
   @inline private def increment(ord: Int) = if (ord == Int.MaxValue) Int.MinValue else ord + 1
 
+  /** Returns a builder for a `TreeSeqMap` ordered by insertion.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return a fresh builder
+   */
   def newBuilder[K, V]: mutable.Builder[(K, V), TreeSeqMap[K, V]] = newBuilder(OrderBy.Insertion)
+  /** Returns a builder for a `TreeSeqMap` with the given ordering mode.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param orderedBy whether the built map orders its entries by insertion or
+   *                   by modification
+   *  @return a fresh builder
+   */
   def newBuilder[K, V](orderedBy: OrderBy): mutable.Builder[(K, V), TreeSeqMap[K, V]] = new Builder[K, V](orderedBy)
 
+  /** A builder for [[TreeSeqMap]], accumulating entries with the given ordering
+   *  mode.
+   *
+   *  After `result()` has been called, further additions go through the built
+   *  map's functional `updated`, so the builder remains usable.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param orderedBy whether the built map orders its entries by insertion or
+   *                   by modification
+   */
   final class Builder[K, V](orderedBy: OrderBy) extends mutable.Builder[(K, V), TreeSeqMap[K, V]] {
     private val bdr = new MapBuilderImpl[K, (Int, V)]
     private var ong = Ordering.empty[K]
@@ -323,7 +527,21 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
     @annotation.stableNull
     private var aliased: TreeSeqMap[K, V] | Null = null
 
+    /** Adds the given key/value pair to this builder.
+     *
+     *  @param elem the key/value pair to add
+     *  @return this builder
+     */
     override def addOne(elem: (K, V)): this.type = addOne(elem._1, elem._2)
+    /** Adds a binding of `key` to `value` to this builder.
+     *
+     *  Under insertion ordering an already-added key keeps its position (its
+     *  value updated); under modification ordering it moves to the end.
+     *
+     *  @param key the key to add or update
+     *  @param value the value to associate with `key`
+     *  @return this builder
+     */
     def addOne(key: K, value: V): this.type = {
       if (aliased ne null) {
         aliased = aliased.updated(key, value)
@@ -345,6 +563,9 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       this
     }
 
+    /** Clears the contents of this builder, making it ready to build a fresh
+     *  map.
+     */
     override def clear(): Unit = {
       ong = Ordering.empty
       ord = 0
@@ -352,6 +573,11 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       aliased = null
     }
 
+    /** Returns the map built from the entries added so far.
+     *
+     *  Repeated calls return the same map; additions made after this call go
+     *  through that map's functional `updated`.
+     */
     override def result(): TreeSeqMap[K, V] = {
       if (aliased eq null) {
         aliased = new TreeSeqMap(ong, bdr.result(), ord, orderedBy)
@@ -468,19 +694,44 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
     }
   }
 
+  /** The modification-order trie of a [[TreeSeqMap]]: a big-endian patricia
+   *  trie (an adapted version of [[IntMap]]) keyed by the map's ordinal
+   *  counter, whose in-order traversal yields values in ascending unsigned
+   *  ordinal order, i.e. oldest first.
+   *
+   *  Since ordinals are assigned by an increasing counter that wraps from
+   *  `Int.MaxValue` to `Int.MinValue`, unsigned order coincides with
+   *  assignment order.
+   *
+   *  @tparam T the type of the values (the map keys of the owning `TreeSeqMap`)
+   */
   sealed abstract class Ordering[+T] {
     import Ordering._
     import scala.annotation.tailrec
     import scala.collection.generic.BitOperations.Int._
 
+    /** Returns the multi-line debug rendering of this trie. */
     override final def toString(): String = format
+    /** Returns a multi-line rendering of this trie, one node per line, drawn as
+     *  a tree.
+     */
     final def format: String = {
       val sb = new StringBuilder
       format(sb, "", "")
       sb.toString()
     }
+    /** Appends this node's debug representation to `sb`.
+     *
+     *  @param sb the builder to append to
+     *  @param prefix the prefix for this node's line
+     *  @param subPrefix the prefix for child lines
+     */
     protected def format(sb: StringBuilder, prefix: String, subPrefix: String): Unit
 
+    /** Returns the value at the lowest ordinal, in unsigned order.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     @tailrec
     final def head: T = this match {
       case Zero => throw new NoSuchElementException("head of empty map")
@@ -488,6 +739,9 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       case Bin(_, _, l, _) => l.head
     }
 
+    /** Optionally returns the value at the lowest ordinal, in unsigned order,
+     *  or `None` if this ordering is empty.
+     */
     @tailrec
     final def headOption: Option[T] = this match {
       case Zero => None
@@ -495,6 +749,10 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       case Bin(_, _, l, _) => l.headOption
     }
 
+    /** Returns the value at the highest ordinal, in unsigned order.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     @tailrec
     final def last: T = this match {
       case Zero => throw new NoSuchElementException("last of empty map")
@@ -502,6 +760,9 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       case Bin(_, _, _, r) => r.last
     }
 
+    /** Optionally returns the value at the highest ordinal, in unsigned order,
+     *  or `None` if this ordering is empty.
+     */
     @tailrec
     final def lastOption: Option[T] = this match {
       case Zero => None
@@ -509,6 +770,9 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       case Bin(_, _, _, r) => r.lastOption
     }
 
+    /** Returns the highest ordinal in this ordering, in unsigned order, or 0 if
+     *  it is empty.
+     */
     @tailrec
     final def ordinal: Int = this match {
       case Zero => 0
@@ -516,12 +780,21 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
       case Bin(_, _, _, r) => r.ordinal
     }
 
+    /** Returns an ordering without the entry at the lowest ordinal.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     final def tail: Ordering[T] = this match {
       case Zero => throw new NoSuchElementException("tail of empty map")
       case Tip(_, _) => Zero
       case Bin(p, m, l, r) => bin(p, m, l.tail, r)
     }
 
+    /** Returns the value at the lowest ordinal together with the ordering
+     *  without that entry.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     final def headTail: (T, Ordering[T]) = this match {
       case Zero => throw new NoSuchElementException("init of empty map")
       case Tip(_, v) => (v, Zero)
@@ -530,6 +803,10 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         (head, bin(p, m, tail, r))
     }
 
+    /** Returns an ordering without the entry at the highest ordinal.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     final def init: Ordering[T] = this match {
       case Zero => throw new NoSuchElementException("init of empty map")
       case Tip(_, _) => Zero
@@ -537,6 +814,11 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         bin(p, m, l, r.init)
     }
 
+    /** Returns the ordering without the entry at the highest ordinal together
+     *  with the value of that entry.
+     *
+     *  @throws NoSuchElementException if this ordering is empty
+     */
     final def initLast: (Ordering[T], T) = this match {
       case Zero => throw new NoSuchElementException("init of empty map")
       case Tip(_, v) => (Zero, v)
@@ -545,11 +827,26 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         (bin(p, m, l, init), last)
     }
 
+    /** Returns an iterator over the values of this ordering in ascending
+     *  unsigned ordinal order.
+     */
     final def iterator: Iterator[T] = this match {
       case Zero => Iterator.empty
       case _ => new Iterator(this)
     }
 
+    /** Returns an ordering with `value` stored at `ordinal`, replacing any value
+     *  already stored at that ordinal.
+     *
+     *  Unlike `append`, the ordinal may lie anywhere relative to the existing
+     *  entries.
+     *
+     *  @tparam S the type of the values in the resulting ordering
+     *  @param ordinal the ordinal to store at
+     *  @param value the value to store
+     *  @return an ordering containing the entries of this one and `value` at
+     *          `ordinal`
+     */
     final def include[S >: T](ordinal: Int, value: S): Ordering[S] = this match {
       case Zero =>
         Tip(ordinal, value)
@@ -562,6 +859,23 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         else Bin(p, m, l, r.include(ordinal, value))
     }
 
+    /** Returns an ordering with `value` stored at `ordinal`, which is meant to be
+     *  greater (in unsigned order) than the current maximum ordinal.
+     *
+     *  That precondition is only partly enforced. A smaller `ordinal` throws only
+     *  where it belongs on the low side of a `Bin` that already covers it; where it
+     *  falls outside the prefix of a `Bin`, or where this ordering is a `Tip` or is
+     *  empty, it is joined in like any other ordinal, and an ordinal equal to a
+     *  `Tip`'s replaces its value.
+     *
+     *  @tparam S the type of the values in the resulting ordering
+     *  @param ordinal the ordinal to store at
+     *  @param value the value to store
+     *  @return an ordering containing the entries of this one and `value` at
+     *          `ordinal`
+     *  @throws IllegalArgumentException if `ordinal` falls within the prefix of a
+     *          `Bin` on the side already covered by its lower subtree
+     */
     final def append[S >: T](ordinal: Int, value: S): Ordering[S] = this match {
       case Zero =>
         Tip(ordinal, value)
@@ -599,6 +913,13 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         }
     }
 
+    /** Returns an ordering without any entry at the given ordinal, or this
+     *  ordering unchanged if no entry is stored there.
+     *
+     *  @param ordinal the ordinal to remove
+     *  @return an ordering containing the entries of this one except at
+     *          `ordinal`
+     */
     final def exclude(ordinal: Int): Ordering[T] = this match {
       case Zero =>
         Zero
@@ -611,6 +932,13 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
         else bin(p, m, l, r.exclude(ordinal))
     }
 
+    /** Returns the ordering of the first `n` entries (in unsigned ordinal
+     *  order) and the ordering of the rest, both keeping their original
+     *  ordinals.
+     *
+     *  @param n the number of entries in the first ordering
+     *  @return a pair of the first `n` entries and the remaining entries
+     */
     final def splitAt(n: Int): (Ordering[T], Ordering[T]) = {
       var rear = Ordering.empty[T]
       var i = n

--- a/library/src/scala/collection/immutable/TreeSet.scala
+++ b/library/src/scala/collection/immutable/TreeSet.scala
@@ -49,24 +49,57 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")
 
+  /** Creates an empty tree set.
+   *
+   *  @param ordering the ordering used to compare elements
+   */
   def this()(implicit ordering: Ordering[A]) = this(null)(using ordering)
 
+  /** Returns the `TreeSet` companion object, the factory used by transformation methods to build new tree sets. */
   override def sortedIterableFactory: TreeSet.type = TreeSet
 
   private def newSetOrSelf(t: RB.Tree[A, Any] | Null) = if(t eq tree) this else new TreeSet[A](t)
 
+  /** Returns the number of elements in this tree set. Takes constant time: subtree sizes are cached. */
   override def size: Int = RB.count(tree)
 
+  /** Returns `true` if this tree set contains no elements. */
   override def isEmpty = size == 0
 
+  /** Returns the smallest element of this tree set.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def head: A = RB.smallest(tree).key
 
+  /** Returns the largest element of this tree set.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def last: A = RB.greatest(tree).key
 
+  /** Returns a tree set containing all elements of this set except the smallest.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def tail: TreeSet[A] = new TreeSet(RB.tail(tree))
 
+  /** Returns a tree set containing all elements of this set except the largest.
+   *
+   *  @throws NoSuchElementException if this tree set is empty
+   */
   override def init: TreeSet[A] = new TreeSet(RB.init(tree))
 
+  /** Returns the smallest element of this tree set with respect to `ord`.
+   *
+   *  When `ord` is the same object as this set's ordering, this is the first element, found in
+   *  logarithmic time; otherwise all elements are scanned.
+   *
+   *  @tparam A1 the type on which `ord` is defined, a supertype of the element type
+   *  @param ord the ordering used to compare elements
+   *  @return the smallest element with respect to `ord`
+   *  @throws UnsupportedOperationException if this tree set is empty
+   */
   override def min[A1 >: A](implicit ord: Ordering[A1]): A = {
     if ((ord eq ordering) && nonEmpty) {
       head
@@ -75,6 +108,16 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     }
   }
 
+  /** Returns the largest element of this tree set with respect to `ord`.
+   *
+   *  When `ord` is the same object as this set's ordering, this is the last element, found in
+   *  logarithmic time; otherwise all elements are scanned.
+   *
+   *  @tparam A1 the type on which `ord` is defined, a supertype of the element type
+   *  @param ord the ordering used to compare elements
+   *  @return the largest element with respect to `ord`
+   *  @throws UnsupportedOperationException if this tree set is empty
+   */
   override def max[A1 >: A](implicit ord: Ordering[A1]): A = {
     if ((ord eq ordering) && nonEmpty) {
       last
@@ -83,18 +126,37 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     }
   }
 
+  /** Returns a tree set containing all elements of this set except the `n` smallest.
+   *
+   *  @param n the number of elements to drop
+   *  @return a tree set without the first `n` elements in ascending order; this set itself if
+   *          `n <= 0`, or the empty set if `n >= size`
+   */
   override def drop(n: Int): TreeSet[A] = {
     if (n <= 0) this
     else if (n >= size) empty
     else new TreeSet(RB.drop(tree, n))
   }
 
+  /** Returns a tree set containing only the `n` smallest elements of this set.
+   *
+   *  @param n the number of elements to take
+   *  @return a tree set with the first `n` elements in ascending order; the empty set if
+   *          `n <= 0`, or this set itself if `n >= size`
+   */
   override def take(n: Int): TreeSet[A] = {
     if (n <= 0) empty
     else if (n >= size) this
     else new TreeSet(RB.take(tree, n))
   }
 
+  /** Returns a tree set containing the elements of this set at indices `from` until `until`,
+   *  where indices count elements in ascending order, starting from zero.
+   *
+   *  @param from the index of the first element to keep
+   *  @param until the index one past the last element to keep
+   *  @return a tree set with the elements at the given indices
+   */
   override def slice(from: Int, until: Int): TreeSet[A] = {
     if (until <= from) empty
     else if (from <= 0) take(until)
@@ -102,8 +164,18 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     else new TreeSet(RB.slice(tree, from, until))
   }
 
+  /** Returns a tree set containing all elements of this set except the `n` largest.
+   *
+   *  @param n the number of elements to drop; treated as `0` if negative
+   *  @return a tree set without the last `n` elements in ascending order
+   */
   override def dropRight(n: Int): TreeSet[A] = take(size - math.max(n, 0))
 
+  /** Returns a tree set containing only the `n` largest elements of this set.
+   *
+   *  @param n the number of elements to take; treated as `0` if negative
+   *  @return a tree set with the last `n` elements in ascending order
+   */
   override def takeRight(n: Int): TreeSet[A] = drop(size - math.max(n, 0))
 
   private def countWhile(p: A => Boolean): Int = {
@@ -112,28 +184,78 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     while (it.hasNext && p(it.next())) result += 1
     result
   }
+  /** Returns a tree set containing all elements of this set except its longest prefix, in
+   *  ascending order, of elements that satisfy `p`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a tree set without the longest prefix of elements satisfying `p`
+   */
   override def dropWhile(p: A => Boolean): TreeSet[A] = drop(countWhile(p))
 
+  /** Returns a tree set containing the longest prefix of this set, in ascending order, of
+   *  elements that satisfy `p`.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a tree set with the longest prefix of elements satisfying `p`
+   */
   override def takeWhile(p: A => Boolean): TreeSet[A] = take(countWhile(p))
 
+  /** Returns a pair of tree sets: the longest prefix of this set, in ascending order, of
+   *  elements that satisfy `p`, and the rest of this set.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of the longest prefix of elements satisfying `p` and the remaining elements
+   */
   override def span(p: A => Boolean): (TreeSet[A], TreeSet[A]) = splitAt(countWhile(p))
 
+  /** Applies `f` to each element of this tree set, in ascending order.
+   *
+   *  @tparam U the result type of `f`; the results are discarded
+   *  @param f the function to apply to each element
+   */
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
 
+  /** Returns the smallest element greater than or equal to `key`, if any.
+   *
+   *  @param key the lower bound (inclusive) for the lookup
+   *  @return a `Some` containing the smallest element greater than or equal to `key`,
+   *          or `None` if no such element exists
+   */
   override def minAfter(key: A): Option[A] = {
     val v = RB.minAfter(tree, key)
     if (v eq null) Option.empty else Some(v.key)
   }
 
+  /** Returns the largest element strictly less than `key`, if any.
+   *
+   *  @param key the upper bound (exclusive) for the lookup
+   *  @return a `Some` containing the largest element strictly less than `key`,
+   *          or `None` if no such element exists
+   */
   override def maxBefore(key: A): Option[A] = {
     val v = RB.maxBefore(tree, key)
     if (v eq null) Option.empty else Some(v.key)
   }
 
+  /** Returns an iterator over the elements of this tree set, in ascending order. */
   def iterator: Iterator[A] = RB.keysIterator(tree)
 
+  /** Returns an iterator over the elements of this tree set that are greater than or equal to
+   *  `start`, in ascending order.
+   *
+   *  @param start the lower bound (inclusive) on the elements to return
+   */
   def iteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
+  /** Returns a stepper over the elements of this tree set, in ascending order.
+   *
+   *  The returned stepper supports efficient splitting for parallel processing. If `shape`
+   *  indicates `Int`, `Long` or `Double` elements, the stepper is a primitive stepper of the
+   *  corresponding type, avoiding boxing.
+   *
+   *  @tparam S the type of the stepper
+   *  @param shape an implicit witness selecting the stepper type for element type `A`
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Tree[A, Any]
@@ -153,8 +275,28 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
    */
   def contains(elem: A): Boolean = RB.contains(tree, elem)
 
+  /** Returns a tree set containing exactly those elements of this set that are greater than or
+   *  equal to `from` and less than `until`.
+   *
+   *  @param from the lower bound (inclusive) on the elements to keep
+   *  @param until the upper bound (exclusive) on the elements to keep
+   *  @return a tree set with the elements in the given range
+   */
   override def range(from: A, until: A): TreeSet[A] = newSetOrSelf(RB.range(tree, from, until))
 
+  /** Returns a tree set containing exactly those elements of this set that lie within the
+   *  given optional bounds.
+   *
+   *  Unlike the ranged projection of a mutable `TreeSet`, the result is an independent set,
+   *  built by extracting the requested range from the underlying tree.
+   *
+   *  @param from the lower bound (inclusive) wrapped in a `Some`, or `None` if there is no
+   *              lower bound
+   *  @param until the upper bound (exclusive) wrapped in a `Some`, or `None` if there is no
+   *               upper bound
+   *  @return a tree set with the elements in the given range; this set itself if neither bound
+   *          is given
+   */
   def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = newSetOrSelf(RB.rangeImpl(tree, from, until))
 
   /** Creates a new `TreeSet` with the entry added.
@@ -173,6 +315,14 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   def excl(elem: A): TreeSet[A] =
     newSetOrSelf(RB.delete(tree, elem))
 
+  /** Returns a tree set containing all elements of this set and all elements of `that`.
+   *
+   *  If `that` is a `TreeSet` with the same ordering, the result is computed by an efficient
+   *  tree union; otherwise the elements of `that` are added one by one.
+   *
+   *  @param that the elements to add
+   *  @return a tree set with the combined elements
+   */
   override def concat(that: collection.IterableOnce[A]^): TreeSet[A] = {
     val t = (that: @unchecked) match {
       case ts: TreeSet[A] if ordering == ts.ordering =>
@@ -186,6 +336,14 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     newSetOrSelf(t)
   }
 
+  /** Returns a tree set containing all elements of this set that are not in `that`.
+   *
+   *  If `that` is a `TreeSet` with the same ordering, the result is computed by an efficient
+   *  tree difference; otherwise the elements of `that` are removed one by one.
+   *
+   *  @param that the elements to remove
+   *  @return a tree set without the given elements
+   */
   override def removedAll(that: IterableOnce[A]^): TreeSet[A] = (that: @unchecked) match {
     case ts: TreeSet[A] if ordering == ts.ordering =>
       newSetOrSelf(RB.difference(tree, ts.tree))
@@ -193,7 +351,12 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
       //TODO add an implementation of a mutable subtractor similar to TreeMap
       //but at least this doesn't create a TreeSet for each iteration
       object sub extends AbstractFunction1[A, Unit] {
+        /** The intermediate tree, with the elements processed so far removed. */
         var currentTree = tree
+        /** Removes `k` from the intermediate tree.
+         *
+         *  @param k the element to remove
+         */
         override def apply(k: A): Unit = {
           currentTree = RB.delete(currentTree, k)
         }
@@ -202,6 +365,14 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
       newSetOrSelf(sub.currentTree)
   }
 
+  /** Returns a tree set containing the elements of this set that are also in `that`.
+   *
+   *  If `that` is a `TreeSet` with the same ordering, the result is computed by an efficient
+   *  tree intersection; otherwise this set is filtered by membership in `that`.
+   *
+   *  @param that the set to intersect with
+   *  @return a tree set with the elements common to this set and `that`
+   */
   override def intersect(that: collection.Set[A]): TreeSet[A] = that match {
     case ts: TreeSet[A] if ordering == ts.ordering =>
       newSetOrSelf(RB.intersect(tree, ts.tree))
@@ -209,6 +380,14 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
       super.intersect(that)
   }
 
+  /** Returns a tree set containing the elements of this set that are not in `that`.
+   *
+   *  If `that` is a `TreeSet` with the same ordering, the result is computed by an efficient
+   *  tree difference; otherwise this set is filtered by non-membership in `that`.
+   *
+   *  @param that the set of elements to exclude
+   *  @return a tree set with the elements of this set that are not in `that`
+   */
   override def diff(that: collection.Set[A]): TreeSet[A] = that match {
     case ts: TreeSet[A] if ordering == ts.ordering =>
       newSetOrSelf(RB.difference(tree, ts.tree))
@@ -216,18 +395,43 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
       super.diff(that)
   }
 
+  /** Returns a tree set containing exactly those elements of this set that satisfy the
+   *  predicate `f`.
+   *
+   *  @param f the predicate used to test elements
+   *  @return a tree set with the elements satisfying `f`; this set itself if every element
+   *          satisfies it
+   */
   override def filter(f: A => Boolean): TreeSet[A] = newSetOrSelf(RB.filterEntries[A, Any](tree, {(k, _) => f(k)}))
 
+  /** Returns a pair of tree sets: the elements of this set that satisfy the predicate `p`, and
+   *  those that do not.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of tree sets with the elements that satisfy `p` and those that do not
+   */
   override def partition(p: A => Boolean): (TreeSet[A], TreeSet[A]) = {
     val (l, r) = RB.partitionEntries(tree, {(a:A, _: Any) => p(a)})
     (newSetOrSelf(l), newSetOrSelf(r))
   }
 
+  /** Returns `true` if `obj` is a set containing the same elements as this set.
+   *
+   *  If `obj` is a `TreeSet` with the same ordering, this is decided by an efficient structural
+   *  comparison in which elements are compared with the ordering; otherwise falls back to the
+   *  general set equality, which tests the sizes and then looks each element of this set up in
+   *  `obj`. That lookup uses whatever notion of equality `obj` implements, so comparing against
+   *  a `TreeSet` with a different ordering compares by that ordering, and the result need not
+   *  be symmetric.
+   *
+   *  @param obj the object to compare with
+   */
   override def equals(obj: Any): Boolean = obj match {
     case that: TreeSet[A @unchecked] if ordering == that.ordering => RB.keysEqual(tree, that.tree)
     case _ => super.equals(obj)
   }
 
+  /** The prefix of this set's string representation: `"TreeSet"`. */
   override protected def className = "TreeSet"
 }
 
@@ -239,8 +443,24 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
 @SerialVersionUID(3L)
 object TreeSet extends SortedIterableFactory[TreeSet] {
 
+  /** Returns an empty tree set, using the implicit ordering on elements.
+   *
+   *  @tparam A the element type of the set, which must have an implicit `Ordering`
+   */
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
+  /** Returns a tree set containing the elements of `it`, ordered by `ordering`.
+   *
+   *  If `it` is already a `TreeSet` with the same ordering, `it` itself is returned. If it is
+   *  another sorted set with the same ordering, or a `Range` ordered compatibly with
+   *  `ordering`, the tree is built directly from its elements in linear time. Otherwise the
+   *  elements are inserted one by one, ignoring duplicates.
+   *
+   *  @tparam E the element type of the set
+   *  @param it the collection of elements
+   *  @param ordering the ordering used to compare elements
+   *  @return a tree set with the elements of `it`
+   */
   def from[E](it: scala.collection.IterableOnce[E]^)(implicit ordering: Ordering[E]): TreeSet[E] =
     (it: @unchecked) match {
       case ts: TreeSet[E] if ordering == ts.ordering => ts
@@ -259,6 +479,14 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
         new TreeSet[E](t)
     }
 
+  /** Returns a new builder for tree sets ordered by `ordering`.
+   *
+   *  The builder can be reused after calling `result()`.
+   *
+   *  @tparam A the element type of the sets built
+   *  @param ordering the ordering used to compare elements
+   *  @return a reusable builder producing a `TreeSet[A]`
+   */
   def newBuilder[A](implicit ordering: Ordering[A]): ReusableBuilder[A, TreeSet[A]] = new TreeSetBuilder[A]
   private class TreeSetBuilder[A](implicit ordering: Ordering[A])
     extends RB.SetHelper[A]

--- a/library/src/scala/collection/immutable/VectorMap.scala
+++ b/library/src/scala/collection/immutable/VectorMap.scala
@@ -41,16 +41,31 @@ final class VectorMap[K, +V] private (
 
   import VectorMap._
 
+  /** The name of this collection class, used as the prefix in its `toString` representation. */
   override protected def className: String = "VectorMap"
 
   private[immutable] def this(fields: Vector[K], underlying: Map[K, (Int, V)]) = this(fields, underlying, 0)
 
+  /** The number of key-value pairs in this map. */
   override val size = underlying.size
 
+  /** Returns the size of this map: the size is always known. */
   override def knownSize: Int = size
 
+  /** Returns `true` if this map contains no key-value pairs, `false` otherwise. */
   override def isEmpty: Boolean = size == 0
 
+  /** Returns a `VectorMap` with `key` bound to `value`.
+   *
+   *  If `key` is already present, the new value replaces the old one at the key's
+   *  existing position in insertion order; otherwise the new binding is appended
+   *  after all existing bindings.
+   *
+   *  @tparam V1 the value type of the returned map, a supertype of `V`
+   *  @param key the key to add or update
+   *  @param value the value to associate with `key`
+   *  @return a `VectorMap` containing the bindings of this map and `key -> value`
+   */
   def updated[V1 >: V](key: K, value: V1): VectorMap[K, V1] = {
     underlying.get(key) match {
       case Some((slot, _)) =>
@@ -60,12 +75,35 @@ final class VectorMap[K, +V] private (
     }
   }
 
+  /** Returns the same map with a given default function, wrapping this map without copying it.
+   *
+   *  The default is only used by `apply` and `default`; methods like `get`, `contains`
+   *  and iteration are unaffected.
+   *
+   *  @tparam V1 the type of the values returned by the default function, a supertype of `V`
+   *  @param d the function mapping keys to values, used for non-present keys
+   *  @return a wrapper of this map with a default function
+   */
   override def withDefault[V1 >: V](d: K -> V1): Map[K, V1] =
     new Map.WithDefault(this, d)
 
+  /** Returns the same map with a given default value, wrapping this map without copying it.
+   *
+   *  The default is only used by `apply` and `default`; methods like `get`, `contains`
+   *  and iteration are unaffected.
+   *
+   *  @tparam V1 the type of the default value, a supertype of `V`
+   *  @param d the value returned for non-present keys
+   *  @return a wrapper of this map with a default value
+   */
   override def withDefaultValue[V1 >: V](d: V1): Map[K, V1] =
     new Map.WithDefault[K, V1](this, _ => d)
 
+  /** Returns the value associated with `key`, if present.
+   *
+   *  @param key the key to look up
+   *  @return `Some` of the value bound to `key`, or `None` if `key` is not in this map
+   */
   def get(key: K): Option[V] = underlying.get(key) match {
     case Some(v) => Some(v._2)
     case None    => None
@@ -80,6 +118,13 @@ final class VectorMap[K, +V] private (
     }
   }
 
+  /** Returns an iterator over the key-value pairs of this map, in insertion order.
+   *
+   *  The iterator traverses the underlying key vector. Slots of removed keys are not
+   *  reclaimed but marked with tombstones, which the iterator skips (a run of adjacent
+   *  tombstones is skipped in a single step), so after many removals a full traversal
+   *  can cost more than the current size of the map suggests.
+   */
   def iterator: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
     private val fieldsLength = fields.length
     private var slot = -1
@@ -118,13 +163,55 @@ final class VectorMap[K, +V] private (
   // No-Op overrides to allow for more efficient steppers in a minor release.
   // Refining the return type to `S with EfficientSplit` is binary compatible.
 
+  /** Returns a [[Stepper]] for the key-value pairs of this map, delegating to the
+   *  inherited implementation.
+   *
+   *  This override exists only so that the return type can later be refined to
+   *  `S with EfficientSplit` in a binary compatible way.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a `Stepper` over the key-value pairs of this map
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[(K, V), S]): S = super.stepper(using shape)
 
+  /** Returns a [[Stepper]] for the keys of this map, delegating to the inherited
+   *  implementation.
+   *
+   *  This override exists only so that the return type can later be refined to
+   *  `S with EfficientSplit` in a binary compatible way.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a `Stepper` over the keys of this map
+   */
   override def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S = super.keyStepper(using shape)
 
+  /** Returns a [[Stepper]] for the values of this map, delegating to the inherited
+   *  implementation.
+   *
+   *  This override exists only so that the return type can later be refined to
+   *  `S with EfficientSplit` in a binary compatible way.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
+   *  @param shape the `StepperShape` that determines the concrete `Stepper` subtype to return
+   *  @return a `Stepper` over the values of this map
+   */
   override def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S = super.valueStepper(using shape)
 
 
+  /** Returns a `VectorMap` without a binding for `key`.
+   *
+   *  An empty map yields the shared empty `VectorMap` without `key` being looked up at
+   *  all, so an empty map that is not that instance is replaced by it. Otherwise, if
+   *  `key` is absent this map itself is returned, and if it is the only key the shared
+   *  empty `VectorMap` is. In the remaining case the key's slot in the underlying vector is not
+   *  reclaimed but replaced by a tombstone, and adjacent tombstones are linked so that
+   *  iteration can skip a whole run of removed slots in one step. The relative order
+   *  of the remaining bindings is unchanged.
+   *
+   *  @param key the key to remove
+   */
   def removed(key: K): VectorMap[K, V] = {
     if (isEmpty) empty
     else {
@@ -168,12 +255,31 @@ final class VectorMap[K, +V] private (
     }
   }
 
+  /** Returns the [[VectorMap$ VectorMap]] companion object as the factory for maps of this kind. */
   override def mapFactory: MapFactory[VectorMap] = VectorMap
 
+  /** Returns `true` if this map has a binding for `key`, `false` otherwise.
+   *
+   *  This is a lookup in the underlying hash map, so it takes amortized effectively
+   *  constant time.
+   *
+   *  @param key the key to test
+   */
   override def contains(key: K): Boolean = underlying.contains(key)
 
+  /** Returns the first key-value pair of this map, in insertion order.
+   *
+   *  @throws NoSuchElementException if this map is empty
+   */
   override def head: (K, V) = iterator.next()
 
+  /** Returns the last key-value pair of this map, in insertion order.
+   *
+   *  Found from the end of the underlying vector, consulting at most one tombstone,
+   *  so this takes effectively constant time.
+   *
+   *  @throws UnsupportedOperationException if this map is empty
+   */
   override def last: (K, V) = {
     if (isEmpty) throw new UnsupportedOperationException("empty.last")
     val lastSlot = fields.length - 1
@@ -186,17 +292,28 @@ final class VectorMap[K, +V] private (
     (last, underlying(last)._2)
   }
 
+  /** Returns `Some` of the last key-value pair of this map, in insertion order, or
+   *  `None` if this map is empty.
+   */
   override def lastOption: Option[(K, V)] = {
     if (isEmpty) None
     else Some(last)
   }
 
+  /** Returns a `VectorMap` with all bindings of this map except the first, in insertion order.
+   *
+   *  @throws UnsupportedOperationException if this map is empty
+   */
   override def tail: VectorMap[K, V] = {
     if (isEmpty) throw new UnsupportedOperationException("empty.tail")
     val (slot, key) = nextValidField(0)
     new VectorMap(fields.drop(slot + 1), underlying - key, dropped + slot + 1)
   }
 
+  /** Returns a `VectorMap` with all bindings of this map except the last, in insertion order.
+   *
+   *  @throws UnsupportedOperationException if this map is empty
+   */
   override def init: VectorMap[K, V] = {
     if (isEmpty) throw new UnsupportedOperationException("empty.init")
     val lastSlot = fields.size - 1
@@ -216,6 +333,11 @@ final class VectorMap[K, +V] private (
   @nowarn("msg=overriding method keys")
   override def keys: Vector[K] = keysIterator.toVector
 
+  /** Returns the values of this map as an `Iterable`, in the insertion order of their keys.
+   *
+   *  The returned collection is a lazy wrapper: its elements are computed from this
+   *  map on each traversal.
+   */
   override def values: Iterable[V] = new Iterable[V] with IterableFactoryDefaults[V, Iterable] {
     override def iterator: Iterator[V] = keysIterator.map(underlying(_)._2)
   }
@@ -233,14 +355,37 @@ object VectorMap extends MapFactory[VectorMap] {
   private final val EmptyMap: VectorMap[Nothing, Nothing] =
     new VectorMap[Nothing, Nothing](Vector.empty[Nothing], HashMap.empty[Nothing, (Int, Nothing)])
 
+  /** An empty [[VectorMap]].
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return the empty `VectorMap` (a single cached instance)
+   */
   def empty[K, V]: VectorMap[K, V] = EmptyMap.asInstanceOf[VectorMap[K, V]]
 
+  /** Returns a [[VectorMap]] containing the key-value pairs of `it`, in its iteration order.
+   *
+   *  If `it` is already a `VectorMap`, it is returned unchanged. If a key occurs more
+   *  than once in `it`, its first occurrence determines its position and its last
+   *  occurrence determines its value.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the source collection of key-value pairs
+   *  @return a `VectorMap[K, V]` with the bindings of `it`
+   */
   def from[K, V](it: collection.IterableOnce[(K, V)]^): VectorMap[K, V] =
     (it: @unchecked) match {
       case vm: VectorMap[K, V] => vm
       case _                   => (newBuilder[K, V] ++= it).result()
     }
 
+  /** Returns a new builder for a [[VectorMap]].
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @return a `Builder` that accepts key-value pairs and produces a `VectorMap[K, V]`
+   */
   def newBuilder[K, V]: mutable.Builder[(K, V), VectorMap[K, V]] = new VectorMapBuilder[K, V]
 }
 

--- a/library/src/scala/collection/immutable/WrappedString.scala
+++ b/library/src/scala/collection/immutable/WrappedString.scala
@@ -39,12 +39,35 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
   with IndexedSeqOps[Char, IndexedSeq, WrappedString]
   with Serializable {
 
+  /** Returns the character at index `i` of the underlying string, in constant time.
+   *
+   *  @param i the index of the character to return
+   *  @throws StringIndexOutOfBoundsException if `i` is negative or not less than the length of this wrapped string
+   */
   def apply(i: Int): Char = self.charAt(i)
 
+  /** Returns a wrapped string holding the characters of `coll`, which is how
+   *  transformation methods such as `filter` build their result.
+   *
+   *  @param coll the characters of the new wrapped string
+   */
   override protected def fromSpecific(coll: scala.collection.IterableOnce[Char]^): WrappedString = WrappedString.fromSpecific(coll)
+  /** Returns a builder that collects characters into a wrapped string, backed by a `StringBuilder`. */
   override protected def newSpecificBuilder: Builder[Char, WrappedString] = WrappedString.newBuilder
+  /** Returns the shared wrapped string of length zero. */
   override def empty: WrappedString = WrappedString.empty
 
+  /** Returns the characters of this wrapped string from `from` up to but not including
+   *  `until`, wrapped in turn.
+   *
+   *  Both indices are clamped to the bounds of this wrapped string, so no exception is
+   *  thrown for out-of-range values; the result is taken with `String.substring`.
+   *
+   *  @param from the index of the first character of the slice
+   *  @param until the index one past the last character of the slice
+   *  @return a wrapped string of the characters at the indices in the interval, empty
+   *          if `until` is not greater than `from`
+   */
   override def slice(from: Int, until: Int): WrappedString = {
     val start = if (from < 0) 0 else from
     if (until <= start || start >= self.length)
@@ -53,10 +76,24 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
     val end = if (until > length) length else until
     new WrappedString(self.substring(start, end))
   }
+  /** Returns the number of characters in this wrapped string, in constant time. */
   override def length = self.length
+  /** Returns the underlying string itself, not the usual `WrappedString(...)` rendering of a collection. */
   override def toString() = self
+  /** Returns a [[StringView]] over the underlying string, which applies transformations lazily. */
   override def view: StringView = new StringView(self)
 
+  /** Returns a stepper over the characters of the underlying string, without boxing
+   *  them when a `CharStepper` is asked for.
+   *
+   *  The stepper is efficiently splittable, since the underlying string can be
+   *  divided by index. Surrogate pairs are stepped over as their two separate `Char`
+   *  values.
+   *
+   *  @tparam S the type of the resulting stepper
+   *  @param shape the shape of the stepper, which must be `CharShape` or `ReferenceShape`
+   *  @return a stepper of shape `S` over the characters of this wrapped string
+   */
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[Char, S]): S & EfficientSplit = {
     val st = new CharStringStepper(self, 0, self.length)
     val r =
@@ -68,29 +105,101 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
     r.asInstanceOf[S & EfficientSplit]
   }
 
+  /** Returns `true` if this wrapped string contains the elements of `that` starting at
+   *  index `offset`.
+   *
+   *  When `that` is itself a wrapped string the test is delegated to
+   *  `String.startsWith`; otherwise the elements are compared one by one by the
+   *  inherited implementation.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection to test for
+   *  @param offset the index of this wrapped string at which to start the comparison
+   *  @return `true` if `that` is a prefix of this wrapped string from `offset` onwards;
+   *          on the delegated path a negative or past-the-end `offset` gives `false`,
+   *          while the inherited implementation gives `true` for an empty `that`
+   *          whatever `offset` is
+   */
   override def startsWith[B >: Char](that: IterableOnce[B]^, offset: Int = 0): Boolean =
     that match {
       case s: WrappedString => self.startsWith(s.self, offset)
       case _                => super.startsWith(that, offset)
     }
 
+  /** Returns `true` if this wrapped string ends with the elements of `that`.
+   *
+   *  When `that` is itself a wrapped string the test is delegated to
+   *  `String.endsWith`; otherwise the elements are compared one by one by the
+   *  inherited implementation.
+   *
+   *  @tparam B the element type of `that`
+   *  @param that the collection to test for
+   *  @return `true` if `that` is a suffix of this wrapped string
+   */
   override def endsWith[B >: Char](that: collection.Iterable[B]^): Boolean =
     that match {
       case s: WrappedString => self.endsWith(s.self)
       case _                => super.endsWith(that)
     }
 
+  /** Returns the index of the first occurrence of `elem` at or after `from`, or `-1` if
+   *  there is none.
+   *
+   *  When `elem` is a `Char` the search is delegated to `String.indexOf`, which treats
+   *  a negative `from` as `0`. Any other value is looked for by the inherited
+   *  implementation, which compares with `==`, so a value whose `equals` accepts a
+   *  `Char` can still be found.
+   *
+   *  @tparam B the type of `elem`
+   *  @param elem the element to look for
+   *  @param from the index at which to start the search
+   *  @return the index of the first occurrence of `elem` at or after `from`, or `-1`
+   */
   override def indexOf[B >: Char](elem: B, from: Int = 0): Int = elem match {
     case c: Char => self.indexOf(c, from)
     case _       => super.indexOf(elem, from)
   }
 
+  /** Returns the index of the last occurrence of `elem` at or before `end`, or `-1` if
+   *  there is none.
+   *
+   *  When `elem` is a `Char` the search is delegated to `String.lastIndexOf`, which
+   *  finds nothing for a negative `end`. Any other value is looked for by the inherited
+   *  implementation, which compares with `==`, so a value whose `equals` accepts a
+   *  `Char` can still be found.
+   *
+   *  @tparam B the type of `elem`
+   *  @param elem the element to look for
+   *  @param end the index at which to end the backwards search, the last index by default
+   *  @return the index of the last occurrence of `elem` at or before `end`, or `-1`
+   */
   override def lastIndexOf[B >: Char](elem: B, end: Int = length - 1): Int =
     elem match {
       case c: Char => self.lastIndexOf(c, end)
       case _       => super.lastIndexOf(elem, end)
     }
 
+  /** Copies characters of this wrapped string to another array, beginning at index
+   *  `start` of `xs`.
+   *
+   *  The number of elements copied is the minimum of `len`, the length of this wrapped
+   *  string, and the remaining capacity of `xs` from `start`; if that minimum is not
+   *  positive, nothing is copied. When `xs` is an `Array[Char]` the copy is performed
+   *  by a single `String.getChars`; otherwise the inherited implementation copies the
+   *  characters one by one, boxing them.
+   *
+   *  A negative `start` is not rejected before that count is computed: the whole length
+   *  of `xs` is taken as the capacity, and the copy that follows a positive count then
+   *  throws rather than writing from a clamped index.
+   *
+   *  @tparam B the element type of the destination array, a supertype of `Char`
+   *  @param xs the destination array
+   *  @param start the index of `xs` at which to write the first character
+   *  @param len the maximum number of characters to copy
+   *  @return the number of characters actually copied
+   *  @throws IndexOutOfBoundsException if `start` is negative and at least one
+   *          character would be copied
+   */
   override def copyToArray[B >: Char](xs: Array[B], start: Int, len: Int): Int =
     (xs: Any) match {
       case chs: Array[Char] =>
@@ -100,20 +209,56 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
       case _                => super.copyToArray(xs, start, len)
     }
 
+  /** Returns a sequence consisting of the characters of this wrapped string followed by
+   *  the elements of `suffix`.
+   *
+   *  When `suffix` is itself a wrapped string the result is another `WrappedString`
+   *  built by `String.concat`; otherwise the inherited implementation fills a builder
+   *  and the result is a [[Vector]] of the common element type.
+   *
+   *  @tparam B the element type of the returned sequence
+   *  @param suffix the collection to append
+   *  @return a sequence with the elements of `suffix` appended to the characters of
+   *          this wrapped string
+   */
   override def appendedAll[B >: Char](suffix: IterableOnce[B]^): IndexedSeq[B] =
     suffix match {
       case s: WrappedString => new WrappedString(self.concat(s.self))
       case _                => super.appendedAll(suffix)
     }
 
+  /** Returns `true` if this wrapped string and `o` contain the same characters in the
+   *  same order.
+   *
+   *  When `o` is itself a wrapped string the two underlying strings are compared
+   *  directly; otherwise the inherited element-by-element comparison is used.
+   *
+   *  @tparam B the element type of `o`
+   *  @param o the collection to compare against
+   */
   override def sameElements[B >: Char](o: IterableOnce[B]^) = o match {
     case s: WrappedString => self == s.self
     case _                => super.sameElements(o)
   }
 
+  /** The name of this collection class, `"WrappedString"`, used as the prefix in the
+   *  string representation of collections derived from it.
+   */
   override protected def className = "WrappedString"
 
+  /** Returns `Int.MaxValue`: indexed access into a string is always cheaper than
+   *  iterating, so `apply` is preferred at every length.
+   */
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
+  /** Returns `true` if `other` is a sequence holding the same characters in the same
+   *  order.
+   *
+   *  Two wrapped strings are compared by their underlying strings; against any other
+   *  value the inherited sequence equality is used, so a wrapped string can equal
+   *  another immutable `Seq[Char]` but never a `String`.
+   *
+   *  @param other the value to compare against
+   */
   override def equals(other: Any): Boolean = other match {
     case that: WrappedString =>
       this.self == that.self
@@ -126,17 +271,32 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
   */
 @SerialVersionUID(3L)
 object WrappedString extends SpecificIterableFactory[Char, WrappedString] {
+  /** Returns a wrapped string holding the characters of `it`, in the order `it` gives
+   *  them out.
+   *
+   *  @param it the characters of the new wrapped string
+   */
   def fromSpecific(it: IterableOnce[Char]^): WrappedString = {
     val b = newBuilder
     b.sizeHint(it)
     b ++= it
     b.result()
   }
+  /** The wrapped string of length zero, shared by every call to `empty`. */
   val empty: WrappedString = new WrappedString("")
+  /** Returns a new builder that collects characters into a wrapped string, using a
+   *  `StringBuilder` to accumulate them.
+   */
   def newBuilder: Builder[Char, WrappedString] =
     new StringBuilder().mapResult(x => new WrappedString(x))
 
+  /** Provides the `unwrap` method on wrapped strings, which recovers the underlying
+   *  `String`.
+   *
+   *  @param value the wrapped string to unwrap
+   */
   implicit class UnwrapOp(private val value: WrappedString) extends AnyVal {
+    /** Returns the underlying string, without copying it. */
     def unwrap: String = value.self
   }
 }

--- a/library/src/scala/collection/immutable/package.scala
+++ b/library/src/scala/collection/immutable/package.scala
@@ -17,12 +17,21 @@ import language.experimental.captureChecking
 
 package object immutable {
   type StringOps = scala.collection.StringOps
+  /** Alias for the [[scala.collection.StringOps]] companion object, so that the name
+   *  resolves under `scala.collection.immutable` alongside the type alias above.
+   */
   val StringOps = scala.collection.StringOps
   type StringView = scala.collection.StringView
+  /** Alias for the [[scala.collection.StringView]] companion object, so that the name
+   *  resolves under `scala.collection.immutable` alongside the type alias above.
+   */
   val StringView = scala.collection.StringView
 
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   type Traversable[+X] = Iterable[X]
+  /** Alias for the [[Iterable]] companion object, kept so that code written against
+   *  the old name can still call factory methods such as `Traversable(1, 2, 3)`.
+   */
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
 


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for the linear, lazy and ordered collections of `scala.collection.immutable` that are completely missing any Scaladoc documentation: `List`, `Set` with its small-arity `Set1` to `Set4` family, the lazy sequences `LazyList`, `LazyListIterable` and the deprecated `Stream`, the red-black tree maps and sets, the sorted and list-backed maps and sets, `Queue`, `WrappedString`, the ranges and the integer-keyed maps. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.