### PR TITLE
fix: Mark FunctionXXL lambdas serializable

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1788,8 +1788,12 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
 
       val generatedType = bTypeLoader.classBTypeFromSymbol(functionalInterface)
       // Lambdas should be serializable if they implement a SAM that extends Serializable or if they
-      // implement a scala.Function* class.
-      val isSerializable = functionalInterface.isSerializable || defn.isFunctionClass(functionalInterface)
+      // implement a scala.Function* class. FunctionXXL is named separately because it lives in
+      // scala.runtime, which isFunctionClass does not look in.
+      val isSerializable =
+        functionalInterface.isSerializable
+        || defn.isFunctionClass(functionalInterface)
+        || functionalInterface == defn.FunctionXXLClass
       val isInterface = isEmittedInterface(lambdaTarget.owner)
       val invokeStyle =
         if (lambdaTarget.isStaticMember) asm.Opcodes.H_INVOKESTATIC

--- a/tests/run/lambda-serialization-others.scala
+++ b/tests/run/lambda-serialization-others.scala
@@ -1,4 +1,6 @@
 //> using options -language:experimental.erasedDefinitions
+// scalajs: --skip
+// (this test uses serialization)
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream, PrintWriter, StringWriter}
 import java.lang.invoke.{MethodHandleInfo, SerializedLambda}

--- a/tests/run/lambda-serialization-others.scala
+++ b/tests/run/lambda-serialization-others.scala
@@ -1,3 +1,5 @@
+//> using options -language:experimental.erasedDefinitions
+
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream, PrintWriter, StringWriter}
 import java.lang.invoke.{MethodHandleInfo, SerializedLambda}
 
@@ -31,7 +33,7 @@ class C1 {
 
   val depfun: (x1: Int) => List[x1.type] = x1 => List(x1)
 
-  val erasedfun: (erased Int) => Int = (erased x1) => 0
+  val erasedfun: (erased x1: Int) => Int = (erased x1) => 0
 }
 
 class C2
@@ -40,7 +42,7 @@ class C2
 
   val impdepfun: (x1: Int) ?=> List[x1.type] = x1 ?=> List(x1)
 
-  val erasedimpfun: (erased Int) ?=> Int = (erased x1) ?=> 0
+  val erasedimpfun: (erased x1: Int) ?=> Int = (erased x1) ?=> 0
 }
 
 object Test {


### PR DESCRIPTION
- Follow-up to #26910

I found that `lambda-serialization-others` has been out of run/test since 0d0453f8.
The file is for a test of `FunctionXXL` serialization.
It compiles with a simple change (name for erased function types, which beaec423aa made mandatory), but throws `NotSerializableException` at runtime.
The cause is that `defn.isFunctionClass` only looks in the scala package, so it stopped matching when `FunctionXXL` moved to `scala.runtime` in 98c463d007.

We may change `defn.isFunctionClass` to handle `scala.runtime.FunctionXXL`, but minimized a change since `defn.isFunctionClass` is used in many places.

## Have you relied on LLM-based tools in this contribution?

Yes, I used LLM to research git history.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
(Historically "existing tests", but out of run)