### PR TITLE
fix: merge completion candidates instead of replacing them

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -508,11 +508,11 @@ object Completion:
         def safeExtensionCompletions =
           try extensionCompletions(adjustedQual)
           catch case _: TypeError => Map.empty
-        implicitConversionMemberCompletions(adjustedQual) ++
-        //safeExtensionCompletions ++
-        extensionCompletions(adjustedQual) ++
-        directMemberCompletions(adjustedQual) ++
         namedTupleCompletions(adjustedQual)
+          .withAlternativesFrom(directMemberCompletions(adjustedQual))
+          .withAlternativesFrom(extensionCompletions(adjustedQual))
+          // .withAlternativesFrom(safeExtensionCompletions)
+          .withAlternativesFrom(implicitConversionMemberCompletions(adjustedQual))
       else
         Map.empty
 
@@ -750,6 +750,15 @@ object Completion:
       def apply(pre: Type, name: Name)(using Context): Boolean =
         !name.isConstructorName && name.toTermName.info.kind == SimpleNameKind && matches(name)
       def isStable = true
+
+    extension (preferred: CompletionMap)
+      def withAlternativesFrom(others: CompletionMap)(using Context): CompletionMap =
+        val merged = others.map: (name, otherDenots) =>
+          val preferredDenots = preferred.getOrElse(name, Nil)
+          def isRedundant(d: SingleDenotation) =
+            preferredDenots.exists(p => p.symbol == d.symbol || p.matchesLoosely(d))
+          name -> (preferredDenots ++ otherDenots.filterNot(isRedundant))
+        preferred ++ merged
 
     extension (denotations: Seq[SingleDenotation])
       def groupByName(using Context): CompletionMap = denotations.groupBy(_.name)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetNegSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetNegSuite.scala
@@ -21,6 +21,7 @@ class CompletionSnippetNegSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       """|apply
+         |apply
          |unapplySeq""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
@@ -15,6 +15,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
         |}
         |""".stripMargin,
       """|apply($0)
+         |apply($0)
          |unapplySeq($0)
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -122,7 +122,10 @@ class CompletionSuite extends BaseCompletionSuite:
          |->[B](inline that: B): (List.type, B)
          |fromSpecific(from: Any)(it: IterableOnce[Nothing]): List[Nothing]
          |fromSpecific(it: IterableOnce[Nothing]): List[Nothing]
+         |newBuilder(from: Any): Builder[Nothing, List[Nothing]]
+         |newBuilder: Builder[Nothing, List[Nothing]]
          |toFactory(from: Any): Factory[Nothing, List[Nothing]]
+         |apply(from: Any): Builder[Nothing, List[Nothing]]
          |iterableFactory[A]: Factory[A, List[A]]
          |asInstanceOf[X0]: X0
          |equals(x$0: Any): Boolean

--- a/repl/test/dotty/tools/repl/ReplTest.scala
+++ b/repl/test/dotty/tools/repl/ReplTest.scala
@@ -47,6 +47,10 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
   def tabComplete(src: String)(implicit state: State): List[String] =
     completions(src.length, src, state).map(_.label).sorted.distinct
 
+  /** The signatures offered under `label`, i.e. all of its overloads */
+  def tabCompleteSignatures(src: String, label: String)(implicit state: State): List[String] =
+    completions(src.length, src, state).filter(_.label == label).map(_.description).sorted
+
   extension [A](state: State)
     infix def andThen(op: State ?=> A): A = op(using state)
 

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -274,4 +274,28 @@ class TabcompleteTests extends ReplTest {
       assertTrue(s"should contain 'a' but was: ${comp.mkString(", ")}", comp.contains("a"))
       assertTrue(s"should contain 'b' but was: ${comp.mkString(", ")}", comp.contains("b"))
     }
+
+  @Test def i26073 = initially {
+    assertEquals(
+      List(
+        "(separator: Char): Array[String]",
+        "(separators: Array[Char]): Array[String]",
+        "(x$0: String): Array[String]",
+        "(x$0: String, x$1: Int): Array[String]"
+      ),
+      tabCompleteSignatures(""""".split""", "split")
+    )
+  }
+
+  @Test def `i26073 extension shadowed by a member` =
+    initially {
+      run("extension (s: String) def split(everyChar: Boolean): List[String] = List(s)")
+    } andThen {
+      storedOutput()
+      val signatures = tabCompleteSignatures(""""".split""", "split")
+      assertTrue(
+        s"should offer the extension but was: ${signatures.mkString(", ")}",
+        signatures.contains("(everyChar: Boolean): List[String]")
+      )
+    }
 }


### PR DESCRIPTION
Fixes #26073

So currently `CompletionMap` is keyed only by the name. Hence, when we had:
```scala
extension (s: String) def split(everyChar: Boolean): List[String] = List(s)
```
it got overshadowed by a method named `split` (with a different signature) that was e.g. in `directMemberCompletions`:

```scala
scala> extension (s: String) def split(everyChar: Boolean): List[String] = List(s)
def split(s: String)(everyChar: Boolean): List[String]
                                                                                                                  
def split(x$0: String): Array[String]
def split(x$0: String, x$1: Int): Array[String]

scala> "".split
split     splitAt
```
This affected also completions outside of REPL. E.g. in Metals it also behaved the same way (although didn't check it was 100% caused by this). This PR changes the behaviour, so we don't replace based only on the `name` but signature instead.

## Have you relied on LLM-based tools in this contribution?

Yes, but only for discussing the issue, and generating/fixing tests. I checked the output by understanding every code change.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
