### PR TITLE
Remove unnecessary sonatype repository

### DIFF
--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -16,7 +16,6 @@ object DependencyResolver:
 
   private val defaultRepositories: List[Repository] = List(
     MavenRepository.of("https://repo1.maven.org/maven2"),
-    MavenRepository.of("https://oss.sonatype.org/content/repositories/releases")
   )
 
   // TODO: support every alias coursier does, once the Coursier Interface exposes its own


### PR DESCRIPTION
Because

```
curl -v https://oss.sonatype.org/content/repositories/releases/org/scala-lang/
```

return http status 302

```
location: https://repo1.maven.org:443/content/repositories/releases/org/scala-lang/
```


```
$ curl -v https://oss.sonatype.org/content/repositories/releases/org/scala-lang/
* Host oss.sonatype.org:443 was resolved.
* IPv6: (none)
* IPv4: 108.138.246.91, 108.138.246.106, 108.138.246.120, 108.138.246.129
*   Trying 108.138.246.91:443...
* Connected to oss.sonatype.org (108.138.246.91) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=oss.sonatype.org
*  start date: Aug  4 00:00:00 2026 GMT
*  expire date: Feb 17 23:59:59 2027 GMT
*  subjectAltName: host "oss.sonatype.org" matched cert's "oss.sonatype.org"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://oss.sonatype.org/content/repositories/releases/org/scala-lang/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: oss.sonatype.org]
* [HTTP/2] [1] [:path: /content/repositories/releases/org/scala-lang/]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /content/repositories/releases/org/scala-lang/ HTTP/2
> Host: oss.sonatype.org
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-type: text/html
< content-length: 110
< location: https://repo1.maven.org:443/content/repositories/releases/org/scala-lang/
< server: awselb/2.0
< date: Wed, 26 Aug 2026 08:51:39 GMT
< x-cache: Miss from cloudfront
< via: 1.1 7189b8cad57dc2d1ab0dd5f90144f2a2.cloudfront.net (CloudFront)
< x-amz-cf-pop: SFO5-P1
< x-amz-cf-id: XgXC6Ga9zoRFFp74ndbEbQksIfg0eGio1IvD4wDr1o5KvdzDFOCxmw==
< x-xss-protection: 1; mode=block
< x-frame-options: SAMEORIGIN
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< strict-transport-security: max-age=31536000
< vary: Origin
< 
<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
</body>
</html>
* Connection #0 to host oss.sonatype.org left intact
```


## Have you relied on LLM-based tools in this contribution?


No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Covered by existing tests (this is a refactoring)
