### PR TITLE
Scaladoc: use system font stacks

### DIFF
--- a/scaladoc/resources/dotty_res/styles/filter-bar.css
+++ b/scaladoc/resources/dotty_res/styles/filter-bar.css
@@ -41,7 +41,7 @@
   border: 1px solid var(--border-medium);
   border-radius: 3px;
   background-color: var(--body-bg);
-  font-family: "Lato", sans-serif;
+  font-family: var(--body-font-family);
   padding: 8px;
   margin-left: 8px;
 }

--- a/scaladoc/resources/dotty_res/styles/theme/components/code-snippet.css
+++ b/scaladoc/resources/dotty_res/styles/theme/components/code-snippet.css
@@ -19,7 +19,7 @@
 }
 
 .snippet pre code {
-  font-family: 'DejaVu Sans Mono', monospace;
+  font-family: var(--code-font-family);
 }
 
 .snippet pre code > span {
@@ -379,7 +379,7 @@ dd .snippet {
 .snippet-popup .scastie .cm-content,
 .snippet-popup .scastie .cm-line,
 .snippet-popup .scastie .inline {
-  font-family: 'DejaVu Sans Mono', monospace !important;
+  font-family: var(--code-font-family) !important;
   font-weight: 400 !important;
 }
 

--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -276,7 +276,7 @@
 
 #content :not(pre) > code {
   color: var(--code-props-content);
-  font-family: 'DejaVu Sans Mono', monospace;
+  font-family: var(--code-font-family);
   border: 1px solid var(--code-props-border);
   padding: 3px 5px 1px 5px;
   border-radius: 4px;

--- a/scaladoc/resources/dotty_res/styles/theme/typography.css
+++ b/scaladoc/resources/dotty_res/styles/theme/typography.css
@@ -93,6 +93,6 @@ h1, h2, h3, h4, h5, h6 {
 
 :root {
   font-variant-ligatures: none;
-  --body-font-family: 'DejaVu Sans', Arial, Helvetica, sans-serif;
-  --code-font-family: 'DejaVu Sans Mono', monospace;
+  --body-font-family: system-ui, 'Segoe UI', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --code-font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
 }


### PR DESCRIPTION
Replace the 'DejaVu Sans' / 'DejaVu Sans Mono' stacks with fonts inspired by [Primer](https://primer.style/)'s fallback fonts, as was done for Scala 2 in scala/scala#11265:

## Have you relied on LLM-based tools in this contribution?

Yes

## How was the solution tested?

Local rendering