### PR TITLE
Backport "Recover call skolems in avoid instead of typing inline proxies as skolem" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -559,12 +559,17 @@ object TypeOps:
    *  does not update `ctx.nestingLevel` when entering a block so I'm leaving
    *  this as Future Work™.
    */
-  def avoid(tp: Type, symsToAvoid: => List[Symbol])(using Context): Type = {
+  def avoid(tp: Type, symsToAvoid: => List[Symbol],
+      replacements: Map[Symbol, Type] = Map.empty)(using Context): Type = {
     val widenMap = new AvoidMap {
       @threadUnsafe lazy val forbidden = symsToAvoid.toSet
       def toAvoid(tp: NamedType) = forbidden.contains(tp.symbol)
 
       override def apply(tp: Type): Type = tp match
+        case tp: TermRef if toAvoid(tp) =>
+          replacements.get(tp.symbol) match
+            case Some(replacement) => replacement
+            case None => super.apply(tp)
         case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
           val lo = TypeComparer.instanceType(
             tp.origin,

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -242,12 +242,12 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  When TypeAssigner types `async(...)`, it skolemizes unstable `am` in the
    *  dependent result type, and the call tree is typed as `Wrap[F, ?1.Context]`.
    *  Then the inliner expands the method body and replace `am` by a proxy `am$proxy`.
-   *  Then `new Wrap[F, am.Context]` becomes `new Wrap[F, am$proxy.Context]`.
    *
-   *  In `paramBindingDef`, we type `am$proxy` as $1, so that both expanded tree and
-   *  call tree is typed `Wrap[F, ?1.Context]`. Otherwise, call tree and expanded tree
-   *  has different types `?1.Context` vs `am$proxy.Context` and compile fails.
-   *  See #26153 and #26031.
+   *  Later, when the Inlined node's type avoids that proxy,
+   *  `TypeAssigner.InlineProxySkolem` on the binding recovers `?1` so the result
+   *  matches the call type `Wrap[F, ?1.Context]`
+   *  (instead of `Wrap[F, am$proxy.Context]` avoids to `Wrap[F, ?]`)
+   *  See #26153, #26031, and #26810.
    */
   private val callValueSkolemss: List[List[Option[SkolemType]]] =
     def loop(tree: Tree, skolemss: List[List[Option[SkolemType]]]): List[List[Option[SkolemType]]] = tree match
@@ -311,7 +311,6 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  @param arg0        the argument corresponding to the parameter
    *  @param buf         the buffer to which the definition should be appended
    *  @param skolem      optional skolem from the call's dependent result type.
-   *                     If present, use it as the proxy type.
    */
   private[inlines] def paramBindingDef(name: Name, formal: Type, arg0: Tree,
                               buf: DefBuffer, skolem: Option[SkolemType] = None)(using Context): ValOrDefDef = {
@@ -330,16 +329,10 @@ class Inliner(val call: tpd.Tree)(using Context):
           dropNameArg(arg0)
     val argtpe = arg.tpe.dealiasKeepAnnots.translateFromRepeated(toArray = false)
     val argIsBottom = argtpe.isBottomTypeAfterErasure
-    val baseBindingType =
+    val bindingType =
       if argIsBottom then formal
       else if isByName then ExprType(argtpe.widen)
       else argtpe.widen
-    // If the call result type used a skolem for this argument, use the same skolem
-    // as the proxy type. `?1` has `argtpe.widen` as its underlying type.
-    val proxySkolem = if argIsBottom then None else skolem
-    val bindingType = proxySkolem match
-      case Some(sk) => if isByName then ExprType(sk) else sk
-      case None => baseBindingType
 
     var bindingFlags: FlagSet = InlineProxy
     if formal.widenExpr.hasAnnotation(defn.InlineParamAnnot) then
@@ -353,13 +346,11 @@ class Inliner(val call: tpd.Tree)(using Context):
       var newArg = arg.changeOwner(ctx.owner, boundSym)
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
-      else proxySkolem match
-        case Some(sk) =>
-          newArg = newArg.cast(sk) // adapt the rhs to the skolem-typed proxy
-        case None => ()
       if isByName then DefDef(boundSym, newArg)
       else ValDef(boundSym, newArg, inferred = true)
     }.withSpan(boundSym.span)
+    if !argIsBottom then // Record typer skolem on the proxy ValDef, so the `avoidingType` can avoid proxy to skolem.
+      skolem.foreach(binding.putAttachment(TypeAssigner.InlineProxySkolem, _))
     inlining.println(i"parameter binding: $binding, $argIsBottom")
     buf += binding
     binding

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -841,7 +841,8 @@ object Inlines:
        *  result type after unpickling.
        */
       val inlined =
-        val proxySkolems = bindings.map(_.symbol.info.widenExpr).collect { case sk: SkolemType => sk }
+        val proxySkolems = bindings.flatMap: b =>
+          b.getAttachment(TypeAssigner.InlineProxySkolem)
         if proxySkolems.nonEmpty && inlined0.tpe.existsPart(proxySkolems.contains) then
           val sealedExpansion =
             inContext(ctx.withSource(expansion.source)):

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -45,7 +45,12 @@ trait TypeAssigner {
   }
 
   def avoidingType(expr: Tree, bindings: List[Tree])(using Context): Type =
-    TypeOps.avoid(expr.tpe, localSyms(bindings).filterConserve(_.isTerm))
+    val syms = localSyms(bindings).filterConserve(_.isTerm)
+    val replacements = bindings.flatMap { b =>
+      b.getAttachment(InlineProxySkolem).map(b.symbol -> _)
+    }
+    if replacements.isEmpty then TypeOps.avoid(expr.tpe, syms)
+    else TypeOps.avoid(expr.tpe, syms, replacements.toMap)
 
   def avoidPrivateLeaks(sym: Symbol)(using Context): Type =
     if sym.owner.isClass && !sym.isOneOf(JavaOrPrivateOrSynthetic)
@@ -620,6 +625,13 @@ object TypeAssigner extends TypeAssigner:
    *  same skolems for path-dependent types in the expansion (see #26153).
    */
   private[dotc] val SkolemizedArgs = new Property.StickyKey[Map[tpd.Tree, SkolemType]]
+
+  /** Sticky attachment on an inline argument proxy ValDef, the typer skolem
+   *  that this proxy stands for (#26153 / #26810). Proxy itself keeps a widened
+   *  type and `avoidingType` recovers the skolem when eliminating the proxy from
+   *  the Inlined result type.
+   */
+  private[dotc] val InlineProxySkolem = new Property.StickyKey[SkolemType]
 
   def seqLitType(tree: untpd.SeqLiteral, elemType: Type)(using Context) = tree match
     case tree: untpd.JavaSeqLiteral => defn.ArrayOf(elemType)

--- a/tests/pos/i26810-min/Macro_1.scala
+++ b/tests/pos/i26810-min/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+object M:
+  transparent inline def apply(inline expr: Any): Any =
+    ${ impl('expr) }
+
+  private def impl(e: Expr[Any])(using Quotes): Expr[Any] = e

--- a/tests/pos/i26810-min/Test_2.scala
+++ b/tests/pos/i26810-min/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test(): Unit =
+  val _ = M { summon[1 <:< Int] }
+  val _ = M { summon[String <:< Any] }

--- a/tests/pos/i26810/Macro_1.scala
+++ b/tests/pos/i26810/Macro_1.scala
@@ -1,0 +1,51 @@
+import scala.quoted.*
+
+final class TestCallTree(inner: => Either[Any, IndexedSeq[TestCallTree]])
+
+object Tests:
+  transparent inline def apply(inline expr: Unit): TestCallTree =
+    ${ applyImpl('expr) }
+
+  private def applyImpl(body: Expr[Unit])(using Quotes): Expr[TestCallTree] =
+    import quotes.reflect.*
+
+    def testCallTreeExpr(setupStats: List[Statement]): Expr[TestCallTree] =
+      val inner =
+        Block(
+          setupStats.dropRight(1),
+          '{ Left(${setupStats.takeRight(1).head.asInstanceOf[Term].asExpr}) }.asTerm
+        )
+      '{ TestCallTree(${inner.asExprOf[Either[Any, IndexedSeq[TestCallTree]]]}) }
+
+    object TestMethod:
+      def unapply(tree: Tree): Option[Term] =
+        Option(tree).collect { case t: Term => t.asExpr }.collect {
+          case '{ ($name: String).-($body) } => body.asTerm
+        }
+
+    object Stats:
+      def partition(stats: List[Statement]): (List[Apply], List[Statement]) =
+        stats.partitionMap {
+          case t: Term if TestMethod.unapply(t).isDefined => Left(t.asInstanceOf[Apply])
+          case stmt                                       => Right(stmt)
+        }
+      def unapply(tree: Tree): Option[(List[Apply], List[Statement])] =
+        tree match
+          case Inlined(_, inlBindings, Stats(tests, testsBindings)) =>
+            Some((tests, inlBindings ++ testsBindings))
+          case Block(stats, expr) => Some(partition(stats :+ expr))
+          case stmt: Statement    => Some(partition(stmt :: Nil))
+          case _                  => None
+
+    body.asTerm match
+      case Stats(tests, _) =>
+        val Some(testBody) = TestMethod.unapply(tests.head): @unchecked
+        testBody match
+          case Stats(Nil, setupStats) => testCallTreeExpr(setupStats)
+          case other                  => testCallTreeExpr(List(other))
+      case other =>
+        report.errorAndAbort("bad Tests body: " + other.show)
+
+extension (name: String)
+  @annotation.compileTimeOnly("only inside Tests")
+  def -(body: => Any): Unit = ()

--- a/tests/pos/i26810/Test_2.scala
+++ b/tests/pos/i26810/Test_2.scala
@@ -1,0 +1,6 @@
+@main def Test(): Unit =
+  val _ = Tests {
+    "x" - {
+      summon[1 <:< Int]
+    }
+  }


### PR DESCRIPTION
Backports #26872 to the 3.10.0-RC1.

PR submitted by the release tooling.
[skip ci]