### PR TITLE
Backport "Tolerate lack of source file for relative paths" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -88,7 +88,8 @@ class SourceFile (val file: AbstractFile | Null, sourceRoot: AbstractFile, codec
     if file eq null then "" else file.path
   @threadUnsafe lazy val pathRelativeToSourceRoot: String =
     if file eq null then
-      throw new AssertionError(s"pathRelativeToSourceRoot called on a missing file")
+      // While this should not happen, it currently does due to known definitions being loaded without a source file
+      ""
     else if file.isVirtual || sourceRoot.isVirtual then
       // This can happen when evaluating debug expressions with fake in-memory files
       file.path

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -134,6 +134,16 @@ class CompilationTests {
     ).times(2).checkCompile()
   }
 
+  @Test def posSpecial(): Unit = {
+    special(
+      defaultOptions.without("-Xsemanticdb"),
+      "tests/pos/26889",
+      expectError = false,
+      o => compileFile("tests/pos-special/26889/lib_1.scala", o),
+      ("lib_1/26889/lib_1/", o => compileFile("tests/pos-special/26889/test_2.scala", o))
+    )
+  }
+
   // Warning tests ------------------------------------------------------------
 
   @Test def warn: Unit = {

--- a/tests/pos-special/26889/lib_1.scala
+++ b/tests/pos-special/26889/lib_1.scala
@@ -1,0 +1,3 @@
+trait Client:
+  @deprecated("use run", "0.1")
+  def fetch: Int

--- a/tests/pos-special/26889/test_2.scala
+++ b/tests/pos-special/26889/test_2.scala
@@ -1,0 +1,3 @@
+class Wrapper(client: Client):
+  export client.fetch
+


### PR DESCRIPTION
Backports #26900 to the 3.10.0-RC1.

PR submitted by the release tooling.
[skip ci]