### PR TITLE
[chore] Set reference version to 3.9.0, correct TASTy version

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,7 +12,7 @@ object Versions {
    *
    *  Warning: Change of this variable needs to be consulted with `expectedTastyVersion`
    */
-  val referenceVersion = "3.9.0-RC6"
+  val referenceVersion = "3.9.0"
 
   /** Version of the Scala compiler targeted in the current release cycle
    *  Contains a version without RC/SNAPSHOT/NIGHTLY specific suffixes
@@ -50,10 +50,8 @@ object Versions {
    *      - in release candidate branch is experimental if {patch == 0}
    *      - in stable release is always non-experimental
    */
-  // TODO: temporary downgraded to 28.9-exp-1 to allow consuming 3.9.0-RC reference compiler. Increment to 28.10-exp-1 when 3.9.0 is released and before 3.10.0-RC1 is published
-  val expectedTastyVersion = "28.9-experimental-1"
-  // TODO: Restore the check once we're bootstrapped on stable 3.9, breaks the nightly releases
-  if (!referenceVersion.startsWith("3.9.0-RC")) checkReleasedTastyVersion()
+  val expectedTastyVersion = "28.10-experimental-1"
+  checkReleasedTastyVersion()
 
   /** Final version of Scala compiler, controlled by environment variables. */
   val dottyVersion = {
@@ -89,7 +87,7 @@ object Versions {
    *   - `3.M.0`     if `P > 0`
    *   - `3.(M-1).0` if `P = 0`
    */
-  val mimaPreviousDottyVersion = "3.9.0-RC1" // TODO: update to 3.9.0 when released
+  val mimaPreviousDottyVersion = "3.9.0"
 
   /* Tests TASTy version invariants during NIGHLY, RC or Stable releases */
   def checkReleasedTastyVersion(): Unit = {

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -325,7 +325,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 9
+  final val MinorVersion: Int = 10
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
Use Scala 3.9.0 to bootstrap compilation and drop temporal workaround, especially the TASTy version
We're already in 3.10.1 cycle, reflect that in version