### PR TITLE
Avoid some instances of boxing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -17,10 +17,10 @@ object NameKinds {
   // These are sharable since all NameKinds are created eagerly at the start of the program
   // before any concurrent threads are forked. for this to work, NameKinds should never
   // be created lazily or in modules that start running after compilers are forked.
-  @sharable private val simpleNameKinds = util.HashMap[Int, ClassifiedNameKind]()
-  @sharable private val qualifiedNameKinds = util.HashMap[Int, QualifiedNameKind]()
-  @sharable private val numberedNameKinds = util.HashMap[Int, NumberedNameKind]()
-  @sharable private val uniqueNameKinds = util.HashMap[String, UniqueNameKind]()
+  @sharable private val simpleNameKinds = new Array[ClassifiedNameKind](64)
+  @sharable private val qualifiedNameKinds = new Array[QualifiedNameKind](64)
+  @sharable private val numberedNameKinds = new Array[NumberedNameKind](64)
+  @sharable private val uniqueNameKinds = util.EqHashMap[TermName, UniqueNameKind]()
 
   /** A class for the info stored in a derived name */
   abstract class NameInfo {
@@ -206,7 +206,7 @@ object NameKinds {
    *
    *  A unique names always constitutes a new name, different from its underlying name.
    */
-  case class UniqueNameKind(val separator: String)
+  case class UniqueNameKind(separator: String)
   extends NumberedNameKind(UNIQUE, s"Unique $separator") {
     override def definesNewName: Boolean = true
 
@@ -225,7 +225,7 @@ object NameKinds {
     def fresh(prefix: TypeName)(using Context): TypeName =
       fresh(prefix.toTermName).toTypeName
 
-    uniqueNameKinds(separator) = this: @unchecked
+    uniqueNameKinds(separatorName) = this: @unchecked
   }
 
   /** An extractor for unique names of arbitrary kind */
@@ -439,8 +439,8 @@ object NameKinds {
   val Scala2MethodNameKinds: List[NameKind] =
     List(DefaultGetterName, ExtMethName, UniqueExtMethName)
 
-  def simpleNameKindOfTag      : util.ReadOnlyMap[Int, ClassifiedNameKind] = simpleNameKinds
-  def qualifiedNameKindOfTag   : util.ReadOnlyMap[Int, QualifiedNameKind]  = qualifiedNameKinds
-  def numberedNameKindOfTag    : util.ReadOnlyMap[Int, NumberedNameKind]   = numberedNameKinds
-  def uniqueNameKindOfSeparator: util.ReadOnlyMap[String, UniqueNameKind]  = uniqueNameKinds
+  def simpleNameKindOfTag      : Array[ClassifiedNameKind] = simpleNameKinds
+  def qualifiedNameKindOfTag   : Array[QualifiedNameKind]  = qualifiedNameKinds
+  def numberedNameKindOfTag    : Array[NumberedNameKind]   = numberedNameKinds
+  def uniqueNameKindOfSeparator: util.EqHashMap[TermName, UniqueNameKind]  = uniqueNameKinds
 }

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -124,7 +124,7 @@ object NameKinds {
     case class QualInfo(name: SimpleName) extends Info with QualifiedInfo {
       override def map(f: SimpleName => SimpleName): NameInfo = new QualInfo(f(name))
       override def toString: String = s"$infoString $name"
-      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
+      override def hashCode: Int = name.hashCode * 31 + kind.hashCode
     }
 
     def apply(qual: TermName, name: SimpleName): TermName =
@@ -172,9 +172,9 @@ object NameKinds {
   /** The kind of numbered names consisting of an underlying name and a number */
   abstract class NumberedNameKind(tag: Int, val infoString: String) extends NameKind(tag) { self =>
     type ThisInfo = NumberedInfo
-    case class NumberedInfo(val num: Int) extends Info with NameKinds.NumberedInfo {
+    case class NumberedInfo(num: Int) extends Info with NameKinds.NumberedInfo {
       override def toString: String = s"$infoString $num"
-      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
+      override def hashCode: Int = num * 31 + kind.hashCode
     }
     def apply(qual: TermName, num: Int): TermName =
       qual.derived(new NumberedInfo(num))
@@ -417,7 +417,7 @@ object NameKinds {
       override def toString: String =
         val targetStr = if target.isEmpty then "" else s" @$target"
         s"$infoString $sig$targetStr"
-      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
+      override def hashCode: Int = ((sig.hashCode * 31) + target.hashCode * 31) + kind.hashCode
     }
     type ThisInfo = SignedInfo
 

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -109,10 +109,9 @@ object NamerOps:
       case Nil =>
         resultType
       case TermSymbols(params) :: paramss1 =>
-        val (isContextual, isImplicit) =
-          if params.isEmpty then (false, false)
-          else (params.head.is(Given), params.head.is(Implicit))
-        val make = MethodType.companion(isContextual = isContextual, isImplicit = isImplicit)
+        val make =
+          if params.isEmpty then MethodType.companion(false, false)
+          else MethodType.companion(isContextual = params.head.is(Given), isImplicit = params.head.is(Implicit))
         if isJava then
           for param <- params do
             if param.info.isDirectRef(defn.ObjectClass) then param.info = defn.AnyType

--- a/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
@@ -21,7 +21,7 @@ class AttributeUnpickler(reader: TastyReader, nameAtRef: NameTable):
         booleanTags += tag
       else if isStringAttrTag(tag) then
         val utf8Ref = readNameRef()
-        val value = nameAtRef(utf8Ref).toString
+        val value = nameAtRef(utf8Ref.index).toString
         stringTagValue += tag -> value
       else
         assert(false, "unknown attribute tag: " + tag)

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -93,11 +93,10 @@ class DottyUnpickler(
   private var ids: Array[String] | Null = null
 
   override def mightContain(id: String)(using Context): Boolean = {
-    if (ids == null)
-      ids =
-        unpickler.nameAtRef.contents.toArray.collect {
+    initialize(ids, ids = _,
+        unpickler.nameAtRef.toArray.collect {
           case name: SimpleName => name.toString
         }.sorted
-    ids.nn.binarySearch(id) >= 0
+    ).binarySearch(id) >= 0
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
@@ -13,7 +13,7 @@ import util.Spans.*
 import Names.TermName
 
 /** Unpickler for tree positions */
-class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
+class PositionUnpickler(reader: TastyReader, nameAtRef: Int => TermName) {
   import reader.*
 
   private var myLineSizes: Array[Int] = uninitialized
@@ -78,5 +78,5 @@ class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
   }
 
   def spanAt(addr: Addr): Span = spans.getOrElse(addr, NoSpan)
-  def sourcePathAt(addr: Addr): String = sourceNameRefs.get(addr).fold("")(nameAtRef(_).toString)
+  def sourcePathAt(addr: Addr): String = sourceNameRefs.get(addr).fold("")(r => nameAtRef(r.index).toString)
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
@@ -61,7 +61,7 @@ class TastyClassName(bytes: Array[Byte], isBestEffortTasty: Boolean = false) {
 
     extension (reader: TastyReader) def readName() = {
       val idx = reader.readNat()
-      nameAtRef(NameRef(idx))
+      nameAtRef(idx)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -108,7 +108,7 @@ class TastyPrinter(bytes: Array[Byte], isBestEffortTasty: Boolean, val testPickl
       base = showBase(unpickler.namesStart.index),
       lineEnd = true
     ))
-    for ((name, idx) <- nameAtRef.contents.zipWithIndex) {
+    for ((name, idx) <- nameAtRef.zipWithIndex) {
       val index = nameStr("%6d".format(idx))
       sb.append(index).append(": ").append(refs.nameRefToString(NameRef(idx))).append("\n")
     }
@@ -229,7 +229,7 @@ class TastyPrinter(bytes: Array[Byte], isBestEffortTasty: Boolean, val testPickl
       for ((addr, nameRef) <- sortedPath) {
         sb.append(treeStr("%6d".format(addr.index)))
         sb.append(": ")
-        sb.append(nameStr(s"${nameRef.index} [${tastyName(nameRef)}]"))
+        sb.append(nameStr(s"${nameRef.index} [${tastyName(nameRef.index)}]"))
         sb.append("\n")
       }
     }
@@ -262,20 +262,20 @@ class TastyPrinter(bytes: Array[Byte], isBestEffortTasty: Boolean, val testPickl
         if isBooleanAttrTag(tag) then ()
         else if isStringAttrTag(tag) then
           val utf8Ref = readNameRef()
-          val value = nameAtRef(utf8Ref).toString
+          val value = nameAtRef(utf8Ref.index).toString
           sb.append(nameStr(s" ${utf8Ref.index} [$value]"))
         sb.append("\n")
       sb.result()
     }
   }
 
-  class NameRefs(sourceFileRefs: Set[NameRef]) extends (NameRef => TermName):
+  class NameRefs(sourceFileRefs: Set[NameRef]) extends (Int => TermName):
     private val isSourceFile = sourceFileRefs.map(_.index).to(BitSet)
 
-    def nameRefToString(ref: NameRef): String = this(ref).debugString
+    def nameRefToString(ref: NameRef): String = this(ref.index).debugString
 
-    def apply(ref: NameRef): TermName =
-      if isSourceFile(ref.index) then NameRefs.elidedSourceFile
+    def apply(ref: Int): TermName =
+      if isSourceFile(ref) then NameRefs.elidedSourceFile
       else nameAtRef(ref)
 
   object NameRefs:

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -113,7 +113,7 @@ class TastyUnpickler(protected val reader: TastyReader, isBestEffortTasty: Boole
       case QUALIFIED | EXPANDED | EXPANDPREFIX =>
         qualifiedNameKindOfTag(tag)(readName(), readName().asSimpleName)
       case UNIQUE =>
-        val separator = readName().toString
+        val separator = readName()
         val num = readNat()
         val originals = until(end)(readName())
         val original = if (originals.isEmpty) EmptyTermName else originals.head

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -27,16 +27,10 @@ case class CommonTastyHeader(
     this(h.uuid, h.majorVersion, h.minorVersion, h.experimentalVersion, h.toolingVersion)
 
 object TastyUnpickler {
+  type NameTable = mutable.ArrayBuffer[TermName]
 
   abstract class SectionUnpickler[R](val name: String) {
     def unpickle(reader: TastyReader, nameAtRef: NameTable): R
-  }
-
-  class NameTable extends (NameRef => TermName) {
-    private val names = new mutable.ArrayBuffer[TermName]
-    def add(name: TermName): mutable.ArrayBuffer[TermName] = names += name
-    def apply(ref: NameRef): TermName = names(ref.index)
-    def contents: Iterable[TermName] = names
   }
 
   trait Scala3CompilerConfig extends UnpicklerConfig:
@@ -82,9 +76,9 @@ class TastyUnpickler(protected val reader: TastyReader, isBestEffortTasty: Boole
   def this(bytes: Array[Byte], isBestEffortTasty: Boolean) = this(new TastyReader(bytes), isBestEffortTasty)
 
   private val sectionReader = new mutable.HashMap[String, TastyReader]
-  val nameAtRef: NameTable = new NameTable
+  val nameAtRef: mutable.ArrayBuffer[TermName] = new mutable.ArrayBuffer[TermName]
 
-  private def readName(): TermName = nameAtRef(readNameRef())
+  private def readName(): TermName = nameAtRef(readNat())
   private def readString(): String = readName().toString
 
   private def readParamSig(): Signature.ParamSig = {
@@ -92,7 +86,7 @@ class TastyUnpickler(protected val reader: TastyReader, isBestEffortTasty: Boole
     if (ref < 0)
       ref.abs
     else
-      nameAtRef(NameRef(ref)).toTypeName
+      nameAtRef(ref).toTypeName
   }
 
   private def readNameContents(): TermName = {
@@ -143,7 +137,7 @@ class TastyUnpickler(protected val reader: TastyReader, isBestEffortTasty: Boole
       new CommonTastyHeader(new TastyHeaderUnpickler(reader).readFullHeader())
 
   def readNames(): Unit =
-    until(readEnd()) { nameAtRef.add(readNameContents()) }
+    until(readEnd()) { nameAtRef += readNameContents() }
 
   def loadSections(): Unit = {
     while (!isAtEnd) {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -647,7 +647,10 @@ class TreeUnpickler(reader: TastyReader,
       val rhsStart = currentAddr
       val rhsIsEmpty = nothingButMods(end)
       if (!rhsIsEmpty) skipTree()
-      val (givenFlags0, annotFns, privateWithin) = readModifiers(end)
+      val annotFns = ListBuffer.empty[Symbol => Annotation]
+      var privateWithinRef: runtime.ObjectRef[Symbol] = runtime.ObjectRef(NoSymbol)
+      val givenFlags0 = readModifiers(end, annotFns, privateWithinRef)
+      val privateWithin = privateWithinRef.elem
       val givenFlags =
         if isClass && unpicklingScala2Library then givenFlags0 | Scala2x | Scala2Tasty
         else if unpicklingJava then givenFlags0 | JavaDefined
@@ -678,7 +681,7 @@ class TreeUnpickler(reader: TastyReader,
       registerSym(start, sym)
       val annotOwner =
         if sym.owner.isClass then newLocalDummy(sym.owner) else sym.owner
-      sym.annotations = annotFns.map(_(annotOwner))
+      sym.annotations = annotFns.map(_(annotOwner)).toList
       if sym.isOpaqueAlias then sym.setFlag(Deferred)
       val isScala2MacroDefinedInScala3 = flags.is(Macro, butNot = Inline) && flags.is(Erased)
       ctx.owner match {
@@ -711,13 +714,13 @@ class TreeUnpickler(reader: TastyReader,
       sym
     }
 
-    /** Read modifier list into triplet of flags, annotations and a privateWithin
+    /** Read modifier list flags, and optionally annotations and a privateWithin
      *  boundary symbol.
      */
-    def readModifiers(end: Addr)(using Context): (FlagSet, List[Symbol => Annotation], Symbol) = {
+    private def readModifiers(end: Addr,
+                      annotFns: ListBuffer[Symbol => Annotation] | Null,
+                      privateWithinRef: runtime.ObjectRef[Symbol] | Null)(using Context): FlagSet = {
       var flags: FlagSet = EmptyFlags
-      var annotFns: List[Symbol => Annotation] = Nil
-      var privateWithin: Symbol = NoSymbol
       while (currentAddr.index != end.index) {
         def addFlag(flag: FlagSet) = {
           flags |= flag
@@ -770,20 +773,21 @@ class TreeUnpickler(reader: TastyReader,
           case INTO => addFlag(Into)
           case PRIVATEqualified =>
             readByte()
-            privateWithin = readWithin
+            if privateWithinRef != null then
+              privateWithinRef.elem = readWithin
           case PROTECTEDqualified =>
             addFlag(Protected)
-            privateWithin = readWithin
+            if privateWithinRef != null then
+              privateWithinRef.elem = readWithin
           case ANNOTATION =>
-            val annotFn =
-              val annot = readAnnot
-              (sym: Symbol) => annot.complete(sym)
-            annotFns = annotFn :: annotFns
+            val annot = readAnnot
+            if annotFns != null then
+              annotFns.addOne((sym: Symbol) => annot.complete(sym))
           case tag =>
             assert(false, s"illegal modifier tag $tag at $currentAddr, end = $end")
         }
       }
-      (flags, annotFns.reverse, privateWithin)
+      flags
     }
 
     private def readWithin(using Context): Symbol = readType().typeSymbol
@@ -1652,7 +1656,7 @@ class TreeUnpickler(reader: TastyReader,
               readName()
               readType()
               val body = readTree()
-              val (givenFlags, _, _) = readModifiers(end)
+              val givenFlags = readModifiers(end, null, null)
               sym.setFlag(givenFlags)
               Bind(sym, body)
             case ALTERNATIVE =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -261,7 +261,7 @@ class TreeUnpickler(reader: TastyReader,
       else tag
     }
 
-    def readName(): TermName = nameAtRef(readNameRef())
+    def readName(): TermName = nameAtRef(readNat())
 
     /** Can `tag` start a type argument of a CompactAnnotation? */
     def isCompactAnnotTypeTag(tag: Int): Boolean = tag match

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -554,7 +554,7 @@ class Pickler extends Phase {
     for ((cls, (unit, unpickler, optCheck)) <- unpicklers) do
       val testJava = unit.typedAsJava
       if testJava then
-        if unpickler.unpickler.nameAtRef.contents.exists(_ == nme.FromJavaObject) then
+        if unpickler.unpickler.nameAtRef.exists(_ == nme.FromJavaObject) then
           report.error(em"Pickled reference to FromJavaObject in Java defined $cls in ${cls.source}")
       val unpickled = unpickler.rootTrees
       val freshUnit = CompilationUnit(rootCtx.compilationUnit.source)


### PR DESCRIPTION
Looking at a `helloWorld` flame graph for 100 iterations at a time, I noticed 1.5% was in integer boxing, so decided to look further.

Self-contained commits, probably best to review commit-by-commit.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
