### PR TITLE
Spec changes for explicit nulls

### DIFF
--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -1634,6 +1634,8 @@ The erased LUB is computed as follows:
 - if both arguments are arrays of same primitives, an array of this primitive
 - if one argument is array of primitives and the other is array of objects, [`Object`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html)
 - if one argument is an array, [`Object`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html)
+- if one argument is `scala.Nothing`, the other argument
+- if one argument is `scala.Null` and the other derives from [`Object`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html), the other argument
 - otherwise a common superclass or trait S of the argument classes, with the following two properties:
   - S is minimal: no other common superclass or trait derives from S, and
   - S is last: in the linearization of the first argument type ´|A|´ there are no minimal common superclasses or traits that come after S.
@@ -1642,6 +1644,10 @@ The erased LUB is computed as follows:
 The rules for ´eglb(A, B)´ are given below in pseudocode:
 
 ```
+eglb(scala.Nothing, B)          = B
+eglb(A, scala.Nothing)          = A
+eglb(scala.Null, B)             = B                     if B derives from Object
+eglb(A, scala.Null)             = A                     if A derives from Object
 eglb(scala.Array[A], JArray[B]) = scala.Array[eglb(A, B)]
 eglb(scala.Array[T], _)         = scala.Array[T]
 eglb(_, scala.Array[T])         = scala.Array[T]

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -1643,10 +1643,6 @@ The erased LUB is computed as follows:
 The rules for ´eglb(A, B)´ are given below in pseudocode:
 
 ```
-eglb(scala.Nothing, B)          = B
-eglb(A, scala.Nothing)          = A
-eglb(scala.Null, B)             = B                     if B derives from Object
-eglb(A, scala.Null)             = A                     if A derives from Object
 eglb(scala.Array[A], JArray[B]) = scala.Array[eglb(A, B)]
 eglb(scala.Array[T], _)         = scala.Array[T]
 eglb(_, scala.Array[T])         = scala.Array[T]

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -98,6 +98,7 @@ Type              ::=  ‘AnyKind‘
                     |  IntersectionType
                     |  MatchType
                     |  SkolemType
+                    |  FlexibleType
 
 TypeLambda        ::=  ‘[‘ TypeParams ‘]‘ ‘=>>‘ Type
 TypeParams        ::=  TypeParam {‘,‘ TypeParam}
@@ -142,6 +143,8 @@ TypeCaseAppliedPattern  ::=  Type ‘[‘ TypeCasePattern { ‘,‘ TypeCasePatt
 TypeCapture             ::=  (id | ‘_‘) TypeBounds
 
 SkolemType        ::=  ‘∃‘ skolemid ‘:‘ Type
+
+FlexibleType      ::=  Type ‘?‘
 
 TypeOrMethodic    ::=  Type
                     |  MethodicType
@@ -352,6 +355,7 @@ They can be referred to with [the fundamental type aliases `scala.AnyKind` and `
 Types can be _concrete_ or _abstract_.
 An abstract type ´T´ always has lower and upper bounds ´L´ and ´H´ such that ´L >: T´ and ´T <: H´.
 A concrete type ´T´ is considered to have itself as both lower and upper bound.
+A flexible type ´T?´ has lower bound `´T´ | scala.Null` and upper bound ´T´.
 
 The kind of a type is indicated by its (transitive) upper bound:
 
@@ -500,7 +504,7 @@ If ´p = \epsilon´ or ´p´ is a package ref, the underlying type ´U´ is the 
 Otherwise, the underlying type ´U´ and whether ´p.x´ is a stable type are determined by [`memberType`](#member-type)`(´p´, ´x´)`.
 
 All term designators are concrete types.
-If `scala.Null ´<: U´`, the term designator denotes the set of values consisting of `null` and the value denoted by ´t´, i.e., the value ´v´ for which `t eq v`.
+Outside the context of a `safeNulls` language import, if `scala.Null ´<: U´`, the term designator denotes the set of values consisting of `null` and the value denoted by ´t´, i.e., the value ´v´ for which `t eq v`.
 Otherwise, the designator denotes the singleton set only containing ´v´.
 
 #### Type Designators
@@ -1495,14 +1499,17 @@ Note that the conditions are not all mutually exclusive.
 - `´(X´ match <: ´H_X´ { case ´P_1´ => ´A_1´; ...; case ´P_n´ => ´A_n´ }´) <: (Y´ match <: ´H_Y´ { case ´Q_1´ => ´B_1´; ...; ´Q_n´ => ´B_n´ }´)´` if ´X =:= Y´ and ´P_i =:= Q_i´ for each ´i´ and ´A_i <: B_i´ for each ´i´
 - `´S = (´=> ´S_1)´` and `´T = (´=> ´T_1)´` and ´S_1 <: T_1´.
 - `´S =´ scala.Null` and:
-  - ´T = q.C[T_1, ..., T_n]´ with ´n \geq 0´ and ´C´ does not derive from `scala.AnyVal` and ´C´ is not the hidden class of an `object`, or
-  - ´T = q.x´ is a term designator with underlying type ´U´ and `scala.Null ´<: U´`, or
+  - in the context of a `safeNulls` language import, `T` is `scala.Null`, `scala.Any`, `scala.AnyVal`, or `scala.Matchable`, or
+  - outside the context of a `safeNulls` language import, ´T = q.C[T_1, ..., T_n]´ with ´n \geq 0´ and ´C´ does not derive from `scala.AnyVal` and ´C´ is not the hidden class of an `object`, or
+  - outside the context of a `safeNulls` language import, ´T = q.x´ is a term designator with underlying type ´U´ and `scala.Null ´<: U´`, or
   - `´T = T_1´ { ´R´ }` and `scala.Null ´<: T_1´`, or
   - `´T =´ { ´\beta´ => ´T_1´ }` and `scala.Null ´<: T_1´`.
 - ´S´ is a stable type and ´T = q.x´ is a term designator with underlying type ´T_1´ and ´T_1´ is a stable type and ´S <: T_1´.
 - `´S = S_1´ { ´R´ }` and ´S_1 <: T´.
 - `´S =´ { ´\alpha´ => ´S_1´ }` and ´S_1 <: T´.
 - `´T =´ scala.Tuple´_n[T_1, ..., T_n]´` with ´1 \leq n \leq 22´, and `´S <: T_1´ *: ... *: ´T_n´ *: scala.EmptyTuple`.
+- `´S = S_1?´` and ´S_1 <: T´.
+- `´T = T_1?´` and `´S <: T_1´ | scala.Null`.
 
 We define `isSubPrefix(´p´, ´q´)` where ´p´ and ´q´ are prefixes as:
 

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -1498,10 +1498,9 @@ Note that the conditions are not all mutually exclusive.
 - `´(X´ match <: ´H´ { ... }´) <: T´` if ´H <: T´
 - `´(X´ match <: ´H_X´ { case ´P_1´ => ´A_1´; ...; case ´P_n´ => ´A_n´ }´) <: (Y´ match <: ´H_Y´ { case ´Q_1´ => ´B_1´; ...; ´Q_n´ => ´B_n´ }´)´` if ´X =:= Y´ and ´P_i =:= Q_i´ for each ´i´ and ´A_i <: B_i´ for each ´i´
 - `´S = (´=> ´S_1)´` and `´T = (´=> ´T_1)´` and ´S_1 <: T_1´.
-- `´S =´ scala.Null` and:
-  - in the context of a `safeNulls` language import, `T` is `scala.Null`, `scala.Any`, `scala.AnyVal`, or `scala.Matchable`, or
-  - outside the context of a `safeNulls` language import, ´T = q.C[T_1, ..., T_n]´ with ´n \geq 0´ and ´C´ does not derive from `scala.AnyVal` and ´C´ is not the hidden class of an `object`, or
-  - outside the context of a `safeNulls` language import, ´T = q.x´ is a term designator with underlying type ´U´ and `scala.Null ´<: U´`, or
+- outside the context of a `safeNulls` language import, `´S =´ scala.Null` and:
+  - ´T = q.C[T_1, ..., T_n]´ with ´n \geq 0´ and ´C´ does not derive from `scala.AnyVal` and ´C´ is not the hidden class of an `object`, or
+  - ´T = q.x´ is a term designator with underlying type ´U´ and `scala.Null ´<: U´`, or
   - `´T = T_1´ { ´R´ }` and `scala.Null ´<: T_1´`, or
   - `´T =´ { ´\beta´ => ´T_1´ }` and `scala.Null ´<: T_1´`.
 - ´S´ is a stable type and ´T = q.x´ is a term designator with underlying type ´T_1´ and ´T_1´ is a stable type and ´S <: T_1´.

--- a/docs/_spec/06-expressions.md
+++ b/docs/_spec/06-expressions.md
@@ -84,7 +84,7 @@ Typing of literals is described along with their [lexical syntax](01-lexical-syn
 
 ## The _Null_ Value
 
-The `null` value is of type `scala.Null`. and thus conforms to every reference type.
+The `null` value is of type `scala.Null`.
 It denotes a special `null` object value.
 This object implements methods in class `scala.Any` as follows:
 

--- a/docs/_spec/06-expressions.md
+++ b/docs/_spec/06-expressions.md
@@ -84,15 +84,19 @@ Typing of literals is described along with their [lexical syntax](01-lexical-syn
 
 ## The _Null_ Value
 
-The `null` value is of type `scala.Null`, and thus conforms to every reference type.
-It denotes a reference value which refers to a special `null` object.
-This object implements methods in class `scala.AnyRef` as follows:
+The `null` value is of type `scala.Null`. and thus conforms to every reference type.
+It denotes a special `null` object value.
+This object implements methods in class `scala.Any` as follows:
 
 - `eq(´x\,´)` and `==(´x\,´)` return `true` iff the argument ´x´ is also the "null" object.
 - `ne(´x\,´)` and `!=(´x\,´)` return true iff the argument x is not also the "null" object.
 - `isInstanceOf[´T\,´]` always returns `false`.
 - `asInstanceOf[´T\,´]` returns the [default value](04-basic-definitions.html#value-definitions) of type ´T´.
 - `##` returns ``0``.
+- `toString` returns `"null"`.
+- `getClass` returns `classOf[scala.Null]`.
+
+Note: `eq` and `ne` are not methods of `scala.Any`, but are provided for `scala.Null` as extension methods in `scala.Predef`.
 
 A reference to any other member of the "null" object causes a `NullPointerException` to be thrown.
 


### PR DESCRIPTION
In anticipation of a SIP for explicit nulls, these are proposed changes to the spec, for discussion.

It remains as a TODO to make changes to 08-pattern-matching.md and 12-the-scala-standard-library.md.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
