### PR TITLE
Remove uses of unsafeNulls from the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -13,8 +13,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import dotty.tools.dotc.config.ScalaSettings
 
 import io.AbstractFile

--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -1,7 +1,5 @@
 package dotty.tools.repl
 
-import scala.language.unsafeNulls
-
 import java.io.File
 import java.net.{URL, URLClassLoader}
 import scala.jdk.CollectionConverters.*

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -1,7 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
 import scala.io.AnsiColor
 
 import java.io.{InputStream, InterruptedIOException}
@@ -242,7 +241,7 @@ class JLineTerminal(providedTerminal: org.jline.terminal.Terminal | Null = null)
         /* missing = */ newLinePrompt)
 
       case class TokenData(token: Token, start: Int, end: Int)
-      def currentToken: TokenData /* | Null */ = {
+      def currentToken: TokenData | Null = {
         val source = SourceFile.virtual("<completions>", input)
         val scanner = new Scanner(source)(using ctx.fresh.setReporter(Reporter.NoReporter))
         var lastBacktickErrorStart: Option[Int] = None

--- a/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
+++ b/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
@@ -2,7 +2,6 @@ package dotty.tools
 package repl
 
 import scala.jdk.CollectionConverters.*
-import scala.language.unsafeNulls
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.tree.*

--- a/repl/src/dotty/tools/repl/ReplBytecodeInstrumentation.scala
+++ b/repl/src/dotty/tools/repl/ReplBytecodeInstrumentation.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.tree.*
@@ -39,8 +37,8 @@ object ReplBytecodeInstrumentation:
       access: Int,
       name: String,
       descriptor: String,
-      signature: String,
-      exceptions: Array[String]
+      signature: String | Null,
+      exceptions: Array[String] | Null
     ): MethodVisitor =
       new InstrumentMethodVisitor(super.visitMethod(access, name, descriptor, signature, exceptions))
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -1,7 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
 import scala.util.control.NonFatal
 
 import java.io.{File => JFile, PrintStream}
@@ -424,8 +423,9 @@ class ReplDriver(settings: Array[String],
 
       case SyntaxErrors(_, errs, _) =>
         // if there is a Run that is tracking suspended parse warnings, ignore (drop) them when erroring
-        if state.context.run != null then
-          state.context.run.suppressions.initSuspendedMessages(oldRun = null)
+        val run = state.context.run
+        if run != null then
+          run.suppressions.initSuspendedMessages(oldRun = null)
         displayErrors(errs, state)
 
       case CommandThenCode(cmd, code) =>

--- a/repl/src/dotty/tools/repl/ScriptEngine.scala
+++ b/repl/src/dotty/tools/repl/ScriptEngine.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.{Reader, StringWriter}
 import javax.script.{AbstractScriptEngine, Bindings, ScriptContext, ScriptEngine => JScriptEngine, ScriptEngineFactory, ScriptException, SimpleBindings}
 import dotc.core.StdNames.str
@@ -83,7 +81,7 @@ object ScriptEngine {
 
     def getOutputStatement(toDisplay: String): String = s"""print("$toDisplay")"""
 
-    def getParameter(key: String): Object = key match {
+    def getParameter(key: String): Object | Null = key match {
       case JScriptEngine.ENGINE           => getEngineName
       case JScriptEngine.ENGINE_VERSION   => getEngineVersion
       case JScriptEngine.LANGUAGE         => getLanguageName

--- a/repl/src/dotty/tools/repl/StackTraceOps.scala
+++ b/repl/src/dotty/tools/repl/StackTraceOps.scala
@@ -12,7 +12,6 @@
 
 package dotty.tools.repl
 
-import scala.language.unsafeNulls
 import collection.mutable, mutable.ListBuffer
 import dotty.tools.dotc.util.chaining.*
 import java.lang.System.lineSeparator


### PR DESCRIPTION
Removes `unsafeNulls` from `repl/src`. `repl/test` to follow.

Four files needed no changes beyond dropping the import.

- `ScriptEngine.getParameter` returns `null` for unknown keys — `Object | Null`.
- `JLineTerminal.currentToken` returns `null` when the cursor is outside a token
  (the signature already carried a `/* | Null */` comment); the only call site
  handles it via `case _`.
- `visitMethod` in `ReplBytecodeInstrumentation`: the compiler accepts the old
  signature, but ASM passes `null` for `signature` and `exceptions`, so I widened
  both. Parameters are forwarded unchanged.
- `ReplDriver`: bound `state.context.run` to a local `val` so flow typing narrows
  it, as in `Reporter.scala:223`, rather than adding `.nn`.

`ScriptEngine.eval` also returns `null`, but `Method.invoke`'s flexible type keeps
it valid as-is, so I left it.

## How much have you relied on LLM-based tools in this contribution?

Some — for running builds and surfacing compiler errors.

## How was the solution tested?

Covered by existing tests (this is a refactoring). `scala3-repl/test` passes:
355 tests, 0 failures.
