### PR TITLE
fix(repl): -Xrepl-interrupt-instrumentation:local instrumenting nothing

### DIFF
--- a/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -46,7 +46,7 @@ class AbstractFileClassLoader(root: AbstractFile, parent: ClassLoader, interrupt
   def this(root: AbstractFile, parent: ClassLoader) = this(root, parent, InterruptInstrumentation.fromString(ScalaSettings.XreplInterruptInstrumentation.default))
 
   override protected def defineClass(name: String, bytes: Array[Byte]): Class[?] =
-    if interruptInstrumentation.is(InterruptInstrumentation.Enabled) then defineClassInstrumented(name, bytes)
+    if interruptInstrumentation.isOneOf(InterruptInstrumentation.Enabled, InterruptInstrumentation.Local) then defineClassInstrumented(name, bytes)
     else super.defineClass(name, bytes)
 
   private def defineClassInstrumented(name: String, originalBytes: Array[Byte]) = {

--- a/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
+++ b/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
@@ -155,9 +155,13 @@ class AbstractFileClassLoaderTest:
     catch case e: java.lang.reflect.InvocationTargetException => e.getCause.isInstanceOf[ThreadDeath]
     finally ReplBytecodeInstrumentation.setStopFlag(loader, false)
 
-  @Test def onlyEnabledAndLocalInstrumentReplClasses(): Unit =
-    assertFalse("false", probeIsInterruptible(Disabled))
-    assertTrue("true", probeIsInterruptible(Enabled))
-    assertTrue("local", probeIsInterruptible(Local))
+  @Test def replClassesAreNotInstrumentedWhenDisabled(): Unit =
+    assertFalse(probeIsInterruptible(Disabled))
+
+  @Test def replClassesAreInstrumentedWhenEnabled(): Unit =
+    assertTrue(probeIsInterruptible(Enabled))
+
+  @Test def replClassesAreInstrumentedWhenLocal(): Unit =
+    assertTrue(probeIsInterruptible(Local))
 
 end AbstractFileClassLoaderTest

--- a/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
+++ b/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
@@ -6,6 +6,11 @@ import scala.language.unsafeNulls
 import org.junit.Assert.*
 import org.junit.Test
 
+import AbstractFileClassLoader.InterruptInstrumentation
+import AbstractFileClassLoader.InterruptInstrumentation.*
+
+class InterruptProbe
+
 class AbstractFileClassLoaderTest:
 
   import dotty.tools.io
@@ -135,4 +140,24 @@ class AbstractFileClassLoaderTest:
     val sut = new AbstractFileClassLoader(fuzz_, p)
     val b = sut.classBytes("buzz/booz.class")
     assertEquals("hello, world", new String(b, UTF8.charSet))
+
+  def probeIsInterruptible(mode: InterruptInstrumentation): Boolean =
+    val parent = classOf[InterruptProbe].getClassLoader
+    val name = classOf[InterruptProbe].getName
+    val root = io.virtualDirectory("replout")
+    val dir = name.split('.').init.foldLeft(root)(_.subdirectoryNamed(_))
+    closing(dir.fileNamed("InterruptProbe.class").output)(_.write(parent.classBytes(name)))
+    val loader = new AbstractFileClassLoader(root, parent, mode)
+    ReplBytecodeInstrumentation.setStopFlag(loader, true)
+    try
+      loader.loadClass(name).getDeclaredConstructor().newInstance()
+      false
+    catch case e: java.lang.reflect.InvocationTargetException => e.getCause.isInstanceOf[ThreadDeath]
+    finally ReplBytecodeInstrumentation.setStopFlag(loader, false)
+
+  @Test def onlyEnabledAndLocalInstrumentReplClasses(): Unit =
+    assertFalse("false", probeIsInterruptible(Disabled))
+    assertTrue("true", probeIsInterruptible(Enabled))
+    assertTrue("local", probeIsInterruptible(Local))
+
 end AbstractFileClassLoaderTest


### PR DESCRIPTION
Fixes an issue where `-Xrepl-interrupt-instrumentation:local` basically worked like `false`. I found the issue while working on a PR (I wanted to use the option but noticed it doesn't work like advertised).

## Have you relied on LLM-based tools in this contribution?

Yes, just for tests. I checked the output by reading and understanding the code.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
