### PR TITLE
fix: rename -Xrepl-disable-display to -Xrepl-disable-evaluation

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -431,7 +431,7 @@ private sealed trait XSettings:
   val XprintInline: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xprint-inline", "Show where inlined code comes from.")
   val XprintSuspension: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xprint-suspension", "Show when code is suspended until macros are compiled.")
   val Xprompt: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xprompt", "Display a prompt after each error (debugging option).")
-  val XreplDisableDisplay: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xrepl-disable-display", "Do not display definitions in REPL.")
+  val XreplDisableEvaluation: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xrepl-disable-evaluation", "Do not evaluate or display definitions in the REPL.", aliases = SettingAlias("-Xrepl-disable-display", Deprecation("Use -Xrepl-disable-evaluation instead.")) :: Nil)
   val XreplPrintHeight: Setting[Int] = IntSetting(AdvancedSetting, "Xrepl-print-height", "Set the row height for pretty-printing in the REPL.", 50)
   val XreplInterruptInstrumentation: Setting[String] = StringSetting(
     AdvancedSetting,

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -494,7 +494,7 @@ class ReplDriver(settings: Array[String],
 
           inContext(newState.context):
             val (updatedState, definitions) =
-              if (!ctx.settings.XreplDisableDisplay.value)
+              if (!ctx.settings.XreplDisableEvaluation.value)
                 renderDefinitions(unit.tpdTree, newestWrapper)(using newStateWithImports)
               else
                 (newStateWithImports, Seq.empty)

--- a/repl/src/dotty/tools/repl/ScriptEngine.scala
+++ b/repl/src/dotty/tools/repl/ScriptEngine.scala
@@ -22,7 +22,7 @@ class ScriptEngine extends AbstractScriptEngine {
       "-classpath", "", // Avoid the default "."
       "-usejavacp",
       "-color:never",
-      "-Xrepl-disable-display",
+      "-Xrepl-disable-evaluation",
       "-Xrepl-interrupt-instrumentation",
       "false"
     ))

--- a/repl/test-resources/repl/settings-repl-disable-evaluation
+++ b/repl/test-resources/repl/settings-repl-disable-evaluation
@@ -1,7 +1,7 @@
 scala> 1
 val res0: Int = 1
 
-scala> :settings -Xrepl-disable-display
+scala> :settings -Xrepl-disable-evaluation
 
 scala> 2
 


### PR DESCRIPTION
Fixes #24443

Doesn't bring back E to REPL, but instead renames the flag so the name corresponds to the behaviour.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
