### PR TITLE
Fix stale symbol error caused by currentSymbol.isStaticOwner call

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -110,7 +110,7 @@ object Substituters:
       case tp: ThisType =>
         if (tp.cls eq from) to else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStaticOwner || (tp.prefix `eq` NoPrefix)) tp
+        if (tp.currentSymbol.originDenotation.isStaticOwner || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substThis(tp.prefix, from, to, theMap))
       case _: BoundType =>
         tp

--- a/tests/pos-macros/i26925/Macro.scala
+++ b/tests/pos-macros/i26925/Macro.scala
@@ -1,0 +1,26 @@
+package a
+
+import scala.quoted.*
+
+class Personality(pars: DynamicWalkParameters)
+
+object Macros {
+  private def enumerateSubclassesImpl[T: Type](using q: Quotes): Expr[Unit] = {
+    import q.reflect.*
+    def visit(t: TypeRepr): Unit =
+      t match
+        case AppliedType(_, args) =>
+          args.foreach(visit)
+        case _ =>
+          if t.typeSymbol.primaryConstructor.exists then
+            println(t)
+            val constructor = t.typeSymbol.primaryConstructor
+            constructor.paramSymss.flatten.foreach { parameter =>
+              visit(t.memberType(parameter))
+            }
+
+    visit(TypeRepr.of[T])
+    '{()}
+  }
+  inline def enumerateSubclasses[T]: Unit = ${ enumerateSubclassesImpl[T] }
+}

--- a/tests/pos-macros/i26925/Test.scala
+++ b/tests/pos-macros/i26925/Test.scala
@@ -1,0 +1,7 @@
+package a
+
+class DynamicWalkParameters
+
+object Test {
+  def test = Macros.enumerateSubclasses[Personality]
+}


### PR DESCRIPTION
Like many other stale symbol issues, it was caused by the compilation suspension of a macro caller file to compile the macro definition file(s). Inb the reproduction, the macro caller defines
`class DynamicWalkParameters`, and the macro definition defines `class Personality(pars: DynamicWalkParameters)`, with the DynamicWalkParameters there using the initial symbol from the first run, remade in the second run.

Then while analysing symbols in the macro and trying to read the Personality primaryConstructor parameters and get the type via `QuotesImpl.memberType`, we would get the error, which, interestingly, would not happen when referncing applying into the constructor directly, outside of the macro.

The issue was with the substThis called in QuotesImpl.memberType, where we had a `tp.currentSymbol.isStaticOwner` check. currentSymbol would return the last calculated symbol for DynamicWalkParameters, which was stale, and then isStaticOwner call would try to bringForward the stale denotation, unsuccessfully. We could drop the currentSymbol optimisation and just use `.symbol``, but I think it makes more sense to still use `currentSymbol`, but manually reference `originDenotation`
- this is safe to do, as the flags checked as part of `isStaticOwner` (`ModuleClass/PackageClass/JavaStatic`) are all assigned as the symbols are first created, and aren't adjusted by the compiler later.

Fixes #26925

## Have you relied on LLM-based tools in this contribution?

Yes, to explore the codebase and understand the issue. The added code is mine.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
