### PR TITLE
Remove uses of unsafeNulls from the REPL tests

### DIFF
--- a/repl/test/dotty/tools/repl/DocTests.scala
+++ b/repl/test/dotty/tools/repl/DocTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 import org.junit.Assert.assertEquals
 

--- a/repl/test/dotty/tools/repl/JLineTerminalTests.scala
+++ b/repl/test/dotty/tools/repl/JLineTerminalTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.{ByteArrayOutputStream, PipedInputStream, PipedOutputStream}
 
 import org.junit.Assert.*

--- a/repl/test/dotty/tools/repl/LoadTests.scala
+++ b/repl/test/dotty/tools/repl/LoadTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.nio.file.{Path, Files}
 import java.util.Comparator
 import java.util.regex.Pattern
@@ -98,7 +96,7 @@ class LoadTests extends ReplTest {
 
 object LoadTests {
 
-  private var dir: Path = null
+  private var dir: Path | Null = null
 
   @BeforeClass def setupDir: Unit =
     dir = Files.createTempDirectory("repl_load_src")

--- a/repl/test/dotty/tools/repl/NonScalaPackageJarTests.scala
+++ b/repl/test/dotty/tools/repl/NonScalaPackageJarTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.{File, FileOutputStream}
 import java.nio.file.{Files, Path}
 import java.util.Comparator

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.util.regex.Pattern
 
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}

--- a/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.{ByteArrayOutputStream, PipedInputStream, PipedOutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.{Executors, TimeUnit, TimeoutException}

--- a/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
+++ b/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import dotc.Driver
 import dotc.interfaces.Diagnostic.ERROR
 import dotc.reporting.TestReporter
@@ -16,11 +14,12 @@ import org.junit.Assert.{assertFalse, assertTrue}
 import org.junit.{AfterClass, Test}
 
 object ReplProductToStringClasspathTests:
-  private var tempDir: Path = null
+  private var tempDir: Path | Null = null
 
   private lazy val fixtureJar: Path =
-    tempDir = Files.createTempDirectory("repl-product-tostring-classpath")
-    createFixtureJar(tempDir)
+    val dir = Files.createTempDirectory("repl-product-tostring-classpath")
+    tempDir = dir
+    createFixtureJar(dir)
 
   def options: Array[String] =
     ReplTest.createOptions(fixtureJar.toAbsolutePath.toString)

--- a/repl/test/dotty/tools/repl/ReplTest.scala
+++ b/repl/test/dotty/tools/repl/ReplTest.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import vulpix.TestConfiguration
 import vulpix.FileDiff
 import dotty.tools.ToolName

--- a/repl/test/dotty/tools/repl/ReplayTests.scala
+++ b/repl/test/dotty/tools/repl/ReplayTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 import org.junit.Assert.assertEquals
 

--- a/repl/test/dotty/tools/repl/RepositoryTests.scala
+++ b/repl/test/dotty/tools/repl/RepositoryTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.FileOutputStream
 import java.nio.file.{Files, Path}
 import java.util.jar.JarOutputStream

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.nio.file.Files
 
 import org.junit.Test

--- a/repl/test/dotty/tools/repl/ScalaPackageJarTests.scala
+++ b/repl/test/dotty/tools/repl/ScalaPackageJarTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.{File, FileOutputStream}
 import java.nio.file.{Files, Path}
 import java.util.Comparator

--- a/repl/test/dotty/tools/repl/SessionFileHelpers.scala
+++ b/repl/test/dotty/tools/repl/SessionFileHelpers.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.FileOutputStream
 import java.nio.file.{Path, Files}
 import java.util.jar.JarOutputStream

--- a/repl/test/dotty/tools/repl/ShadowingBatchTests.scala
+++ b/repl/test/dotty/tools/repl/ShadowingBatchTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.File
 import java.nio.file.Files
 

--- a/repl/test/dotty/tools/repl/ShadowingTests.scala
+++ b/repl/test/dotty/tools/repl/ShadowingTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import java.io.File
 import java.nio.file.{Path, Files}
 import java.util.Comparator
@@ -26,13 +24,13 @@ import vulpix.{TestConfiguration, TestFlags}
  */
 object ShadowingTests:
   // The directory on the classpath containing artifacts to be shadowed
-  private var dir: Path = null
+  private var dir: Path | Null = null
 
-  def shadowDir = dir.toAbsolutePath.toString
+  def shadowDir = dir.nn.toAbsolutePath.toString
   def options = ReplTest.createOptions(shadowDir)
 
   def createSubDir(name: String): Path =
-    val subdir = dir.resolve(name)
+    val subdir = dir.nn.resolve(name)
     try Files.createDirectory(subdir)
     catch case _: java.nio.file.FileAlreadyExistsException =>
       assert(Files.isDirectory(subdir), s"failed to create shadowed subdirectory $subdir")

--- a/repl/test/dotty/tools/repl/StackTraceTest.scala
+++ b/repl/test/dotty/tools/repl/StackTraceTest.scala
@@ -1,8 +1,6 @@
 
 package dotty.tools.repl
 
-import scala.language.unsafeNulls
-
 import scala.util.{Failure, Success, Try}
 import scala.util.chaining.given
 

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import org.junit.Assert._
 import org.junit.Test
 


### PR DESCRIPTION
Removes `unsafeNulls` from 17 of the 18 files in `repl/test`. Follow-up to #26954.

Fourteen files needed no changes beyond dropping the import. The remaining three are
all the same shape — a `@BeforeClass`-initialised `var` declared as `= null`, now
`Path | Null`:

- `ReplProductToStringClasspathTests.fixtureJar` binds the temp directory to a local
  `val` before assigning the field, so no assertion is needed there.
- `ShadowingTests.shadowDir` and `createSubDir` use `.nn`. `dir` is initialised by
  `@BeforeClass` and cleared by `@AfterClass`, and both methods are only reached
  between those hooks; `.nn` is a local assertion of that test-suite lifecycle
  invariant, which Scala's flow analysis cannot infer.
- `LoadTests` needed nothing beyond the declaration: its uses of `dir` all pass it to
  `java.nio.file.Files`, where flexible types accept it as-is.

`AbstractFileClassLoaderTest` is intentionally the one exception. Its `NoClassLoader`
(one declaration, eight call sites) is a deliberate null parent, not an uninitialised
field. Removing the import there would mean deciding whether the REPL and IO
class-loader constructors should accept `ClassLoader | Null`, which would be more
misleading than honest — `Rendering.scala` documents that the REPL cannot use a null
parent, and `repl.AbstractFileClassLoader` calls `getParent` directly in its
instrumentation paths. The file also has two unrelated nullability questions of its
own (`classAsStream`'s return type, and passing a nullable stream to `closing`), so I
kept it out of this test-only cleanup.

If you think nullable parents should be modelled explicitly, I'd be happy to prepare
a separate follow-up PR covering the REPL and IO class-loader signatures, the related
null handling, and the tests that go with it.

## How much have you relied on LLM-based tools in this contribution?

Some — for running builds and surfacing compiler errors.

## How was the solution tested?

`scala3-repl/test` passes: 355 tests, 0 failures — unchanged from before the change.
