### PR TITLE
scaladoc: fix image overflow on static-site pages

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/container.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/container.css
@@ -19,7 +19,7 @@ p {
   --header-height: calc(8 * var(--base-spacing));
 }
 
-.site-container img{
+#content img {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
The theme sized images with a `.site-container img` rule, but no element in the generated HTML carries that class - the content wrapper is `#content`. As a result images on static-site markdown pages had no width constraint and overflowed the content column at their natural resolution. Point the rule at `#content img`, which is present on both static and API pages.

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by self-review and manual tests

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

manual tests

before

<img width="1624" height="1061" alt="Screenshot 2026-09-02 at 18 37 37" src="https://github.com/user-attachments/assets/369da839-833b-4e8a-a86c-bfba15e2e11f" />

after

<img width="1624" height="1061" alt="Screenshot 2026-09-02 at 18 40 06" src="https://github.com/user-attachments/assets/9c4217ae-c1a2-4a80-b6ac-075ee7b0707f" />
