### PR TITLE
Stop passing a null parent in AbstractFileClassLoaderTest

### DIFF
--- a/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
+++ b/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
@@ -36,7 +36,7 @@ class AbstractFileClassLoaderTest:
   // cf ScalaClassLoader#classBytes
   extension (loader: ClassLoader)
     // An InputStream representing the given class name, or null if not found.
-    def classAsStream(className: String): InputStream = loader.getResourceAsStream {
+    def classAsStream(className: String): InputStream | Null = loader.getResourceAsStream {
       if className.endsWith(".class") then className
       else s"${className.replace('.', '/')}.class"  // classNameToPath
     }
@@ -121,7 +121,7 @@ class AbstractFileClassLoaderTest:
     val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
     val r = x.getResourceAsStream("buzz/booz.class")
     assertNotNull(r)
-    assertEquals("hello, world", closing(r)(is => Source.fromInputStream(is).mkString))
+    assertEquals("hello, world", closing(r.nn)(is => Source.fromInputStream(is).mkString))
 
   @Test def afclGetsClassBytes(): Unit =
     val (fuzz, booz) = fuzzBuzzBooz

--- a/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
+++ b/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
@@ -1,7 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
 
 import org.junit.Assert.*
 import org.junit.Test
@@ -45,7 +44,10 @@ class AbstractFileClassLoaderTest:
       case null   => Array()
       case stream => stream.bytes
 
-  val NoClassLoader: ClassLoader = null
+  // A parent that resolves nothing from the application classpath, so these tests
+  // only ever see resources served by the AbstractFileClassLoader under test.
+  // `fromURLsParallelCapable` defaults to the platform classloader on Java 9+.
+  val noResourcesParent: ClassLoader = ScalaClassLoader.fromURLsParallelCapable(Nil)
 
   // virtual dir "fuzz" and "fuzz/buzz/booz.class"
   def fuzzBuzzBooz: (AbstractFile, AbstractFile) =
@@ -63,7 +65,7 @@ class AbstractFileClassLoaderTest:
   @Test def afclGetsResource(): Unit =
     val (fuzz, booz) = fuzzBuzzBooz
     booz.writeContent("hello, world")
-    val sut = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val sut = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val res = sut.getResource("buzz/booz.class")
     assertNotNull("Find buzz/booz.class", res)
     assertEquals("hello, world", slurp(res))
@@ -73,7 +75,7 @@ class AbstractFileClassLoaderTest:
     val (fuzz_, booz_) = fuzzBuzzBooz
     booz.writeContent("hello, world")
     booz_.writeContent("hello, world_")
-    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val p = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val sut = new AbstractFileClassLoader(fuzz_, p)
     val res = sut.getResource("buzz/booz.class")
     assertNotNull("Find buzz/booz.class", res)
@@ -85,7 +87,7 @@ class AbstractFileClassLoaderTest:
     val bass = fuzz.fileNamed("bass")
     booz.writeContent("hello, world")
     bass.writeContent("lo tone")
-    val sut = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val sut = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val res = sut.getResource("booz.class")
     assertNotNull(res)
     assertEquals("hello, world", slurp(res))
@@ -95,7 +97,7 @@ class AbstractFileClassLoaderTest:
   @Test def afclGetsResources(): Unit =
     val (fuzz, booz) = fuzzBuzzBooz
     booz.writeContent("hello, world")
-    val sut = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val sut = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val e = sut.getResources("buzz/booz.class")
     assertTrue("At least one buzz/booz.class", e.hasMoreElements)
     assertEquals("hello, world", slurp(e.nextElement))
@@ -106,7 +108,7 @@ class AbstractFileClassLoaderTest:
     val (fuzz_, booz_) = fuzzBuzzBooz
     booz.writeContent("hello, world")
     booz_.writeContent("hello, world_")
-    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val p = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val x = new AbstractFileClassLoader(fuzz_, p)
     val e = x.getResources("buzz/booz.class")
     assertTrue(e.hasMoreElements)
@@ -118,7 +120,7 @@ class AbstractFileClassLoaderTest:
   @Test def afclGetsResourceAsStream(): Unit =
     val (fuzz, booz) = fuzzBuzzBooz
     booz.writeContent("hello, world")
-    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val x = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val r = x.getResourceAsStream("buzz/booz.class")
     assertNotNull(r)
     assertEquals("hello, world", closing(r.nn)(is => Source.fromInputStream(is).mkString))
@@ -126,7 +128,7 @@ class AbstractFileClassLoaderTest:
   @Test def afclGetsClassBytes(): Unit =
     val (fuzz, booz) = fuzzBuzzBooz
     booz.writeContent("hello, world")
-    val sut = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val sut = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val b = sut.classBytes("buzz/booz.class")
     assertEquals("hello, world", new String(b, UTF8.charSet))
 
@@ -136,7 +138,7 @@ class AbstractFileClassLoaderTest:
     booz.writeContent("hello, world")
     booz_.writeContent("hello, world_")
 
-    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val p = new AbstractFileClassLoader(fuzz, noResourcesParent)
     val sut = new AbstractFileClassLoader(fuzz_, p)
     val b = sut.classBytes("buzz/booz.class")
     assertEquals("hello, world", new String(b, UTF8.charSet))


### PR DESCRIPTION
Removes the last `unsafeNulls` import in the REPL. Follow-up to #26954 and #26965.

Two things:

- `classAsStream` is declared as returning `InputStream`, but it returns whatever
  `getResourceAsStream` gives back — null when the resource is missing, as the
  comment above it says and as `classBytes` assumes by matching on `case null`.
  Now `InputStream | Null`.

- `NoClassLoader` was a null parent. It is now an empty loader, and renamed.

The second one turned out to be a fix rather than a rename. `parent` is
non-nullable in both class-loader constructors, and that is a real constraint,
not an oversight: instrumentation is on by default, and with a null parent
`loadClass("dotty.tools.repl.StopRepl")` throws

```
NullPointerException: Cannot invoke "java.lang.ClassLoader.getResourceAsStream(String)"
because the return value of "AbstractFileClassLoader.getParent()" is null
```

while the other `getParent` path silently degrades, since its NPE is swallowed by
the surrounding `catch case ex: Exception => super.loadClass(name)`. `Rendering.scala`
documents the same constraint from the other side — the REPL deliberately avoids a
null parent because on Java 9+ that is the bootstrap loader.

So these tests were running in a configuration the REPL does not support, and passed
because none of the eight cases reach either path. Replacing the null with
`ScalaClassLoader.fromURLsParallelCapable(Nil)` keeps what the fixture was actually
for — a parent that serves none of the test resources — while matching the supported
configuration. That helper is used rather than a bare `URLClassLoader` because it
defaults to the platform classloader on Java 9+, so the application classpath cannot
leak in. No test asserts on a null parent; `afclGetsParent` uses its own loader.

## How much have you relied on LLM-based tools in this contribution?

Some — for running builds and surfacing compiler errors.

## How was the solution tested?

`scala3-repl/test` passes: 358 tests, 0 failures.
