### PR TITLE
fix isNullableClassAfterErasure for Null under AnyVal

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -941,7 +941,10 @@ object SymDenotations {
      *  but it becomes nullable after erasure.
      */
     final def isNullableClassAfterErasure(using Context): Boolean =
-      isClass && !isValueClass && !is(ModuleClass) && symbol != defn.NothingClass
+      // `Null` derives from `AnyVal` under explicit nulls, so it would be excluded by
+      // `!isValueClass`, even though `null` is of course a value of it.
+      symbol == defn.NullClass
+      || isClass && !isValueClass && !is(ModuleClass) && symbol != defn.NothingClass
 
     /** Is `pre` the same as C.this, where C is exactly the owner of this symbol,
      *  or, if this symbol is protected, a subclass of the owner?

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -944,7 +944,8 @@ object SymDenotations {
       // `Null` derives from `AnyVal` under explicit nulls, so it would be excluded by
       // `!isValueClass`, even though `null` is of course a value of it.
       isClass && {
-        if isValueClass then symbol == defn.NullClass || symbol == defn.AnyValClass
+        if isValueClass then
+          symbol == defn.NullClass || ctx.explicitNulls && symbol == defn.AnyValClass
         else !is(ModuleClass) && symbol != defn.NothingClass
       }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -943,8 +943,10 @@ object SymDenotations {
     final def isNullableClassAfterErasure(using Context): Boolean =
       // `Null` derives from `AnyVal` under explicit nulls, so it would be excluded by
       // `!isValueClass`, even though `null` is of course a value of it.
-      symbol == defn.NullClass
-      || isClass && !isValueClass && !is(ModuleClass) && symbol != defn.NothingClass
+      isClass && {
+        if isValueClass then symbol == defn.NullClass || symbol == defn.AnyValClass
+        else !is(ModuleClass) && symbol != defn.NothingClass
+      }
 
     /** Is `pre` the same as C.this, where C is exactly the owner of this symbol,
      *  or, if this symbol is protected, a subclass of the owner?

--- a/tests/explicit-nulls/run/unsafe-nulls-null-scrutinee.scala
+++ b/tests/explicit-nulls/run/unsafe-nulls-null-scrutinee.scala
@@ -1,0 +1,29 @@
+// Under unsafe nulls, `null` is still a value of every reference type, so a scrutinee of
+// type `Null` must not be treated as known to be non-null. Otherwise a type test against a
+// reference type is folded to a constant `true`, and the pattern matcher omits the null test
+// that guards the placeholder plan it emits for a scrutinee of bottom type.
+
+object Test {
+  import scala.language.unsafeNulls
+
+  def typeTest: Int = null match {
+    case _: AnyRef => 1
+    case _ => -1
+  }
+
+  def extractor: String =
+    try {
+      val Some(_) = null: @unchecked
+      "matched"
+    } catch {
+      case _: MatchError => "MatchError"
+    }
+
+  def main(args: Array[String]): Unit = {
+    // evaluated before asserting, so that both are exercised on every run
+    val t = typeTest
+    val e = extractor
+    assert(t == -1, s"type test on a null scrutinee gave $t")
+    assert(e == "MatchError", s"extractor on a null scrutinee gave $e")
+  }
+}

--- a/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.check
+++ b/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.check
@@ -1,4 +1,4 @@
--- [E121] Pattern Match Warning: tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala:16:9 --------------------
-16 |    case _ => -1 // warn
+-- [E121] Pattern Match Warning: tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala:18:9 --------------------
+18 |    case _ => -1 // warn
    |         ^
    |         Unreachable case except for null (if this is intentional, consider writing case null => instead).

--- a/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.check
+++ b/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.check
@@ -1,0 +1,4 @@
+-- [E121] Pattern Match Warning: tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala:16:9 --------------------
+16 |    case _ => -1 // warn
+   |         ^
+   |         Unreachable case except for null (if this is intentional, consider writing case null => instead).

--- a/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala
+++ b/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala
@@ -8,8 +8,10 @@ import scala.language.unsafeNulls
 
 object Test:
   val n: Null = null
+  val n2: AnyVal = null
 
   val s = n.nn // no warning: the qualifier really can be null
+  val s2 = n2.nn // no warning: the qualifier really can be null
 
   def typeTest = null match
     case _: AnyRef => 1

--- a/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala
+++ b/tests/explicit-nulls/warn/unsafe-nulls-null-is-nullable.scala
@@ -1,0 +1,16 @@
+// Under unsafe nulls, a value of type `Null` must not be treated as known to be non-null.
+// If it were, `.nn` on it would be reported as unnecessary, and a type test against a
+// reference type would be reported as matching everything rather than everything but null.
+// Both diagnostics are compile-time symptoms of the same defect that
+// `tests/explicit-nulls/run/unsafe-nulls-null-scrutinee.scala` observes at run time.
+
+import scala.language.unsafeNulls
+
+object Test:
+  val n: Null = null
+
+  val s = n.nn // no warning: the qualifier really can be null
+
+  def typeTest = null match
+    case _: AnyRef => 1
+    case _ => -1 // warn


### PR DESCRIPTION
#25393 left an oversight in `isNullableClassAfterErasure`. Now that `Null` `isValueClass`, `isNullableClassAfterErasure` needs to not blindly test `!isValueClass`.

## Have you relied on LLM-based tools in this contribution?

Human found the bug.
Claude wrote the tests and the fix.
Human reviewed the tests and the fix.

## How was the solution tested?

New automated tests