### PR TITLE
fix(repl): do not reuse a resN name that is still in use

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -572,7 +572,8 @@ class ReplDriver(settings: Array[String],
           ++ defs.map(rendering.renderMethod)
           ++ renderedVals
         val diagnostics = if formattedMembers.isEmpty then rendering.forceModule(symbol) else formattedMembers
-        (state.copy(valIndex = state.valIndex - vals.count(resAndUnit)), diagnostics)
+        val reclaimed = vals.toList.reverse.takeWhile(resAndUnit).length
+        (state.copy(valIndex = state.valIndex - reclaimed), diagnostics)
     }
     else (state, Seq.empty)
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -572,7 +572,10 @@ class ReplDriver(settings: Array[String],
           ++ defs.map(rendering.renderMethod)
           ++ renderedVals
         val diagnostics = if formattedMembers.isEmpty then rendering.forceModule(symbol) else formattedMembers
-        val reclaimed = vals.toList.reverse.takeWhile(resAndUnit).length
+        val reclaimed = vals.toList.reverse
+          .filter(_.symbol.name.show.startsWith(str.REPL_RES_PREFIX))
+          .takeWhile(resAndUnit)
+          .length
         (state.copy(valIndex = state.valIndex - reclaimed), diagnostics)
     }
     else (state, Seq.empty)

--- a/repl/test-resources/repl/i26973
+++ b/repl/test-resources/repl/i26973
@@ -7,3 +7,10 @@ val res2: Int = 1
 
 scala> res1 + 1
 val res3: Int = 43
+
+scala> { println("b"); val c = 3 }
+b
+val c: Int = 3
+
+scala> c + 1
+val res4: Int = 4

--- a/repl/test-resources/repl/i26973
+++ b/repl/test-resources/repl/i26973
@@ -1,0 +1,9 @@
+scala> { println("a"); 42 }
+a
+val res1: Int = 42
+
+scala> 1
+val res2: Int = 1
+
+scala> res1 + 1
+val res3: Int = 43


### PR DESCRIPTION
Fixes #26973

So instead of just counting how many Unit resN we bound, which breaks when one of them isn't the last binding, we count only the trailing Unit resN. A number can be given back only if no non-Unit resN comes after it.

EDIT: added `.filter(_.symbol.name.show.startsWith(str.REPL_RES_PREFIX))` so `val b = 42` does not get treated as res non-Unit

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
