### PR TITLE
Fix Java record unapply crash under explicit nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1920,7 +1920,7 @@ trait Applications extends Compatibility {
           // For `Rec()` we do `Boolean`
           if componentTypes.isEmpty then defn.BooleanType
           else if isVararg then
-            val defn.ArrayOf(elemType) = componentTypes.last.runtimeChecked
+            val defn.ArrayOf(elemType) = componentTypes.last.stripNull().runtimeChecked
             val wrapperType = defn.Array_UnapplySeqWrapper.typeRef.appliedTo(elemType)
             // For `Rec(T*)` we do `Array.UnapplySeqWrapper[T]`
             if componentTypes.length == 1 then wrapperType
@@ -1948,7 +1948,7 @@ trait Applications extends Compatibility {
           if fields.isEmpty then Literal(Constant(true))
           else if isVararg then
             val lastField = accessor(fields.last)
-            val defn.ArrayOf(lastElemType) = lastField.tpe.runtimeChecked
+            val defn.ArrayOf(lastElemType) = lastField.tpe.stripNull().runtimeChecked
             val lastFieldSeq = ref(defn.ArrayModule.requiredMethod(nme.unapplySeq))
               .appliedToType(lastElemType).appliedTo(lastField)
             if fields.length == 1 then lastFieldSeq

--- a/tests/explicit-nulls/pos/java-record-varargs-src/J.java
+++ b/tests/explicit-nulls/pos/java-record-varargs-src/J.java
@@ -1,0 +1,4 @@
+public class J {
+  public record RecVarOnly(String... xs) {}
+  public record RecVar(int x, String... xs) {}
+}

--- a/tests/explicit-nulls/pos/java-record-varargs-src/S.scala
+++ b/tests/explicit-nulls/pos/java-record-varargs-src/S.scala
@@ -1,0 +1,15 @@
+import J.*
+
+def varargOnly(r: RecVarOnly): Unit =
+  r match
+    case RecVarOnly(xs*) => xs.foreach(x => ())
+  r match
+    case RecVarOnly(a, rest*) => ()
+    case _ => ()
+
+def varargWithPrefix(r: RecVar): Unit =
+  r match
+    case RecVar(x, xs*) => xs.foreach(x => ())
+  r match
+    case RecVar(x, a, b) => ()
+    case _ => ()


### PR DESCRIPTION
#26497 did not consider explicit nulls, specifically the flexible types that are added for Java varargs. This PR fixes a crash when using the generated unapply under explicit nulls.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked fix and tests by hand.

## How was the solution tested?

New automated tests