### PR TITLE
Do not reuse the def's TypeTree when when wrapping rhs for inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -256,7 +256,10 @@ object PrepareInlineable {
 
   /** The type ascription `rhs: tpt`, unless `original` is `transparent`. */
   def wrapRHS(original: untpd.DefDef, tpt: Tree, rhs: Tree)(using Context): Tree =
-    if original.mods.is(Transparent) then rhs else Typed(rhs, tpt)
+    val isInferred = tpt match
+      case tpt: TypeTree => tpt.isInferred
+      case _ => false
+    if original.mods.is(Transparent) then rhs else Typed(rhs, TypeTree(tpt.tpe, inferred = isInferred).withSpan(tpt.span))
 
   /** Return result of evaluating `op`, but drop `Inline` flag and `Body` annotation
    *  of `sym` in case that leads to errors.

--- a/tests/pos/i24308.scala
+++ b/tests/pos/i24308.scala
@@ -1,0 +1,4 @@
+class ValHolder(val v: Int):
+  self =>
+  inline def doesntCompile: ValHolder { val v: self.v.type } = ???
+end ValHolder

--- a/tests/run-macros/i5119.check
+++ b/tests/run-macros/i5119.check
@@ -1,2 +1,2 @@
-Select(Typed(Apply(Select(New(TypeIdent("StringContextOps")), "<init>"), List(Apply(Select(Select(Select(Ident("_root_"), "scala"), "StringContext"), "apply"), List(Typed(Repeated(List(Literal(StringConstant("Hello World ")), Literal(StringConstant("!"))), Inferred()), Inferred()))))), TypeIdent("StringContextOps")), "Macro$StringContextOps$$inline$sc")
+Select(Typed(Apply(Select(New(TypeIdent("StringContextOps")), "<init>"), List(Apply(Select(Select(Select(Ident("_root_"), "scala"), "StringContext"), "apply"), List(Typed(Repeated(List(Literal(StringConstant("Hello World ")), Literal(StringConstant("!"))), Inferred()), Inferred()))))), Inferred()), "Macro$StringContextOps$$inline$sc")
 Typed(Repeated(List(Literal(IntConstant(1))), Inferred()), Inferred())


### PR DESCRIPTION
Fixes #24308

In the issue reproduction a pickler assertion was thrown because a single "val v" definition was attempted to be pickled twice - once as part of the definitions type tree, and a second time for the rhs wrapper in the method body added for non-transparent inline methods. Both definitions referred to the exact same symbol, causing the issue. 

Now, instead of reusing the return type typeTree directly, we just reuse its type, wrapping that into a TypeTree - this way the problematic symbol is not defined twice, just referred to. This is something also done elsewhere in the compiler e.g. in: https://github.com/scala/scala3/blob/47333e6d14f979304571c24f6eb4b089aaa6c182/compiler/src/dotty/tools/dotc/typer/Applications.scala#L504


## Have you relied on LLM-based tools in this contribution?

Yes, to find the culprit symbol duplication.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
