### PR TITLE
Fix typo in `->` ScalaDoc

### DIFF
--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -761,7 +761,7 @@ object Predef extends LowPriorityImplicits {
   extension [A](inline self: A)
     /**
      *  @tparam A the type of the left-hand side of the arrow association
-     *  @tparam B the type of the left-hand side of the arrow association
+     *  @tparam B the type of the right-hand side of the arrow association
      *  @param self the value to use as the first element of the resulting tuple
      *  @param that the value to use as the second element of the resulting tuple
      */


### PR DESCRIPTION
## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

N/A