### PR TITLE
Also dealias transparent types when dealiasing opaques in typedSplice

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1112,6 +1112,9 @@ class Inliner(val call: tpd.Tree)(using Context):
               case tp: TypeRef if tp.typeSymbol.isOpaqueAlias =>
                 val sym = tp.typeSymbol
                 apply(sym.opaqueAlias.asSeenFrom(tp.prefix, sym.owner))
+              case tp: TypeRef if tp.typeSymbol.isAliasType =>
+                val tp1 = tp.dealias
+                if tp1 eq tp then tp else apply(tp1)
               case _ =>
                 mapOver(tp)
 

--- a/tests/pos-macros/i26947/Macro_1.scala
+++ b/tests/pos-macros/i26947/Macro_1.scala
@@ -1,0 +1,18 @@
+package lib
+
+import scala.quoted.*
+
+object Wrapper:
+  opaque type Impl = Int
+  object Impl:
+    def apply(x: Int): Impl = x
+
+type MyType = Wrapper.Impl
+object MyType:
+  def apply(x: Int): MyType = Wrapper.Impl(x)
+
+object MyMacro:
+  def createImpl(using Quotes): Expr[MyType] =
+    '{ MyType(42) }
+
+  inline def create: MyType = ${ createImpl }

--- a/tests/pos-macros/i26947/Test_2.scala
+++ b/tests/pos-macros/i26947/Test_2.scala
@@ -1,0 +1,5 @@
+package lib
+
+@main def test =
+  val x: MyType = MyMacro.create
+  println(x)


### PR DESCRIPTION
Fixes #26947 

The issue was introduced in https://github.com/scala/scala3/commit/69f7ab1d9eacc9ade77d5d9f4732eff1bc5ffc2a, with the opaque dealiasing introduced when typechecking a splice. The problem in the reproduction was that, without also dealiasing transparent types, we would not handle a chain like  `MyType (transparent) -> Wrapper.Impl (opaque) -> Int` correctly, when comparing to `Wrapper.Impl (opaque) -> Int`.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
