### PR TITLE
Make parameter proxies of inline methods have explicit types

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -353,7 +353,7 @@ class Inliner(val call: tpd.Tree)(using Context):
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
       if isByName then DefDef(boundSym, newArg)
-      else ValDef(boundSym, newArg, inferred = true)
+      else ValDef(boundSym, newArg)
     }.withSpan(boundSym.span)
     if !argIsBottom then // Record typer skolem on the proxy ValDef, so the `avoidingType` can avoid proxy to skolem.
       skolem.foreach(binding.putAttachment(TypeAssigner.InlineProxySkolem, _))
@@ -810,7 +810,7 @@ class Inliner(val call: tpd.Tree)(using Context):
     // corresponding arguments or proxies on the type and term level. It also changes
     // the owner from the inlined method to the current owner.
 
-    // This is reused through InlineTraitAncestors for inline traits, so inlinedMethod might not exist there  
+    // This is reused through InlineTraitAncestors for inline traits, so inlinedMethod might not exist there
     val oldOwners = if (inlinedMethod.exists) then inlinedMethod :: Nil else Nil
     val newOwners = if (inlinedMethod.exists) then ctx.owner :: Nil else Nil
 

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -11,6 +11,7 @@ import NameKinds.InlineBinderName
 import ProtoTypes.shallowSelectionProto
 import SymDenotations.SymDenotation
 import Inferencing.isFullyDefined
+import config.Feature
 import config.Printers.inlining
 import ErrorReporting.errorTree
 import util.{SimpleIdentitySet, SrcPos}
@@ -742,6 +743,12 @@ class Inliner(val call: tpd.Tree)(using Context):
         // reference to a private method is kept at runtime.
         cpy.Select(tree)(qual.asInstance(qual.tpe.widen), name)
 
+      case tree: TypeTree if Feature.ccEnabled =>
+        // cc.Setup.setupTraverser.transformTT creates scope-dependent capture types,
+        // cached by tree identity in transform.Recheck.Rechecker.nuTypes. Sharing a
+        // TypeTree would reuse the definition's (or another call's) capture roots
+        // in this expansion. See tests/pos-custom-args/captures/inline-result-captures.scala.
+        tree.cloneIn(tree.source)
       case tree => tree
     }
 

--- a/tests/neg-custom-args/captures/cc-inline1.check
+++ b/tests/neg-custom-args/captures/cc-inline1.check
@@ -1,0 +1,149 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:65:41 -----------------------------------
+65 |  val leaked1 = Fs.useFile(f => llist.map({x => f.write(x); x + 1})) // error
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                Found:    scala.collection.immutable.LazyListIterable[Int]^{f}
+   |                                Required: scala.collection.immutable.LazyListIterable[Int]
+   |
+   |                                Note that capability `f` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:66:32 -----------------------------------
+66 |  val leaked2 = Fs.useFile(l => l) // error
+   |                                ^
+   |Found:    (l : Fs.FileHandle^{any})
+   |Required: Fs.FileHandle
+   |
+   |Note that capability `any` cannot flow into capture set {}.
+   |
+   |where:    any is a root capability created in anonymous function of type (l²: Fs.FileHandle^): Fs.FileHandle of parameter parameter l of method $anonfun
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:67:32 -----------------------------------
+67 |  val leaked3 = Fs.useFile(f => () => f.write(42)) // error
+   |                                ^^^^^^^^^^^^^^^^^
+   |                                Found:    () ->{f} Unit
+   |                                Required: () -> Unit
+   |
+   |                                Note that capability `f` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:69:56 -----------------------------------
+69 |    val proxy: (f: Fs.FileHandle^) -> () -> Unit = f => () => f.write(42) // error
+   |                                                        ^^^^^^^^^^^^^^^^^
+   |                                                       Found:    () ->{f} Unit
+   |                                                       Required: () -> Unit
+   |
+   |                                                       Note that capability `f` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:75:33 -----------------------------------
+75 |  val _: LazyListIterable[Int] = leaked1 // error
+   |                                 ^^^^^^^
+   |                                 Found:    (leaked1 :
+   |                                   scala.collection.immutable.LazyListIterable[Int]{
+   |                                     val lazyState:
+   |                                       (scala.collection.immutable.LazyListIterable.EmptyMarker.type | (() ->
+   |                                         scala.collection.immutable.LazyListIterable[Int]^))^²
+   |                                   }^{any}
+   |                                 )
+   |                                 Required: scala.collection.immutable.LazyListIterable[Int]
+   |
+   |                                 Note that capability `any` cannot flow into capture set {}.
+   |
+   |                                 where:    ^   refers to a root capability in the type of value leaked1
+   |                                           ^²  refers to a root capability in the type of value lazyState
+   |                                           any is a root capability in the type of value leaked1
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:77:25 -----------------------------------
+77 |  val _: Fs.FileHandle = leaked2 // error
+   |                         ^^^^^^^
+   |                         Found:    (leaked2 : Fs.FileHandle^{any})
+   |                         Required: Fs.FileHandle
+   |
+   |                         Note that capability `any` cannot flow into capture set {}.
+   |
+   |                         where:    any is a root capability in the type of value leaked2
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:79:22 -----------------------------------
+79 |  val _: () -> Unit = leaked3 // error
+   |                      ^^^^^^^
+   |                      Found:    (leaked3 : () ->{any} Unit)
+   |                      Required: () -> Unit
+   |
+   |                      Note that capability `any` cannot flow into capture set {}.
+   |
+   |                      where:    any is a root capability in the type of value leaked3
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:83:42 -----------------------------------
+83 |  val leaked1 = Fs.useFile2(f => llist.map({x => f.write(x); x + 1})) // error
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 Found:    scala.collection.immutable.LazyListIterable[Int]^{f}
+   |                                 Required: scala.collection.immutable.LazyListIterable[Int]
+   |
+   |                                 Note that capability `f` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:84:33 -----------------------------------
+84 |  val leaked2 = Fs.useFile2(l => l) // error
+   |                                 ^
+   |Found:    (l : Fs.FileHandle^{any})
+   |Required: Fs.FileHandle
+   |
+   |Note that capability `any` cannot flow into capture set {}.
+   |
+   |where:    any is a root capability created in anonymous function of type (l²: Fs.FileHandle^): Fs.FileHandle of parameter parameter l of method $anonfun
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:85:33 -----------------------------------
+85 |  val leaked3 = Fs.useFile2(f => () => f.write(42)) // error
+   |                                 ^^^^^^^^^^^^^^^^^
+   |                                 Found:    () ->{f} Unit
+   |                                 Required: () -> Unit
+   |
+   |                                 Note that capability `f` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:90:33 -----------------------------------
+90 |  val _: LazyListIterable[Int] = leaked1 // error
+   |                                 ^^^^^^^
+   |                                 Found:    (leaked1 :
+   |                                   scala.collection.immutable.LazyListIterable[Int]{
+   |                                     val lazyState:
+   |                                       (scala.collection.immutable.LazyListIterable.EmptyMarker.type | (() ->
+   |                                         scala.collection.immutable.LazyListIterable[Int]^))^²
+   |                                   }^{any}
+   |                                 )
+   |                                 Required: scala.collection.immutable.LazyListIterable[Int]
+   |
+   |                                 Note that capability `any` cannot flow into capture set {}.
+   |
+   |                                 where:    ^   refers to a root capability in the type of value leaked1
+   |                                           ^²  refers to a root capability in the type of value lazyState
+   |                                           any is a root capability in the type of value leaked1
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:92:25 -----------------------------------
+92 |  val _: Fs.FileHandle = leaked2 // error
+   |                         ^^^^^^^
+   |                         Found:    (leaked2 : Fs.FileHandle^{any})
+   |                         Required: Fs.FileHandle
+   |
+   |                         Note that capability `any` cannot flow into capture set {}.
+   |
+   |                         where:    any is a root capability in the type of value leaked2
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-inline1.scala:94:22 -----------------------------------
+94 |  val _: () -> Unit = leaked3 // error
+   |                      ^^^^^^^
+   |                      Found:    (leaked3 : () ->{any} Unit)
+   |                      Required: () -> Unit
+   |
+   |                      Note that capability `any` cannot flow into capture set {}.
+   |
+   |                      where:    any is a root capability in the type of value leaked3
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/cc-inline1.scala
+++ b/tests/neg-custom-args/captures/cc-inline1.scala
@@ -1,0 +1,106 @@
+import scala.language.experimental.{captureChecking}
+import caps.unsafe.untrackedCaptures
+
+object Fs {
+
+  class FileHandle {
+    @untrackedCaptures var isClosed = false
+    def write(x: Int): Unit = {
+      if isClosed then
+        throw new IllegalStateException("File is closed")
+      else
+        println(s"Writing $x to file")
+    }
+    def close(): Unit = {
+      isClosed = true
+    }
+  }
+
+  inline def useFile[T](body: FileHandle^ => T): T =
+    val fileHandle: FileHandle = new FileHandle
+    try {
+      body(fileHandle)
+    } finally {
+      fileHandle.close()
+    }
+
+  inline def useFile1[T](inline body: FileHandle^ => T): T =
+    val fileHandle: FileHandle^ = new FileHandle
+    try {
+      body(fileHandle)
+    } finally {
+      fileHandle.close()
+    }
+
+  inline def useFile1Leaky[T](inline body: FileHandle^ => T): T =
+    val fileHandle: FileHandle = new FileHandle   // need to be declared FileHandle^, or its not a capability
+    try {
+      body(fileHandle)
+    } finally {
+      fileHandle.close()
+    }
+
+  transparent inline def useFile2[T](body: FileHandle^ => T): T =
+    val fileHandle: FileHandle = new FileHandle
+    try {
+      body(fileHandle)
+    } finally {
+      fileHandle.close()
+    }
+
+  transparent inline def useFile3[T](inline body: FileHandle^ => T): T =
+    val fileHandle: FileHandle^ = new FileHandle
+    try {
+      body(fileHandle)
+    } finally {
+      fileHandle.close()
+    }
+}
+// Example.scala
+import scala.collection.immutable.LazyListIterable
+
+def testInline = {
+  val llist = LazyListIterable(1, 2, 3)
+  val fileHandle: Fs.FileHandle^ = new Fs.FileHandle()
+  val leaked1 = Fs.useFile(f => llist.map({x => f.write(x); x + 1})) // error
+  val leaked2 = Fs.useFile(l => l) // error
+  val leaked3 = Fs.useFile(f => () => f.write(42)) // error
+  val leaked4 =
+    val proxy: (f: Fs.FileHandle^) -> () -> Unit = f => () => f.write(42) // error
+    ()
+}
+def testInline1 = {
+  val llist = LazyListIterable(1, 2, 3)
+  val leaked1 = Fs.useFile1(f => llist.map({x => f.write(x); x + 1}))
+  val _: LazyListIterable[Int] = leaked1 // error
+  val leaked2 = Fs.useFile1(l => l)
+  val _: Fs.FileHandle = leaked2 // error
+  val leaked3 = Fs.useFile1(f => () => f.write(42))
+  val _: () -> Unit = leaked3 // error
+}
+def testTransparent = {
+  val llist = LazyListIterable(1, 2, 3)
+  val leaked1 = Fs.useFile2(f => llist.map({x => f.write(x); x + 1})) // error
+  val leaked2 = Fs.useFile2(l => l) // error
+  val leaked3 = Fs.useFile2(f => () => f.write(42)) // error
+}
+def testTransparent1 = {
+  val llist = LazyListIterable(1, 2, 3)
+  val leaked1 = Fs.useFile3(f => llist.map({x => f.write(x); x + 1}))
+  val _: LazyListIterable[Int] = leaked1 // error
+  val leaked2 = Fs.useFile3(l => l)
+  val _: Fs.FileHandle = leaked2 // error
+  val leaked3 = Fs.useFile3(f => () => f.write(42))
+  val _: () -> Unit = leaked3 // error
+}
+
+def testInlineLeaky = {
+  val llist = LazyListIterable(1, 2, 3)
+  val leaked1 = Fs.useFile1Leaky(f => llist.map({x => f.write(x); x + 1}))
+  val _: LazyListIterable[Int] = leaked1 // ok
+  val leaked2 = Fs.useFile1Leaky(l => l)
+  val _: Fs.FileHandle = leaked2 // ok
+  val leaked3 = Fs.useFile1Leaky(f => () => f.write(42))
+  val _: () -> Unit = leaked3 // ok
+}
+

--- a/tests/pos-custom-args/captures/inline-result-captures.scala
+++ b/tests/pos-custom-args/captures/inline-result-captures.scala
@@ -1,0 +1,9 @@
+import language.experimental.captureChecking
+
+class Resource extends caps.ExclusiveCapability:
+  def use(): Unit = ()
+  inline def action(cond: Boolean): Int ?=> Unit = if cond then use()
+
+def condition(): Boolean = true
+// Keep the result closure from being beta-reduced before capture checking.
+def test(r: Resource^): Unit = r.action(condition())(using 1)

--- a/tests/run/errorhandling/Test.scala
+++ b/tests/run/errorhandling/Test.scala
@@ -81,6 +81,17 @@ def validateTest() = {
   import Validation.validate
   import Validation.scope
 
+  locally {
+    // FIXME: leaker!
+
+    class ParseErr
+
+    Validation.validate[() => Validation[ParseErr]^, ParseErr] {
+      val v = scope
+      () => v
+    }
+  }
+
   case class Email private (value: String)
   object Email:
     def from(raw: String): Result[Email, String] =

--- a/tests/run/errorhandling/Test.scala
+++ b/tests/run/errorhandling/Test.scala
@@ -81,17 +81,6 @@ def validateTest() = {
   import Validation.validate
   import Validation.scope
 
-  locally {
-    // FIXME: leaker!
-
-    class ParseErr
-
-    Validation.validate[() => Validation[ParseErr]^, ParseErr] {
-      val v = scope
-      () => v
-    }
-  }
-
   case class Email private (value: String)
   object Email:
     def from(raw: String): Result[Email, String] =

--- a/tests/run/errorhandling/Test.scala
+++ b/tests/run/errorhandling/Test.scala
@@ -79,6 +79,7 @@ def resultTest() = {
 def validateTest() = {
   println("validateTest")
   import Validation.validate
+  import Validation.scope
 
   case class Email private (value: String)
   object Email:
@@ -88,17 +89,17 @@ def validateTest() = {
   case class Form(name: String, email: Email, age: Int)
 
   def validatedForm(name: String, rawEmail: String, age: Int, confirmed: Boolean): Result[Form, List[String]] =
-    validate: v =>
-      v.require(!name.isEmpty, "Missing name")
-      v.test(name.head.isUpper, s"${name} does not start with uppercase letter")
-      val email = v.test(Email.from(rawEmail))
-      v.test(age >= 18, s"Age ${age} is below minimum age 18")
-      v.test(confirmed, "Missing confirmation")
-      Form(name, email.valid, age)
+    validate:
+      scope.require(!name.isEmpty, "Missing name")
+      scope.test(name.head.isUpper, s"${name} does not start with uppercase letter")
+      val email = scope.test(Email.from(rawEmail))
+      scope.test(age >= 18, s"Age ${age} is below minimum age 18")
+      scope.test(confirmed, "Missing confirmation")
+      Form(name, email.?, age)
 
   // Good stuff: can no longer edit the scope if you leak it
   // def leak(): Unit =
-  //   val leaked: Result[Validation[String]^, List[String]] = Validation.validate: v =>
+  //   val leaked: Result[Validation[String]^, List[String]] = Validation.validate:
   //     v
   //   leaked match
   //     case Ok(scope) =>
@@ -114,21 +115,21 @@ def validateTest() = {
     case Refund(invoiceId: String, reason: String)
 
   def validateJson(json: JsonDict): Result[InvoiceOrRefund, List[String]] =
-    validate: v =>
-      val kind = v.require(Result.fromOption(json.get("kind"), "missing 'kind'"))
-      v.require(kind == "invoice" || kind == "refund", s"invalid 'kind' ${kind}")
+    validate:
+      val kind = scope.test(Result.fromOption(json.get("kind"), "missing 'kind'")).?
+      scope.require(kind == "invoice" || kind == "refund", s"invalid 'kind' ${kind}")
       if kind == "invoice" then
-        val customerId = v.test(Result.fromOption(json.get("customerId"), s"Missing customerId"))
-        val amount = v.test {
+        val customerId = scope.test(Result.fromOption(json.get("customerId"), s"Missing customerId"))
+        val amount = scope.test {
           respond:
             val amount = Result.fromOption(json.get("amount"), s"Missing amount").?
             Result(BigInt(amount)).mapErr(err => s"Invalid amount: ${err.getMessage}").?
         }
-        InvoiceOrRefund.Invoice(customerId.valid, amount.valid)
+        InvoiceOrRefund.Invoice(customerId.?, amount.?)
       else
-        val invoiceId = v.test(Result.fromOption(json.get("invoiceId"), s"Missing invoiceId"))
-        val reason = v.test(Result.fromOption(json.get("reason"), s"Missing reason"))
-        InvoiceOrRefund.Refund(invoiceId.valid, reason.valid)
+        val invoiceId = scope.test(Result.fromOption(json.get("invoiceId"), s"Missing invoiceId"))
+        val reason = scope.test(Result.fromOption(json.get("reason"), s"Missing reason"))
+        InvoiceOrRefund.Refund(invoiceId.?, reason.?)
 
   def printResult[T, E](result: Result[T, List[E]]): Unit = result match
     case Ok(value) => println(s"ok: $value")

--- a/tests/run/errorhandling/Validator.scala
+++ b/tests/run/errorhandling/Validator.scala
@@ -1,74 +1,91 @@
 //> using options -language:experimental.captureChecking,experimental.separationChecking
 package scala.util
-import boundary.{break, Label}
+
+import language.experimental.{captureChecking, separationChecking}
+
+import scala.util.boundary, boundary.{break, Label}
+
 import collection.mutable
 import caps.Control
 import caps.fresh
 import caps.any
 import caps.Control
 
-import Validation.{Validated, Checked}
+import Validation.{Checked, Validated, Tested, CanCheck}
+import scala.annotation.publicInBinary
+import Validation.Step
 
 object Validation {
-  object Abort
-  type Abort = Abort.type
 
-  type Checked[+T] = Label[Abort] ?-> T
+  type Validated[+T, E] = Result[T, List[E]]
+  type Tested[+T] = Result[T, Unit]
+  type CanCheck = boundary.Label[Err[Unit]]
+  type Checked[+T] = CanCheck ?=> T
+  type Step[+T, E] = (CanCheck, Validation[E]^) ?=> T
+  def scope[E](using scope: Validation[E]^): scope.type = scope
 
-  inline def validate[T, E](inline op: Validation[E]^ -> Checked[T]): Result[T, List[E]] =
-    val scope: Validation[E]^ = new Validation[E]
-    val userResult =
-      boundary[Validated[T]]:
-        Validated.success(op(scope))
-    caps.freeze(scope)
-    val errors = scope.snapshot
-    userResult match
-      case ok: Ok[?] if errors.isEmpty => ok
-      case _ => Err(errors)
+  inline def validate[T, E](inline step: Step[T, E]): Validated[T, E] =
+    given (Validation[E]^)()
+    scope.result(step)
 
+  val invalid: Err[Unit] = Err(())
 
-  opaque type Validated[+A] = Ok[A] | Abort
-  object Validated:
-    def failure: Validated[Nothing] = Abort
-    def success[A](value: A): Validated[A] = Ok(value)
-    def fromOk[A](value: Ok[A]): Validated[A] = value
-    extension [A](c: Validated[A])
-      inline def valid: Checked[A] = c match
-        case ok: Ok[?] => ok.value
-        case _ => scala.util.boundary.break(Abort)
 }
 
-class Validation[E] extends caps.Mutable:
+class Validation[E] extends caps.Stateful, caps.ExclusiveCapability:
   self: Validation[E]^{any} =>
 
   private val errors = mutable.ListBuffer[E]()
 
-  def snapshot: List[E] = errors.toList
+  consume def close(): List[E] = {
+    val es = errors.toList
+    errors.clear()
+    es
+  }
 
-  update def appendOne(e: E): Unit =
+  @publicInBinary
+  private[Validation] update def appendOne(e: E): Unit =
     errors += e
 
-  update inline def test(inline cond: Boolean, inline error: E): Unit =
+  @publicInBinary
+  private[Validation] update def appendAll(es: List[E]): Unit =
+    errors ++= es
+
+  update inline def test(cond: Boolean, inline error: E): Unit =
     if !cond then
       appendOne(error)
 
-  update inline def test[A](inline cond: Result[A, E]): Validated[A] =
-    cond match
-      case ok: Ok[?] =>
-        Validated.fromOk(ok)
-      case Err(e) =>
-        appendOne(e)
-        Validated.failure
-
-  update inline def require(inline cond: Boolean, inline error: E): Checked[Unit] =
+  update inline def require(cond: Boolean, inline error: E): Checked[Unit] = (lbl: CanCheck) ?=>
     if !cond then
       appendOne(error)
-      break(Validation.Abort)
+      break(Validation.invalid)
 
-  update inline def require[A](inline cond: Result[A, E]): Checked[A] =
+  update def test[A](cond: Result[A, E]): Tested[A] =
     cond match
       case ok: Ok[?] =>
-        ok.value
+        ok
       case Err(e) =>
         appendOne(e)
-        break(Validation.Abort)
+        Validation.invalid
+
+  inline update def testStep[A](inline cond: Step[A, E]): Tested[A] =
+    val scope: Validation[E]^{this} = this
+    val tested = boundary[Tested[A]] { lbl ?=>
+      Ok(cond(using lbl, scope))
+    }
+    tested
+
+  update def testAll[A](validated: Validated[A, E]): Tested[A] =
+    validated match
+      case ok: Ok[?] =>
+        ok
+      case Err(es) =>
+        appendAll(es)
+        Validation.invalid
+
+  inline consume def result[A](inline cond: Step[A, E]): Validated[A, E] =
+    val validated = testStep(cond)
+    val errs = close()
+    validated match
+      case ok @ Ok(_) if errs.isEmpty => ok
+      case _ => Err(errs)

--- a/tests/run/errorhandling/Validator.scala
+++ b/tests/run/errorhandling/Validator.scala
@@ -25,8 +25,12 @@ object Validation {
   def scope[E](using scope: Validation[E]^): scope.type = scope
 
   inline def validate[T, E](inline step: Step[T, E]): Validated[T, E] =
-    given (Validation[E]^)()
-    scope.result(step)
+    val scp: Validation[E]^ = Validation[E]()
+    // FIXME: would prefer to do scp.result(step) but this breaks capture checking error messages
+    val tested = boundary[Tested[T]] { lbl ?=>
+      Ok(step(using lbl, scp))
+    }
+    scp.finish(tested)
 
   val invalid: Err[Unit] = Err(())
 
@@ -83,9 +87,13 @@ class Validation[E] extends caps.Stateful, caps.ExclusiveCapability:
         appendAll(es)
         Validation.invalid
 
-  inline consume def result[A](inline cond: Step[A, E]): Validated[A, E] =
-    val validated = testStep(cond)
+  inline consume def result[A](consume inline cond: Step[A, E]): Validated[A, E] =
+    val tested = testStep(cond)
+    finish(tested)
+
+  @publicInBinary
+  private[Validation] consume def finish[A](consume tested: Tested[A]): Validated[A, E] =
     val errs = close()
-    validated match
+    tested match
       case ok @ Ok(_) if errs.isEmpty => ok
       case _ => Err(errs)


### PR DESCRIPTION
Fixes #26982

## Have you relied on LLM-based tools in this contribution?

Originally, no. Then after https://github.com/scala/scala3/pull/26976 was merged, then a new error appeared. @bishabosha used GPT-6 Astra to diagnose that when a call is inlined, it can share TypeTree's, but these need to be cloned so that identity maps in cc see a different tree.
