### PR TITLE
Scala.js: Prepare for minimal Wasm modules.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -3035,7 +3035,10 @@ class JSCodeGen()(using genCtx: Context) {
           else externalEqualsNumObject
         } else externalEquals
       }
-      genApplyStatic(equalsMethod, List(lsrc, rsrc))
+
+      // Force the non-module class, to be consistent with the JVM
+      js.ApplyStatic(js.ApplyFlags.empty, BoxesRunTimeClassName,
+          encodeMethodSym(equalsMethod), List(lsrc, rsrc))(jstpe.BooleanType)
     } else {
       // if (lsrc eq null) rsrc eq null else lsrc.equals(rsrc)
       if (lsym == defn.StringClass) {
@@ -5257,6 +5260,7 @@ object JSCodeGen {
 
   private val AbstractFunction0ClassName = ClassName("scala.runtime.AbstractFunction0")
   private val AbstractFunction1ClassName = ClassName("scala.runtime.AbstractFunction1")
+  private val BoxesRunTimeClassName = ClassName("scala.runtime.BoxesRunTime")
   private val Function0ClassName = ClassName("scala.Function0")
   private val Function1ClassName = ClassName("scala.Function1")
   private val Tuple2ClassName = ClassName("scala.Tuple2")

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1059,8 +1059,12 @@ class JSCodeGen()(using genCtx: Context) {
       implicit pos: SourcePosition): Option[js.Tree] = {
     val fqcnArg = js.StringLiteral(sym.fullName.toString)
     val runtimeClassArg = js.ClassOf(toTypeRef(sym.info))
-    val loadModuleFunArg =
-      js.Closure(js.ClosureFlags.arrow, Nil, Nil, None, jstpe.AnyType, genLoadModule(sym), Nil)
+
+    val loadModuleFunArg = js.NewLambda(
+        js.NewLambda.Descriptor(AbstractFunction0ClassName, Nil,
+            MethodName("apply", Nil, jswkn.ObjectRef), Nil, jstpe.AnyType),
+        js.Closure(js.ClosureFlags.typed, Nil, Nil, None, jstpe.AnyType, genLoadModule(sym), Nil)
+    )(jstpe.ClassType(Function0ClassName, nullable = false, exact = false))
 
     val stat = genApplyMethod(
         genLoadModule(jsdefn.ReflectModule),
@@ -1079,33 +1083,83 @@ class JSCodeGen()(using genCtx: Context) {
     if (ctors.isEmpty) {
       None
     } else {
+      val objectArrayRef = jstpe.ArrayTypeRef(jswkn.ObjectRef, 1)
+      val objectArrayType = jstpe.ArrayType(objectArrayRef, nullable = true, exact = false)
+      val tuple2ArrayRef = jstpe.ArrayTypeRef(jstpe.ClassRef(Tuple2ClassName), 1)
+      val classClassRef = jstpe.ClassRef(jswkn.ClassClass)
+      val classArrayRef = jstpe.ArrayTypeRef(classClassRef, 1)
+
+      val tuple2Ctor = MethodName.constructor(List(jswkn.ObjectRef, jswkn.ObjectRef))
+
+      val newInstanceFunDescriptor = {
+        js.NewLambda.Descriptor(AbstractFunction1ClassName, Nil,
+            MethodName("apply", List(jswkn.ObjectRef), jswkn.ObjectRef),
+            List(jstpe.AnyType), jstpe.AnyType)
+      }
+
       val constructorsInfos = for {
         ctor <- ctors
       } yield {
-        withNewLocalNameScope {
-          val (parameterTypes, formalParams, actualParams) = (for {
-            (paramName, paramInfo) <- ctor.info.paramNamess.flatten.zip(ctor.info.paramInfoss.flatten)
+        val paramTypesArray = js.ArrayValue(classArrayRef,
+            ctor.info.paramInfoss.flatten.map(ptpe => js.ClassOf(toTypeRef(ptpe))))
+
+        val newInstanceClosure = {
+          // param args: Object
+          val argsParamDef = js.ParamDef(js.LocalIdent(LocalName("args")),
+              NoOriginalName, jstpe.AnyType, mutable = false)
+
+          // val argsArray: Object[] = args.asInstanceOf[Object[]]
+          val argsArrayVarDef = js.VarDef(js.LocalIdent(LocalName("argsArray")),
+              NoOriginalName, objectArrayType, mutable = false,
+              js.AsInstanceOf(argsParamDef.ref, objectArrayType))
+
+          // argsArray[i].asInstanceOf[Ti] for every parameter of the constructor
+          val actualParams = for {
+            (paramType, index) <- ctor.info.paramInfoss.flatten.zipWithIndex
           } yield {
-            val paramType = js.ClassOf(toTypeRef(paramInfo))
-            val paramDef = js.ParamDef(freshLocalIdent(paramName),
-                NoOriginalName, jstpe.AnyType, mutable = false)
-            val actualParam = unbox(paramDef.ref, paramInfo)
-            (paramType, paramDef, actualParam)
-          }).unzip3
+            /* Note that we do *not* use `paramType` entering posterasure
+             * (neither to compute `paramType` nor to give to `unbox`).
+             * Logic would tell us that we should do so, but we intentionally
+             * do not to preserve the behavior on the JVM regarding value
+             * classes. If a constructor takes a value class as parameter, as
+             * in:
+             *
+             *   class ValueClass(val underlying: Int) extends AnyVal
+             *   class Foo(val vc: ValueClass)
+             *
+             * then, from a reflection point of view, on the JVM, the
+             * constructor of `Foo` takes an `Int`, not a `ValueClas`. It
+             * must therefore be identified as the constructor whose
+             * parameter types is `List(classOf[Int])`, and when invoked
+             * reflectively, it must be given an `Int` (or `Integer`).
+             */
+            unbox(
+                js.ArraySelect(argsArrayVarDef.ref, js.IntLiteral(index))(jstpe.AnyType),
+                paramType)
+          }
 
-          val paramTypesArray = js.JSArrayConstr(parameterTypes)
-
-          val newInstanceFun = js.Closure(js.ClosureFlags.arrow, Nil, formalParams, None, jstpe.AnyType, {
-            js.New(encodeClassName(sym), encodeMethodSym(ctor), actualParams)
+          /* typed-lambda<>(args: Object): any = {
+           *   val argsArray: Object[] = args.asInstanceOf[Object[]]
+           *   new MyClass(...argsArray[i].asInstanceOf[Ti])
+           * }
+           */
+          js.Closure(js.ClosureFlags.typed, Nil, argsParamDef :: Nil, None, jstpe.AnyType, {
+            js.Block(
+              argsArrayVarDef,
+              js.New(encodeClassName(sym), encodeMethodSym(ctor), actualParams)
+            )
           }, Nil)
-
-          js.JSArrayConstr(List(paramTypesArray, newInstanceFun))
         }
+
+        val newInstanceFun = js.NewLambda(newInstanceFunDescriptor, newInstanceClosure)(
+            jstpe.ClassType(Function1ClassName, nullable = false, exact = false))
+
+        js.New(Tuple2ClassName, js.MethodIdent(tuple2Ctor), List(paramTypesArray, newInstanceFun))
       }
 
       val fqcnArg = js.StringLiteral(sym.fullName.toString)
       val runtimeClassArg = js.ClassOf(toTypeRef(sym.info))
-      val ctorsInfosArg = js.JSArrayConstr(constructorsInfos)
+      val ctorsInfosArg = js.ArrayValue(tuple2ArrayRef, constructorsInfos)
 
       val stat = genApplyMethod(
           genLoadModule(jsdefn.ReflectModule),
@@ -5196,6 +5250,12 @@ object JSCodeGen {
   private val JSObjectClassName = ClassName("scala.scalajs.js.Object")
   private val JavaScriptExceptionClassName = ClassName("scala.scalajs.js.JavaScriptException")
   private val ScalaJSRuntimeModClassName = ClassName("scala.scalajs.runtime.package$")
+
+  private val AbstractFunction0ClassName = ClassName("scala.runtime.AbstractFunction0")
+  private val AbstractFunction1ClassName = ClassName("scala.runtime.AbstractFunction1")
+  private val Function0ClassName = ClassName("scala.Function0")
+  private val Function1ClassName = ClassName("scala.Function1")
+  private val Tuple2ClassName = ClassName("scala.Tuple2")
 
   private val ObjectArrayTypeRef = jstpe.ArrayTypeRef(jswkn.ObjectRef, 1)
 

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -869,14 +869,19 @@ class JSCodeGen()(using genCtx: Context) {
 
     assert(moduleClass.is(ModuleClass), moduleClass)
 
+    /* Unlike the JVM backend, we detect conflicts based on full signatures,
+     * not just simple names. Moreover, we only issue conflicts with *static*
+     * methods. In principle, this means we never have actual conflicts, and
+     * we can generate forwarders for all candidate methods.
+     *
+     * This is particularly important when we use Scala `object`s as
+     * implementations for Java static methods.
+     */
     val existingPublicStaticMethodNames = existingMethods.collect {
       case js.MethodDef(flags, name, _, _, _, _)
           if flags.namespace == js.MemberNamespace.PublicStatic =>
         name.name
     }.toSet
-
-    val staticNames = moduleClass.companionClass.info.allMembers
-      .collect { case d if d.name.isTermName && d.symbol.isScalaStatic => d.name }.toSet
 
     val members = {
       moduleClass.info.membersBasedOnFlags(required = Flags.Method,
@@ -900,7 +905,6 @@ class JSCodeGen()(using genCtx: Context) {
         || hasAccessBoundary
         || isOfJLObject
         || m.hasAnnotation(jsdefn.JSNativeAnnot) || isDefaultParamOfJSNativeDef // #4557
-        || staticNames(m.name)
     }
 
     val forwarders = for {

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -248,9 +248,9 @@ final class JSDefinitions() {
 
   @threadUnsafe lazy val ReflectModuleRef = requiredModuleRef("scala.scalajs.reflect.Reflect")
   def ReflectModule(using Context) = ReflectModuleRef.symbol
-    @threadUnsafe lazy val Reflect_registerLoadableModuleClassR = ReflectModule.requiredMethodRef("registerLoadableModuleClass")
+    @threadUnsafe lazy val Reflect_registerLoadableModuleClassR = ReflectModule.requiredMethodRef("registerLoadableModuleClassV2")
     def Reflect_registerLoadableModuleClass(using Context) = Reflect_registerLoadableModuleClassR.symbol
-    @threadUnsafe lazy val Reflect_registerInstantiatableClassR = ReflectModule.requiredMethodRef("registerInstantiatableClass")
+    @threadUnsafe lazy val Reflect_registerInstantiatableClassR = ReflectModule.requiredMethodRef("registerInstantiatableClassV2")
     def Reflect_registerInstantiatableClass(using Context) = Reflect_registerInstantiatableClassR.symbol
 
   @threadUnsafe lazy val ReflectSelectableType: TypeRef = requiredClassRef("scala.reflect.Selectable")

--- a/library-js/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library-js/src/scala/collection/mutable/ArrayBuilder.scala
@@ -20,6 +20,7 @@ import scala.runtime.BoxedUnit
 
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** A builder class for arrays.
  *
@@ -101,9 +102,13 @@ object ArrayBuilder {
    *  @return       a new empty array builder.
    */
   @inline
-  def make[T: ClassTag]: ArrayBuilder[T] =
-    if (LinkingInfo.isWebAssembly) makeForWasm
-    else makeForJS
+  def make[T: ClassTag]: ArrayBuilder[T] = {
+    linkTimeIf(LinkingInfo.isWebAssembly) {
+      makeForWasm
+    } {
+      makeForJS
+    }
+  }
 
   /** Implementation of `make` for JS.
    *

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -16,6 +16,8 @@ package mutable
 import scala.language.`2.13`
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.linkTimeIf
 
 /** A `Buffer` is a growable and shrinkable `Seq`.
  *
@@ -231,10 +233,22 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
 }
 
 @SerialVersionUID(3L)
-object Buffer extends SeqFactory.Delegate[Buffer](js.WrappedArray)
+object Buffer extends SeqFactory.Delegate[Buffer](
+  linkTimeIf[SeqFactory[Buffer]](LinkingInfo.isWebAssembly) {
+    ArrayBuffer
+  } {
+    js.WrappedArray
+  }
+)
 
 @SerialVersionUID(3L)
-object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](js.WrappedArray)
+object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](
+  linkTimeIf[SeqFactory[IndexedBuffer]](LinkingInfo.isWebAssembly) {
+    ArrayBuffer
+  } {
+    js.WrappedArray
+  }
+)
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)

--- a/library-js/src/scala/runtime/BoxesRunTime.scala
+++ b/library-js/src/scala/runtime/BoxesRunTime.scala
@@ -4,12 +4,19 @@ import scala.language.`2.13`
 
 import scala.math.ScalaNumber
 
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.{linkTimeIf, moduleKind}
+
 /* The declaration of the class is only to make the JVM back-end happy when
  * compiling the scalalib.
  */
 final class BoxesRunTime
 
 object BoxesRunTime {
+  // TODO Get this value from 'import scala.scalajs.LinkingInfo.ModuleKind.WasmModule'
+  // when we upgrade to Scala.js 1.23.0+.
+  private final val WasmModule = 4
+
   def boxToBoolean(b: Boolean): java.lang.Boolean =
     b.asInstanceOf[java.lang.Boolean]
 
@@ -50,9 +57,21 @@ object BoxesRunTime {
 
   def unboxToDouble(d: Any): Double = d.asInstanceOf[Double]
 
-  def equals(x: Object, y: Object): Boolean =
-    if (scala.scalajs.js.special.strictEquals(x, y)) true
-    else equals2(x, y)
+  def equals(x: Object, y: Object): Boolean = {
+    linkTimeIf(moduleKind == WasmModule) {
+      if (x eq y) {
+        (x: Any) match {
+          case x: Double => x == x // rejects NaN to align with `strictEquals` semantics.
+          case _         => true
+        }
+      } else {
+        equals2(x, y)
+      }
+    } {
+      if (scala.scalajs.js.special.strictEquals(x, y)) true
+      else equals2(x, y)
+    }
+  }
 
   @inline // only called by equals(), not by codegen
   def equals2(x: Object, y: Object): Boolean = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1226,9 +1226,7 @@ object Build {
           ))
           .flatMap(_.relativeTo(baseDirectory.value / "src")).toSet
 
-        files.filterNot(_.getPath().contains("BoxesRunTime.scala"))
-             .filterNot(_.getPath().contains("ScalaNumber.scala"))
-             .filterNot(file =>
+        files.filterNot(file =>
           file.relativeTo((`scala-library-bootstrapped` / baseDirectory).value / "src")
             .exists(overwrittenSources.contains))
 

--- a/tests/run/i19394.scala
+++ b/tests/run/i19394.scala
@@ -1,3 +1,6 @@
+// scalajs: --skip
+// @static was never stabilized; it sometimes work by accident on Scala.js, but not here.
+
 import scala.annotation.{ static, targetName }
 
 class Foo


### PR DESCRIPTION
Forward ports of the relevant parts of

* https://github.com/scala-js/scala-js/pull/5161
* https://github.com/scala-js/scala-js/pull/5353

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)

## Backport info

Backportable to 3.9.x and 3.10.x.

Not backportable to 3.3.x.