### PR TITLE
addLambdaDeserialize during classnode creation

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1879,11 +1879,8 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives) extends BCodeSkelBuilder
         // altMetafactory required to be able to pass the flags and additional arguments if needed
         bc.invokedynamic(methodName, desc, bTypes.jliLambdaMetaFactoryAltMetafactoryHandle, bsmArgs)
         // collect serializable lambdas
-        val metafactoryFlags = bsmArgs(3).asInstanceOf[Integer].toInt
-        val isSerializable = (metafactoryFlags & FLAG_SERIALIZABLE) != 0
         if isSerializable then
-          val implMethod = bsmArgs(1).asInstanceOf[Handle]
-          serializableLambdas ::= implMethod
+          serializableLambdas ::= targetHandle
 
       generatedType
     }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -32,7 +32,7 @@ import dotty.tools.dotc.util.SrcPos
  *  @version 1.0
  *
  */
-trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes) extends BCodeSkelBuilder {
+trait BCodeBodyBuilder(val primitives: ScalaPrimitives) extends BCodeSkelBuilder {
   /*
    * Functionality to build the body of ASM MethodNode, except for `synchronized` and `try` expressions.
    */
@@ -1873,13 +1873,17 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
 
       val bsmArgs = bsmArgs0 ++ bsmArgs1 ++ bsmArgs2
 
-      val metafactory =
-        if (flags != 0)
-          bTypes.jliLambdaMetaFactoryAltMetafactoryHandle // altMetafactory required to be able to pass the flags and additional arguments if needed
-        else
-          bTypes.jliLambdaMetaFactoryMetafactoryHandle
-
-      bc.invokedynamic(methodName, desc, metafactory, bsmArgs)
+      if flags == 0 then
+        bc.invokedynamic(methodName, desc, bTypes.jliLambdaMetaFactoryMetafactoryHandle, bsmArgs)
+      else
+        // altMetafactory required to be able to pass the flags and additional arguments if needed
+        bc.invokedynamic(methodName, desc, bTypes.jliLambdaMetaFactoryAltMetafactoryHandle, bsmArgs)
+        // collect serializable lambdas
+        val metafactoryFlags = bsmArgs(3).asInstanceOf[Integer].toInt
+        val isSerializable = (metafactoryFlags & FLAG_SERIALIZABLE) != 0
+        if isSerializable then
+          val implMethod = bsmArgs(1).asInstanceOf[Handle]
+          serializableLambdas ::= implMethod
 
       generatedType
     }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -26,6 +26,8 @@ import dotty.tools.dotc.transform.Mixin
 import tpd.*
 
 import scala.compiletime.uninitialized
+import org.objectweb.asm.{Handle, Opcodes}
+import org.objectweb.asm.tree.ClassNode
 
 /*
  *
@@ -33,7 +35,7 @@ import scala.compiletime.uninitialized
  *  @version 1.0
  *
  */
-trait BCodeSkelBuilder extends BCodeHelpers {
+trait BCodeSkelBuilder(val bTypes: KnownBTypes) extends BCodeHelpers {
 
   final class BTypesStack:
     // Anecdotally, growing past 16 to 32 is common; growing past 32 is rare
@@ -136,6 +138,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     // current class
     private var cnode: ClassNode1  = uninitialized
     private var thisName: String   = uninitialized // the internal name of the class being emitted
+    protected var serializableLambdas: List[Handle] = uninitialized
 
     protected var claszSymbol: Symbol = uninitialized
     private var isCZStaticModule    = false
@@ -165,6 +168,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
       claszSymbol       = cd0.symbol
       isCZStaticModule  = claszSymbol.isStaticModuleClass
       thisName          = bTypeLoader.classBTypeFromSymbol(claszSymbol).internalName
+      serializableLambdas = Nil
 
       cnode = new ClassNode1()
 
@@ -283,11 +287,80 @@ trait BCodeSkelBuilder extends BCodeHelpers {
       // This needs to wait until now since it uses `superCallTargets` which is populating while emitting the class body
       initJClass(cnode)
 
+      addLambdaDeserialize(cnode, serializableLambdas)
+
       TraceUtils.traceClassIfRequested(cnode)
 
       assert(cd.symbol == claszSymbol, "Someone messed up BCodePhase.claszSymbol during genPlainClass().")
       cnode
     } // end of method genPlainClass()
+
+
+    /*
+    * Add:
+    *
+    * private static Object $deserializeLambda$(SerializedLambda l) {
+    *   try return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup$0](l)
+    *   catch {
+    *     case i: IllegalArgumentException =>
+    *       try return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup$1](l)
+    *       catch {
+    *         case i: IllegalArgumentException =>
+    *           ...
+    *             return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup${NUM_GROUPS-1}](l)
+    *       }
+    *   }
+    * }
+    *
+    * We use invokedynamic here to enable caching within the deserializer without needing to
+    * host a static field in the enclosing class. This allows us to add this method to interfaces
+    * that define lambdas in default methods.
+    *
+    * SI-10232 we can't pass arbitrary number of method handles to the final varargs parameter of the bootstrap
+    * method due to a limitation in the JVM. Instead, we emit a separate invokedynamic bytecode for each group of target
+    * methods.
+    */
+    private def addLambdaDeserialize(classNode: ClassNode, serializableLambdas: List[Handle]): Unit = {
+      if serializableLambdas.isEmpty then
+        return
+
+      val cw = classNode
+      // Make sure to reference the ClassBTypes of all types that are used in the code generated
+      // here (e.g. java/util/Map) are initialized. Initializing a ClassBType adds it to
+      // `classBTypeFromInternalNameMap`. When writing the classfile, the asm ClassWriter computes
+      // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
+      // ClassBTypes mentioned in the source code to exist in the map.
+      val serializedLambdaObjDesc = s"(Ljava/lang/invoke/SerializedLambda;)L${ClassBType.javaLangObjectInternalName};"
+      val mv = cw.visitMethod(Opcodes.ACC_PRIVATE + Opcodes.ACC_STATIC + Opcodes.ACC_SYNTHETIC, "$deserializeLambda$", serializedLambdaObjDesc, null, null)
+
+      def emitLambdaDeserializeIndy(targetMethods: Seq[Handle]): Unit = {
+        mv.visitVarInsn(Opcodes.ALOAD, 0)
+        mv.visitInvokeDynamicInsn("lambdaDeserialize", serializedLambdaObjDesc, bTypes.jliLambdaDeserializeBootstrapHandle, targetMethods *)
+      }
+
+      val targetMethodGroupLimit = 255 - 1 - 3 // JVM limit. See MAX_MH_ARITY in CallSite.java
+      val groups = serializableLambdas.grouped(targetMethodGroupLimit).toArray
+      val numGroups = groups.length
+
+      import org.objectweb.asm.Label
+      val initialLabels = Array.fill(numGroups - 1)(new Label())
+      val terminalLabel = new Label
+
+      def nextLabel(i: Int) = if (i == numGroups - 2) terminalLabel else initialLabels(i + 1)
+
+      for ((label, i) <- initialLabels.iterator.zipWithIndex) {
+        mv.visitTryCatchBlock(label, nextLabel(i), nextLabel(i), "java/lang/IllegalArgumentException")
+      }
+      for ((label, i) <- initialLabels.iterator.zipWithIndex) {
+        mv.visitLabel(label)
+        emitLambdaDeserializeIndy(groups(i).toIndexedSeq)
+        mv.visitInsn(Opcodes.ARETURN)
+      }
+      mv.visitLabel(terminalLabel)
+      emitLambdaDeserializeIndy(groups(numGroups - 1).toIndexedSeq)
+      mv.visitInsn(Opcodes.ARETURN)
+    }
+
 
     /*
      *  Add public static final field serialVersionUID with value `id`

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -60,14 +60,14 @@ class GenBCode extends Phase { self =>
       val callGraph = new OptimizerCallGraph(byteCodeRepository, bTypesFromClassfile)
       _postProcessor = new PostProcessorWithOptimizations(classBTypeCache, byteCodeRepository, bTypesFromClassfile, callGraph, knownBTypes)
       _generatedClassHandler = GeneratedClassHandler.withGlobalOptimizations(createClassHandler(_postProcessor))
-      object impl extends BCodeIdiomatic(callGraph), BCodeHelpers(bTypeLoader), BCodeBodyBuilder(primitives, knownBTypes), BCodeSyncAndTry
+      object impl extends BCodeIdiomatic(callGraph), BCodeSkelBuilder(knownBTypes), BCodeHelpers(bTypeLoader), BCodeBodyBuilder(primitives), BCodeSyncAndTry
       _codeGen = new CodeGen(impl)
     else
       val bTypeLoader = new BTypeLoader(primitives, classBTypeCache, None)
       val knownBTypes = new KnownBTypes(bTypeLoader)
       _postProcessor = new PostProcessor(classBTypeCache, knownBTypes)
       _generatedClassHandler = createClassHandler(_postProcessor)
-      object impl extends BCodeIdiomatic(DisabledCallGraph), BCodeHelpers(bTypeLoader), BCodeBodyBuilder(primitives, knownBTypes), BCodeSyncAndTry
+      object impl extends BCodeIdiomatic(DisabledCallGraph), BCodeSkelBuilder(knownBTypes), BCodeHelpers(bTypeLoader), BCodeBodyBuilder(primitives), BCodeSyncAndTry
       _codeGen = new CodeGen(impl)
     _initialized = true
 

--- a/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
@@ -49,7 +49,6 @@ class PostProcessor(classBTypeCache: ClassBType.Cache, bTypes: KnownBTypes)(usin
       try
         if !clazz.isArtifact then
           runLocalOptimizations(classNode)
-          addLambdaDeserialize(classNode)
         warnCaseInsensitiveOverwrite(clazz)
         setInnerClasses(classNode)
         serializeClass(classNode)
@@ -136,93 +135,6 @@ class PostProcessor(classBTypeCache: ClassBType.Cache, bTypes: KnownBTypes)(usin
     val cw = new ClassWriterWithBTypeLub(asm.ClassWriter.COMPUTE_MAXS | asm.ClassWriter.COMPUTE_FRAMES)
     classNode.accept(cw)
     cw.toByteArray.nn
-  }
-
-  private def collectSerializableLambdas(classNode: ClassNode): Array[Handle] = {
-    val indyLambdaBodyMethods = new mutable.ArrayBuffer[Handle]
-    for (m <- classNode.methods.asScala) {
-      val iter = m.instructions.iterator
-      while (iter.hasNext) {
-        val insn = iter.next()
-        insn match {
-          case indy: InvokeDynamicInsnNode
-            if indy.bsm == bTypes.jliLambdaMetaFactoryAltMetafactoryHandle =>
-            import java.lang.invoke.LambdaMetafactory.FLAG_SERIALIZABLE
-            val metafactoryFlags = indy.bsmArgs(3).asInstanceOf[Integer].toInt
-            val isSerializable = (metafactoryFlags & FLAG_SERIALIZABLE) != 0
-            if isSerializable then
-              val implMethod = indy.bsmArgs(1).asInstanceOf[Handle]
-              indyLambdaBodyMethods += implMethod
-          case _ =>
-        }
-      }
-    }
-    indyLambdaBodyMethods.toArray
-  }
-
-  /*
-  * Add:
-  *
-  * private static Object $deserializeLambda$(SerializedLambda l) {
-  *   try return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup$0](l)
-  *   catch {
-  *     case i: IllegalArgumentException =>
-  *       try return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup$1](l)
-  *       catch {
-  *         case i: IllegalArgumentException =>
-  *           ...
-  *             return indy[scala.runtime.LambdaDeserialize.bootstrap, targetMethodGroup${NUM_GROUPS-1}](l)
-  *       }
-  *   }
-  * }
-  *
-  * We use invokedynamic here to enable caching within the deserializer without needing to
-  * host a static field in the enclosing class. This allows us to add this method to interfaces
-  * that define lambdas in default methods.
-  *
-  * SI-10232 we can't pass arbitrary number of method handles to the final varargs parameter of the bootstrap
-  * method due to a limitation in the JVM. Instead, we emit a separate invokedynamic bytecode for each group of target
-  * methods.
-  */
-  private def addLambdaDeserialize(classNode: ClassNode): Unit = {
-    val implMethodsArray = collectSerializableLambdas(classNode)
-    if implMethodsArray.isEmpty then
-      return
-
-    import asm.Opcodes.*
-    val cw = classNode
-    // Make sure to reference the ClassBTypes of all types that are used in the code generated
-    // here (e.g. java/util/Map) are initialized. Initializing a ClassBType adds it to
-    // `classBTypeFromInternalNameMap`. When writing the classfile, the asm ClassWriter computes
-    // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
-    // ClassBTypes mentioned in the source code to exist in the map.
-    val serializedLambdaObjDesc = s"(Ljava/lang/invoke/SerializedLambda;)L${ClassBType.javaLangObjectInternalName};"
-    val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", serializedLambdaObjDesc, null, null)
-    def emitLambdaDeserializeIndy(targetMethods: Seq[Handle]): Unit = {
-      mv.visitVarInsn(ALOAD, 0)
-      mv.visitInvokeDynamicInsn("lambdaDeserialize", serializedLambdaObjDesc, bTypes.jliLambdaDeserializeBootstrapHandle, targetMethods*)
-    }
-
-    val targetMethodGroupLimit = 255 - 1 - 3 // JVM limit. See MAX_MH_ARITY in CallSite.java
-    val groups: Array[Array[Handle]] = implMethodsArray.grouped(targetMethodGroupLimit).toArray
-    val numGroups = groups.length
-
-    import org.objectweb.asm.Label
-    val initialLabels = Array.fill(numGroups - 1)(new Label())
-    val terminalLabel = new Label
-    def nextLabel(i: Int) = if (i == numGroups - 2) terminalLabel else initialLabels(i + 1)
-
-    for ((label, i) <- initialLabels.iterator.zipWithIndex) {
-      mv.visitTryCatchBlock(label, nextLabel(i), nextLabel(i), "java/lang/IllegalArgumentException")
-    }
-    for ((label, i) <- initialLabels.iterator.zipWithIndex) {
-      mv.visitLabel(label)
-      emitLambdaDeserializeIndy(groups(i).toIndexedSeq)
-      mv.visitInsn(ARETURN)
-    }
-    mv.visitLabel(terminalLabel)
-    emitLambdaDeserializeIndy(groups(numGroups - 1).toIndexedSeq)
-    mv.visitInsn(ARETURN)
   }
 
   /*


### PR DESCRIPTION
Should help perf a little by not iterating over every single instruction we emit. Also moves the code closer to where it logically makes sense.

My understanding is that this info won't change during inlining because we can move INDYs but not change what they point to.

I added `-opt -opt-inline:**,!java.**` locally and no `testCompilation` test failed because of this

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
