### PR TITLE
Use GitHub Actions's built-in `CI` var instead of redefining our own

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
   # Run tests before publishing a release
   stdlib-tests:

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
 
   community_build_a:

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
 
   test-scala3-compiler-nonbootstrapped:

--- a/.github/workflows/mima.yaml
+++ b/.github/workflows/mima.yaml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
 
   mima-scala-library-nonbootstrapped:

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
 
   scripted-tests:

--- a/.github/workflows/scoverage.yaml
+++ b/.github/workflows/scoverage.yaml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DOTTY_CI_RUN: true
+
 # This workflow compiles a subset of the Scala 3 projects with
 # scoverage enabled to test robustness of scoverage.
 #

--- a/.github/workflows/scoverage.yaml
+++ b/.github/workflows/scoverage.yaml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 # This workflow compiles a subset of the Scala 3 projects with
 # scoverage enabled to test robustness of scoverage.
 #

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -13,9 +13,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
   specification:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTTY_CI_RUN: true
-
 jobs:
 
   test-scala-library-nonbootstrapped:

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -11,7 +11,7 @@ object Properties {
     sys.props.getOrElse(name, "FALSE") == "TRUE"
 
   /** Are we running on the CI? */
-  val isRunByCI: Boolean = sys.env.isDefinedAt("DOTTY_CI_RUN")
+  val isRunByCI: Boolean = sys.env.isDefinedAt("CI")
 
   /** Filter out tests not matching the regex supplied by "dotty.tests.filter"
    *  define


### PR DESCRIPTION
This ensures Vulpix doesn't print progress bars, so the output is actually readable

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
