### PR TITLE
Update Tasty format BNF

### DIFF
--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -276,7 +276,8 @@ All elements of a position section are serialized as Ints
 
 Standard Section: "Comments" Comment*
 ```none
-  Comment       = Utf8 LongInt              // Raw comment's bytes encoded as UTF-8, followed by the comment's coordinates.
+  Comment       = Addr Utf8 LongInt         // Address of the commented definition, raw comment's bytes encoded as UTF-8,
+                                            // followed by the comment's coordinates.
 ```
 
 Standard Section: "Attributes" Attribute*


### PR DESCRIPTION
https://github.com/scala/scala3/blob/main/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala#L23-L27

Bug found during PR to tasty-query by AI, manually checked here with proof of the mistake in the code above.