### PR TITLE
represent FlexibleType using AppliedType

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1995,8 +1995,8 @@ class CheckCaptures extends Recheck, SymTransformer:
           case _ =>
 
         actual match
-          case actual: FlexibleType =>
-            return actual.derivedFlexibleType(recur(actual.hi, expected, covariant))
+          case actual @ FlexibleType(hi) =>
+            return FlexibleType.derivedFlexibleType(actual, recur(hi, expected, covariant))
           case _ =>
 
         // Decompose the actual type into the inner shape type, the capture set and the box status

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -832,6 +832,14 @@ trait ConstraintHandling {
    */
   protected def addConstraint(param: TypeParamRef, bound: Type, fromBelow: Boolean)(using Context): Boolean =
     if !bound.isValueTypeOrLambda then return false
+    // Never infer the `<FlexibleType>` type constructor for a higher-kinded type
+    // parameter. A flexible type is an implementation device of explicit nulls that
+    // should be transparent to type inference; if we allowed `param := <FlexibleType>`,
+    // every `F[A]`-shaped signature would match a flexible-typed value, shadowing the
+    // members of its underlying type (see tests/explicit-nulls/pos/flexible-hk-extension.scala).
+    // Refusing the constraint makes the comparison fall back to looking through the
+    // flexible type.
+    if FlexibleType.isTypeConstructor(bound) then return false
 
     /** When comparing lambdas we might get constraints such as
      *  `A <: X0` or `A = List[X0]` where `A` is a constrained parameter

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -720,8 +720,8 @@ trait ConstraintHandling {
       tp.rebind(tp.parent.hardenUnions)
     case tp: HKTypeLambda =>
       tp.derivedLambdaType(resType = tp.resType.hardenUnions)
-    case tp: FlexibleType =>
-      tp.derivedFlexibleType(tp.hi.hardenUnions)
+    case tp @ FlexibleType(hi) =>
+      FlexibleType.derivedFlexibleType(tp, hi.hardenUnions)
     case tp: OrType =>
       val tp1 = tp.stripNull(stripFlexibleTypes = false)
       if tp1 ne tp then tp.derivedOrType(tp1.hardenUnions, defn.NullType, soft = false)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -449,6 +449,17 @@ class Definitions {
     newPermanentSymbol(OpsPackageClass, tpnme.FromJavaObject, JavaDefined, TypeAlias(ObjectType)).entered
   def FromJavaObjectType: TypeRef = FromJavaObjectSymbol.typeRef
 
+  @tu lazy val FlexibleTypeSymbol: TypeSymbol =
+    newPermanentSymbol(ScalaPackageClass, tpnme.FlexibleType, EmptyFlags, TypeBounds(
+      HKTypeLambda(TypeBounds.empty :: Nil)(
+        tl => OrNull(tl.paramRefs(0))
+      ),
+      HKTypeLambda(TypeBounds.empty :: Nil)(
+        tl => tl.paramRefs(0)
+      )
+    )).entered
+  def FlexibleTypeType: TypeRef = FlexibleTypeSymbol.typeRef
+
   @tu lazy val AnyRefAlias: TypeSymbol = enterAliasType(tpnme.AnyRef, ObjectType)
   def AnyRefType: TypeRef = AnyRefAlias.typeRef
 
@@ -2022,8 +2033,8 @@ class Definitions {
         asContextFunctionType(TypeComparer.bounds(tp1).hiBound)
       case tp1 @ PolyFunctionOf(mt: MethodType) if mt.isContextualMethod =>
         tp1
-      case tp: FlexibleType =>
-        asContextFunctionType(tp.hi)
+      case FlexibleType(hi) =>
+        asContextFunctionType(hi)
       case tp1 =>
         if tp1.typeSymbol.name.isContextFunction && isFunctionNType(tp1) then tp1
         else NoType

--- a/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
+++ b/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
@@ -198,6 +198,12 @@ object ImplicitNullInterop:
             OrNull(derivedAnnotatedType(tp, parent2a, tp.annot))
           case _ =>
             derivedAnnotatedType(tp, parent2, tp.annot)
+      case FlexibleType(_) =>
+        // A flexible type is already a fully-nullified result, so nullification must be
+        // idempotent on it: leave it unchanged. Without this case it would match the
+        // `AppliedType` case below (a flexible type is encoded as `AppliedType(FlexibleType, T)`)
+        // and get wrapped a second time, e.g. `(Array[T])?` becoming `((Array[T])?)?`.
+        tp
       case appTp @ AppliedType(tycon, targs) =>
         val savedState = state
         // If Java-defined tycon, don't nullify outer level of type args (Java classes are fully nullified)

--- a/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
+++ b/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
@@ -192,7 +192,7 @@ object ImplicitNullInterop:
         state = savedState
         if isNullAnnot then parent2
         else parent2 match
-          case FlexibleType(_, parent2a) =>
+          case FlexibleType(parent2a) =>
             FlexibleType(derivedAnnotatedType(tp, parent2a, tp.annot))
           case OrNull(parent2a) =>
             OrNull(derivedAnnotatedType(tp, parent2a, tp.annot))
@@ -236,7 +236,7 @@ object ImplicitNullInterop:
         // This keeps the result minimal and avoids duplicating `| Null`
         // on both sides and at the outer level.
         (this(tp.tp1), this(tp.tp2)) match
-          case (FlexibleType(_, t1), FlexibleType(_, t2)) if ctx.flexibleTypes =>
+          case (FlexibleType(t1), FlexibleType(t2)) if ctx.flexibleTypes =>
             FlexibleType(derivedAndOrType(tp, t1, t2))
           case (OrNull(t1), OrNull(t2)) =>
             OrNull(derivedAndOrType(tp, t1, t2))
@@ -256,7 +256,7 @@ object ImplicitNullInterop:
 
         // If the parent type becomes nullable, then we pop the nullification to the outer level.
         parent2 match
-          case FlexibleType(_, parent2a) =>
+          case FlexibleType(parent2a) =>
             FlexibleType(derivedRefinedType(tp, parent2a, refinedInfo2))
           case OrNull(parent2a) =>
             OrNull(derivedRefinedType(tp, parent2a, refinedInfo2))

--- a/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
+++ b/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
@@ -33,9 +33,9 @@ object NullOpsDecorator:
             if (tp1s ne tp1) && (tp2s ne tp2) then
               tp.derivedAndType(tp1s, tp2s)
             else tp
-          case tp: FlexibleType =>
-            val hi1 = strip(tp.hi)
-            if stripFlexibleTypes then hi1 else tp.derivedFlexibleType(hi1)
+          case tp @ FlexibleType(hi) =>
+            val hi1 = strip(hi)
+            if stripFlexibleTypes then hi1 else FlexibleType.derivedFlexibleType(tp, hi1)
           case tp @ TypeBounds(lo, hi) =>
             tp.derivedTypeBounds(strip(lo), strip(hi))
           case tp => tp

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -557,8 +557,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         if underlying1 ne tp.underlying then underlying1 else tp
       case CapturingType(parent, refs) =>
         tp.derivedCapturingType(recur(parent), refs)
-      case tp: FlexibleType =>
-        tp.derivedFlexibleType(recur(tp.hi))
+      case tp @ FlexibleType(hi) =>
+        FlexibleType.derivedFlexibleType(tp, recur(hi))
       case tp: AnnotatedType =>
         tp.derivedAnnotatedType(recur(tp.parent), tp.annot)
       case _ =>
@@ -754,7 +754,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     case tp: TypeVar if contains(tp.origin) => withHard(tp)
     case tp: TypeParamRef if contains(tp)   => hardenTypeVars(typeVarOfParam(tp))
     case tp: AndOrType                      => hardenTypeVars(tp.tp1).hardenTypeVars(tp.tp2)
-    case tp: FlexibleType                   => hardenTypeVars(tp.hi)
+    case FlexibleType(hi)                   => hardenTypeVars(hi)
     case _                                  => this
 
   def remove(pt: TypeLambda)(using Context): This = {

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -167,7 +167,7 @@ trait PatternTypeConstrainer { self: TypeComparer =>
         // additional trait - argument-less enum cases desugar to vals.
         // See run/enum-Tree.scala.
         if tp.classSymbol.exists then tp else tp.info
-      case tp: FlexibleType => dealiasDropNonmoduleRefs(tp.underlying)
+      case FlexibleType(hi) => dealiasDropNonmoduleRefs(hi)
       case tp => tp
     }
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -206,6 +206,7 @@ object StdNames {
     final val NotNull: N             = "NotNull"
     final val Null: N                = "Null"
     final val Object: N              = "Object"
+    final val FlexibleType : N       = "<FlexibleType>"
     final val FromJavaObject: N      = "<FromJavaObject>"
     final val Record: N              = "Record"
     final val Product: N             = "Product"

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -589,8 +589,8 @@ class TypeApplications(val self: Type) extends AnyVal {
    *  Existential types in arguments are returned as TypeBounds instances.
    */
   final def argInfos(using Context): List[Type] = self.stripped match
+    case FlexibleType(hi) => hi.argInfos
     case AppliedType(tycon, args) => args
-    case tp: FlexibleType => tp.underlying.argInfos
     case _ => Nil
 
   /** If this is an encoding of a function type, return its arguments, otherwise return Nil.

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -683,6 +683,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       }
 
     def thirdTry: Boolean = tp2 match {
+      case FlexibleType(hi2) =>
+        recur(tp1, OrNull(hi2))
       case tp2 @ AppliedType(tycon2, args2) =>
         compareAppliedType2(tp2, tycon2, args2)
       case tp2: NamedType =>
@@ -950,8 +952,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             false
         }
         compareClassInfo
-      case tp2: FlexibleType =>
-        recur(tp1, tp2.lo)
       case _ =>
         fourthTry
     }
@@ -1012,6 +1012,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       else fourthTry
 
     def fourthTry: Boolean = tp1 match {
+      case FlexibleType(hi1) =>
+        recur(hi1, tp2)
       case tp1: TypeRef =>
         tp1.info match {
           case info1 @ TypeBounds(lo1, hi1) =>
@@ -1160,8 +1162,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case tp1: ExprType if ctx.phaseId > gettersPhase.id =>
         // getters might have converted T to => T, need to compensate.
         recur(tp1.widenExpr, tp2)
-      case tp1: FlexibleType =>
-        recur(tp1.hi, tp2)
       case _ =>
         false
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -683,8 +683,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       }
 
     def thirdTry: Boolean = tp2 match {
-      case FlexibleType(hi2) =>
-        recur(tp1, OrNull(hi2))
       case tp2 @ AppliedType(tycon2, args2) =>
         compareAppliedType2(tp2, tycon2, args2)
       case tp2: NamedType =>
@@ -1012,8 +1010,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       else fourthTry
 
     def fourthTry: Boolean = tp1 match {
-      case FlexibleType(hi1) =>
-        recur(hi1, tp2)
       case tp1: TypeRef =>
         tp1.info match {
           case info1 @ TypeBounds(lo1, hi1) =>
@@ -1277,6 +1273,14 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
      *  - Some explanations on how this impacts API design: https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2
      */
     def compareAppliedTypeParamRef(tycon: TypeParamRef, args: List[Type], other: AppliedType, fromBelow: Boolean): Boolean =
+      // Never infer the `<FlexibleType>` type constructor for a higher-kinded type
+      // parameter. A flexible type is an implementation device of explicit nulls that
+      // should be transparent to type inference; if we allowed `tycon := <FlexibleType>`
+      // here, every `F[A]`-shaped signature would match a flexible-typed value, shadowing
+      // the members of its underlying type (see tests/explicit-nulls/pos/flexible-hk-extension.scala).
+      // Bailing out makes the comparison fall back to looking through the flexible type.
+      if FlexibleType.isTypeConstructor(other.tycon) then return false
+
       def directionalIsSubType(tp1: Type, tp2: Type): Boolean =
         if fromBelow then isSubType(tp2, tp1) else isSubType(tp1, tp2)
       def directionalRecur(tp1: Type, tp2: Type): Boolean =
@@ -1318,7 +1322,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     /** Subtype test for the hk application `tp2 = tycon2[args2]`.
      */
     def compareAppliedType2(tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
-      if (FlexibleType.isInstance(tp2.widen)) return false
       val tparams = tycon2.typeParams
       if (tparams.isEmpty) return false // can happen for ill-typed programs, e.g. neg/tcpoly_overloaded.scala
 
@@ -1326,7 +1329,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
        */
       def isMatchingApply(tp1: Type): Boolean = tp1.widen match {
-        case FlexibleType(_) => false
         case tp1 @ AppliedType(tycon1, args1) =>
           // We intentionally do not automatically dealias `tycon1` or `tycon2` here.
           // `TypeApplications#appliedTo` already takes care of dealiasing type
@@ -1376,7 +1378,10 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           def loop(tycon1: Type, args1: List[Type]): Boolean = tycon1 match {
             case tycon1: TypeParamRef =>
               (tycon1 == tycon2 ||
-               canConstrain(tycon1) && isSubType(tycon1, tycon2)) &&
+               // as in `compareAppliedTypeParamRef`, `<FlexibleType>` is never inferred
+               // as the instance of a type constructor parameter
+               canConstrain(tycon1) && !FlexibleType.isTypeConstructor(tycon2)
+               && isSubType(tycon1, tycon2)) &&
               isSubArgs(args1, args2, tp1, tparams)
             case tycon1: TypeRef =>
               tycon2 match {
@@ -1447,7 +1452,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        */
       def canInstantiate(tycon2: TypeParamRef): Boolean = {
         def appOK(tp1base: Type) = tp1base match {
-          case FlexibleType(_) => false
           case tp1base: AppliedType =>
             compareAppliedTypeParamRef(tycon2, args2, tp1base, fromBelow = true)
           case _ => false
@@ -1547,11 +1551,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     /** Subtype test for the application `tp1 = tycon1[args1]`.
      */
     def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type]): Boolean =
-      if (FlexibleType.isInstance(tp1.widen)) return false
       tycon1 match {
         case param1: TypeParamRef =>
           def canInstantiate = tp2 match {
-            case FlexibleType(_) => false
             case tp2base: AppliedType =>
               compareAppliedTypeParamRef(param1, args1, tp2base, fromBelow = false)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1273,14 +1273,6 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
      *  - Some explanations on how this impacts API design: https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2
      */
     def compareAppliedTypeParamRef(tycon: TypeParamRef, args: List[Type], other: AppliedType, fromBelow: Boolean): Boolean =
-      // Never infer the `<FlexibleType>` type constructor for a higher-kinded type
-      // parameter. A flexible type is an implementation device of explicit nulls that
-      // should be transparent to type inference; if we allowed `tycon := <FlexibleType>`
-      // here, every `F[A]`-shaped signature would match a flexible-typed value, shadowing
-      // the members of its underlying type (see tests/explicit-nulls/pos/flexible-hk-extension.scala).
-      // Bailing out makes the comparison fall back to looking through the flexible type.
-      if FlexibleType.isTypeConstructor(other.tycon) then return false
-
       def directionalIsSubType(tp1: Type, tp2: Type): Boolean =
         if fromBelow then isSubType(tp2, tp1) else isSubType(tp1, tp2)
       def directionalRecur(tp1: Type, tp2: Type): Boolean =
@@ -1378,10 +1370,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           def loop(tycon1: Type, args1: List[Type]): Boolean = tycon1 match {
             case tycon1: TypeParamRef =>
               (tycon1 == tycon2 ||
-               // as in `compareAppliedTypeParamRef`, `<FlexibleType>` is never inferred
-               // as the instance of a type constructor parameter
-               canConstrain(tycon1) && !FlexibleType.isTypeConstructor(tycon2)
-               && isSubType(tycon1, tycon2)) &&
+               canConstrain(tycon1) && isSubType(tycon1, tycon2)) &&
               isSubArgs(args1, args2, tp1, tparams)
             case tycon1: TypeRef =>
               tycon2 match {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1318,6 +1318,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     /** Subtype test for the hk application `tp2 = tycon2[args2]`.
      */
     def compareAppliedType2(tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
+      if (FlexibleType.isInstance(tp2.widen)) return false
       val tparams = tycon2.typeParams
       if (tparams.isEmpty) return false // can happen for ill-typed programs, e.g. neg/tcpoly_overloaded.scala
 
@@ -1325,6 +1326,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
        */
       def isMatchingApply(tp1: Type): Boolean = tp1.widen match {
+        case FlexibleType(_) => false
         case tp1 @ AppliedType(tycon1, args1) =>
           // We intentionally do not automatically dealias `tycon1` or `tycon2` here.
           // `TypeApplications#appliedTo` already takes care of dealiasing type
@@ -1445,6 +1447,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        */
       def canInstantiate(tycon2: TypeParamRef): Boolean = {
         def appOK(tp1base: Type) = tp1base match {
+          case FlexibleType(_) => false
           case tp1base: AppliedType =>
             compareAppliedTypeParamRef(tycon2, args2, tp1base, fromBelow = true)
           case _ => false
@@ -1544,9 +1547,11 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     /** Subtype test for the application `tp1 = tycon1[args1]`.
      */
     def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type]): Boolean =
+      if (FlexibleType.isInstance(tp1.widen)) return false
       tycon1 match {
         case param1: TypeParamRef =>
           def canInstantiate = tp2 match {
+            case FlexibleType(_) => false
             case tp2base: AppliedType =>
               compareAppliedTypeParamRef(param1, args1, tp2base, fromBelow = false)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3493,6 +3493,15 @@ object Types extends TypeUtils {
 
     def isInstance(tp: Type)(using Context): Boolean = unapply(tp).isDefined
 
+    /** Is `tp` the `<FlexibleType>` type constructor itself (possibly eta-expanded)?
+     *  Such a type is an implementation device of explicit nulls; it must never be
+     *  inferred as the instance of a higher-kinded type parameter.
+     */
+    def isTypeConstructor(tp: Type)(using Context): Boolean = tp.stripTypeVar match
+      case tp: TypeRef => tp.symbol eq defn.FlexibleTypeSymbol
+      case tp: HKTypeLambda => isInstance(tp.resType) || isTypeConstructor(tp.resType)
+      case _ => false
+
     def derivedFlexibleType(tp: Type, hi: Type)(using Context): Type =
       tp match
         case FlexibleType(hi0) if hi eq hi0 => tp

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -318,7 +318,7 @@ object Types extends TypeUtils {
       isRef(defn.ObjectClass) && (typeSymbol eq defn.FromJavaObjectSymbol)
 
     def containsFromJavaObject(using Context): Boolean = this match
-      case tp: FlexibleType => tp.underlying.containsFromJavaObject
+      case FlexibleType(hi) => hi.containsFromJavaObject
       case tp: OrType => tp.tp1.containsFromJavaObject || tp.tp2.containsFromJavaObject
       case tp: AndType => tp.tp1.containsFromJavaObject && tp.tp2.containsFromJavaObject
       case _ => isFromJavaObject
@@ -383,7 +383,7 @@ object Types extends TypeUtils {
     /** Is this type guaranteed not to have `null` as a value? */
     final def isNotNull(using Context): Boolean = this match {
       case tp: ConstantType => tp.value.value != null
-      case tp: FlexibleType => false
+      case FlexibleType(_) => false
       case tp: ThisType => true
       case tp: SuperType => true
       case tp: ClassInfo => !tp.cls.isNullableClass && !tp.isNothingType
@@ -401,7 +401,7 @@ object Types extends TypeUtils {
         case OrType(l, r) => r.admitsNull || l.admitsNull
         case AndType(l, r) => r.admitsNull && l.admitsNull
         case TypeBounds(lo, hi) => lo.admitsNull
-        case FlexibleType(lo, hi) => true
+        case FlexibleType(_) => true
         case tp: TypeProxy => tp.underlying.admitsNull
         case _ => false
       )
@@ -427,7 +427,7 @@ object Types extends TypeUtils {
         case AppliedType(tycon, args) => tycon.unusableForInference || args.exists(_.unusableForInference)
         case RefinedType(parent, _, rinfo) => parent.unusableForInference || rinfo.unusableForInference
         case TypeBounds(lo, hi) => lo.unusableForInference || hi.unusableForInference
-        case tp: FlexibleType => tp.underlying.unusableForInference
+        case FlexibleType(hi) => hi.unusableForInference
         case tp: AndOrType => tp.tp1.unusableForInference || tp.tp2.unusableForInference
         case tp: LambdaType => tp.resultType.unusableForInference || tp.paramInfos.exists(_.unusableForInference)
         case WildcardType(optBounds) => optBounds.unusableForInference
@@ -467,8 +467,9 @@ object Types extends TypeUtils {
       (new isGroundAccumulator).apply(true, this)
 
     /** Is this a type of a repeated parameter? */
-    def isRepeatedParam(using Context): Boolean =
-      typeSymbol eq defn.RepeatedParamClass
+    def isRepeatedParam(using Context): Boolean = this match
+      case FlexibleType(hi) => hi.isRepeatedParam
+      case _ => typeSymbol eq defn.RepeatedParamClass
 
     /** Is this type of the form `compiletime.into[T]`, which means it can be the
      *  target of an implicit converson without requiring a language import?
@@ -1474,8 +1475,8 @@ object Types extends TypeUtils {
         tp.rebind(tp.parent.widenUnion)
       case tp: HKTypeLambda =>
         tp.derivedLambdaType(resType = tp.resType.widenUnion)
-      case tp: FlexibleType =>
-        tp.derivedFlexibleType(tp.hi.widenUnionWithoutNull)
+      case tp @ FlexibleType(hi) =>
+        FlexibleType.derivedFlexibleType(tp, hi.widenUnionWithoutNull)
       case tp =>
         tp
 
@@ -1905,8 +1906,8 @@ object Types extends TypeUtils {
         t
       case t @ SAMType(_, _) =>
         t
-      case ft: FlexibleType =>
-        ft.underlying.findFunctionType
+      case FlexibleType(hi) =>
+        hi.findFunctionType
       case _ =>
         NoType
 
@@ -3452,24 +3453,24 @@ object Types extends TypeUtils {
    * `T | Null .. T`, so that `T | Null <: FlexibleType(T) <: T`.
    * A flexible type will be erased to its original type `T`.
    */
-  case class FlexibleType protected(lo: Type, hi: Type) extends CachedProxyType with ValueType {
+  // case class FlexibleType protected(lo: Type, hi: Type) extends CachedProxyType with ValueType {
 
-    override def underlying(using Context): Type = hi
+  //   override def underlying(using Context): Type = hi
 
-    def derivedFlexibleType(hi: Type)(using Context): Type =
-      if hi eq this.hi then this else FlexibleType.make(hi)
+  //   def derivedFlexibleType(hi: Type)(using Context): Type =
+  //     if hi eq this.hi then this else FlexibleType.make(hi)
 
-    override def computeHash(bs: Binders): Int = doHash(bs, hi)
+  //   override def computeHash(bs: Binders): Int = doHash(bs, hi)
 
-    override final def baseClasses(using Context): List[ClassSymbol] = hi.baseClasses
-  }
+  //   override final def baseClasses(using Context): List[ClassSymbol] = hi.baseClasses
+  // }
 
   object FlexibleType:
-    def apply(tp: Type)(using Context): FlexibleType =
+    def apply(tp: Type)(using Context): Type =
       assert(tp.isValueType, s"Should not flexify ${tp}")
       tp match
-        case ft: FlexibleType => ft
-        case _ => FlexibleType(OrNull(tp), tp)
+        case ft @ FlexibleType(hi) => ft
+        case _ => AppliedType(defn.FlexibleTypeType, tp :: Nil)
           // val tp1 = tp.stripNull()
           // if tp1.isNullType then
           //   // (Null)? =:= ? >: Null <: (Object & Null)
@@ -3486,8 +3487,19 @@ object Types extends TypeUtils {
           // It is not necessary according to the use cases, so we choose to use a simpler
           // rule.
 
+    def unapply(tp: Type)(using Context): Option[Type] = tp match
+      case AppliedType(tycon, args) if tycon.isRef(defn.FlexibleTypeSymbol) => Some(args.head)
+      case _ => None
+
+    def isInstance(tp: Type)(using Context): Boolean = unapply(tp).isDefined
+
+    def derivedFlexibleType(tp: Type, hi: Type)(using Context): Type =
+      tp match
+        case FlexibleType(hi0) if hi eq hi0 => tp
+        case _ => FlexibleType.make(hi)
+
     def make(tp: Type)(using Context): Type = tp match
-      case _: FlexibleType => tp // tp is already flexible
+      case tp @ FlexibleType(hi) => tp // tp is already flexible
       case SimpleOrNull(_) => tp // tp is already nullable
       case TypeBounds(lo, hi) => TypeBounds(FlexibleType.make(lo), FlexibleType.make(hi))
       case wt: WildcardType => wt.optBounds match
@@ -6060,8 +6072,8 @@ object Types extends TypeUtils {
         samClass(tp.underlying)
       case tp: AnnotatedType =>
         samClass(tp.underlying)
-      case tp: FlexibleType =>
-        samClass(tp.underlying)
+      case FlexibleType(hi) =>
+        samClass(hi)
       case _ =>
         NoSymbol
 
@@ -6219,8 +6231,6 @@ object Types extends TypeUtils {
       tp.derivedJavaArrayType(elemtp)
     protected def derivedExprType(tp: ExprType, restpe: Type): Type =
       tp.derivedExprType(restpe)
-    protected def derivedFlexibleType(tp: FlexibleType, hi: Type): Type =
-      tp.derivedFlexibleType(hi)
     // note: currying needed  because Scala2 does not support param-dependencies
     protected def derivedLambdaType(tp: LambdaType)(formals: List[tp.PInfo], restpe: Type): Type =
       tp.derivedLambdaType(tp.paramNames, formals, restpe)
@@ -6415,9 +6425,6 @@ object Types extends TypeUtils {
 
         case tp: OrType =>
           derivedOrType(tp, this(tp.tp1), this(tp.tp2))
-
-        case tp: FlexibleType =>
-          derivedFlexibleType(tp, this(tp.hi))
 
         case tp: MatchType =>
           val bound1 = this(tp.bound)
@@ -6663,6 +6670,16 @@ object Types extends TypeUtils {
 
     override protected def derivedAppliedType(tp: AppliedType, tycon: Type, args: List[Type]): Type =
       tycon match {
+        case tr if tr.isRef(defn.FlexibleTypeSymbol) =>
+          val hi = args.head
+          hi match {
+            case Range(lo, hi) =>
+              // We know FlexibleType(t).hi = t and FlexibleType(t).lo = OrNull(t)
+              range(OrNull(lo), hi)
+            case _ =>
+              if (hi.isExactlyNothing) hi
+              else FlexibleType.derivedFlexibleType(tp, hi)
+          }
         case Range(tyconLo, tyconHi) =>
           range(derivedAppliedType(tp, tyconLo, args), derivedAppliedType(tp, tyconHi, args))
         case _ =>
@@ -6728,16 +6745,6 @@ object Types extends TypeUtils {
         case _ =>
           if (underlying.isExactlyNothing) underlying
           else tp.derivedAnnotatedType(underlying, annot)
-      }
-
-    override protected def derivedFlexibleType(tp: FlexibleType, hi: Type): Type =
-      hi match {
-        case Range(lo, hi) =>
-          // We know FlexibleType(t).hi = t and FlexibleType(t).lo = OrNull(t)
-          range(OrNull(lo), hi)
-        case _ =>
-          if (hi.isExactlyNothing) hi
-          else tp.derivedFlexibleType(hi)
       }
 
     override protected def derivedCapturingType(tp: Type, parent: Type, refs: CaptureSet): Type =
@@ -6877,9 +6884,6 @@ object Types extends TypeUtils {
         this(y, restpe)
 
       case tp: TypeVar =>
-        this(x, tp.underlying)
-
-      case tp: FlexibleType =>
         this(x, tp.underlying)
 
       case ExprType(restpe) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3450,17 +3450,6 @@ object Types extends TypeUtils {
    * `T | Null .. T`, so that `T | Null <: FlexibleType(T) <: T`.
    * A flexible type will be erased to its original type `T`.
    */
-  // case class FlexibleType protected(lo: Type, hi: Type) extends CachedProxyType with ValueType {
-
-  //   override def underlying(using Context): Type = hi
-
-  //   def derivedFlexibleType(hi: Type)(using Context): Type =
-  //     if hi eq this.hi then this else FlexibleType.make(hi)
-
-  //   override def computeHash(bs: Binders): Int = doHash(bs, hi)
-
-  //   override final def baseClasses(using Context): List[ClassSymbol] = hi.baseClasses
-  // }
 
   object FlexibleType:
     def apply(tp: Type)(using Context): Type =
@@ -3468,27 +3457,14 @@ object Types extends TypeUtils {
       tp match
         case ft @ FlexibleType(hi) => ft
         case _ => AppliedType(defn.FlexibleTypeType, tp :: Nil)
-          // val tp1 = tp.stripNull()
-          // if tp1.isNullType then
-          //   // (Null)? =:= ? >: Null <: (Object & Null)
-          //   FlexibleType(tp, AndType(defn.ObjectType, defn.NullType))
-          // else
-          //   // (T | Null)? =:= ? >: T | Null <: T
-          //   // (T)? =:= ? >: T | Null <: T
-          //   val hi = tp1
-          //   val lo = if hi eq tp then OrNull(hi) else tp
-          //   FlexibleType(lo, hi)
-          //
-          // The commented out code does more work to analyze the original type to ensure the
-          // flexible type is always a subtype of the original type and the Object type.
-          // It is not necessary according to the use cases, so we choose to use a simpler
-          // rule.
 
-    def unapply(tp: Type)(using Context): Option[Type] = tp match
-      case AppliedType(tycon, args) if tycon.isRef(defn.FlexibleTypeSymbol) => Some(args.head)
-      case _ => None
+    def unapply(tp: AppliedType)(using Context): Option[Type] =
+      if tp.tycon.isRef(defn.FlexibleTypeSymbol) then Some(tp.args.head)
+      else None
 
-    def isInstance(tp: Type)(using Context): Boolean = unapply(tp).isDefined
+    def isInstance(tp: Type)(using Context): Boolean = tp match
+      case FlexibleType(_) => true
+      case _ => false
 
     /** Is `tp` the `<FlexibleType>` type constructor itself (possibly eta-expanded)?
      *  Such a type is an implementation device of explicit nulls; it must never be

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -427,7 +427,6 @@ object Types extends TypeUtils {
         case AppliedType(tycon, args) => tycon.unusableForInference || args.exists(_.unusableForInference)
         case RefinedType(parent, _, rinfo) => parent.unusableForInference || rinfo.unusableForInference
         case TypeBounds(lo, hi) => lo.unusableForInference || hi.unusableForInference
-        case FlexibleType(hi) => hi.unusableForInference
         case tp: AndOrType => tp.tp1.unusableForInference || tp.tp2.unusableForInference
         case tp: LambdaType => tp.resultType.unusableForInference || tp.paramInfos.exists(_.unusableForInference)
         case WildcardType(optBounds) => optBounds.unusableForInference
@@ -1906,8 +1905,6 @@ object Types extends TypeUtils {
         t
       case t @ SAMType(_, _) =>
         t
-      case FlexibleType(hi) =>
-        hi.findFunctionType
       case _ =>
         NoType
 
@@ -6081,8 +6078,6 @@ object Types extends TypeUtils {
         samClass(tp.underlying)
       case tp: AnnotatedType =>
         samClass(tp.underlying)
-      case FlexibleType(hi) =>
-        samClass(hi)
       case _ =>
         NoSymbol
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -187,6 +187,9 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
   }
 
   private def pickleNewType(tpe: Type, richTypes: Boolean)(using Context): Unit = tpe match {
+    case FlexibleType(hi) =>
+      writeByte(FLEXIBLEtype)
+      withLength { pickleType(hi, richTypes) }
     case AppliedType(tycon, args) =>
       if tycon.typeSymbol == defn.MatchCaseClass then
         writeByte(MATCHCASEtype)
@@ -294,9 +297,6 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
     case tpe: OrType =>
       writeByte(ORtype)
       withLength { pickleType(tpe.tp1, richTypes); pickleType(tpe.tp2, richTypes) }
-    case tpe: FlexibleType =>
-      writeByte(FLEXIBLEtype)
-      withLength { pickleType(tpe.underlying, richTypes)  }
     case tpe: ExprType =>
       writeByte(BYNAMEtype)
       pickleType(tpe.underlying)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -332,7 +332,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
             toText(tpe)
           case _ =>
             toTextLocal(tpe) ~ " " ~ toText(annot)
-      case FlexibleType(_, tpe) =>
+      case FlexibleType(tpe) =>
         "(" ~ toText(tpe) ~ ")?"
       case tp: TypeVar =>
         def toTextCaret(tp: Type) = if printDebug then toTextLocal(tp) ~ Str("^") else toText(tp)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -243,6 +243,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
         ParamRefNameString(tp) ~ hashStr(tp.binder) ~ suffix
       case tp: SingletonType =>
         toTextSingleton(tp)
+      case FlexibleType(tpe) =>
+        "(" ~ toText(tpe) ~ ")?"
       case AppliedType(tycon, args) =>
         (toTextLocal(tycon) ~ "[" ~ argsText(args) ~ "]").close
       case tp: RefinedType =>
@@ -332,8 +334,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
             toText(tpe)
           case _ =>
             toTextLocal(tpe) ~ " " ~ toText(annot)
-      case FlexibleType(tpe) =>
-        "(" ~ toText(tpe) ~ ")?"
       case tp: TypeVar =>
         def toTextCaret(tp: Type) = if printDebug then toTextLocal(tp) ~ Str("^") else toText(tp)
         if (tp.isInstantiated)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -299,6 +299,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         Str("")
 
     homogenize(tp) match {
+      case tp @ FlexibleType(_) =>
+        super.toText(tp)
       case tp: AppliedType =>
         val refined = appliedText(tp)
         if refined.isEmpty then super.toText(tp) else refined

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -548,6 +548,8 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
         else
           tp.prefix
         api.Projection.of(apiType(prefix), sym.name.toString)
+      case FlexibleType(hi) =>
+        apiType(hi)
       case AppliedType(tycon, args) =>
         def processArg(arg: Type): api.Type = arg match {
           case arg @ TypeBounds(lo, hi) => // Handle wildcard parameters
@@ -627,8 +629,6 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
       case tp: OrType =>
         val s = combineApiTypes(apiType(tp.tp1), apiType(tp.tp2))
         withMarker(s, orMarker)
-      case tp: FlexibleType =>
-        apiType(tp.underlying)
       case ExprType(resultType) =>
         withMarker(apiType(resultType), byNameMarker)
       case MatchType(bound, scrut, cases) =>

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -151,8 +151,8 @@ object TypeTestsCasts {
             //   - T1 & T2 <:< T3
             // See TypeComparer#either
             recur(tp1, P) && recur(tp2, P)
-          case tpX: FlexibleType =>
-            recur(tpX.underlying, P)
+          case FlexibleType(hi) =>
+            recur(hi, P)
           case x =>
             // always false test warnings are emitted elsewhere
             // provablyDisjoint wants fully applied types as input; because we're in the middle of erasure, we sometimes get raw types here

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -971,7 +971,7 @@ object SpaceEngine {
     case tp: SingletonType                          => toUnderlying(tp.underlying)
     case tp: ExprType                               => toUnderlying(tp.resultType)
     case AnnotatedType(tp, annot)                   => AnnotatedType(toUnderlying(tp), annot)
-    case tp: FlexibleType                           => tp.derivedFlexibleType(toUnderlying(tp.underlying))
+    case tp @ FlexibleType(hi)                      => FlexibleType.derivedFlexibleType(tp, toUnderlying(hi))
     case _                                          => tp
   })
 
@@ -1115,7 +1115,7 @@ object SpaceEngine {
 
   def checkReachability(m: Match)(using Context): Unit = trace(i"checkReachability($m)"):
     val selTyp = toUnderlying(m.selector.tpe).dealias
-    val isNullable = selTyp.isInstanceOf[FlexibleType] || selTyp.classSymbol.isNullableClass
+    val isNullable = FlexibleType.isInstance(selTyp) || selTyp.classSymbol.isNullableClass
     val targetSpace = trace(i"targetSpace($selTyp)"):
       if isNullable && !ctx.mode.is(Mode.SafeNulls)
       then project(OrType(selTyp, ConstantType(Constant(null)), soft = false))
@@ -1144,7 +1144,7 @@ object SpaceEngine {
               if isSubspace(covered, prev) then
                 report.warning(MatchCaseUnreachable(), pat.srcPos)
               else if isNullable
-                && (!ctx.mode.is(Mode.SafeNulls) || selTyp.isInstanceOf[FlexibleType])
+                && (!ctx.mode.is(Mode.SafeNulls) || FlexibleType.isInstance(selTyp))
                 && isWildcardArg(pat)
                 && isSubspace(covered, Or(prev :: nullSpace :: Nil))
                 && !hadNullOnly

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1047,6 +1047,10 @@ trait Implicits:
     // This is done to check whether such types might plausibly be comparable to each other.
     val lift = new TypeMap {
       def apply(t: Type): Type = t match {
+        case FlexibleType(_) =>
+          // Keep flexible types as-is: they admit null, and lifting their
+          // abstract tycon to its upper bound would lose that information.
+          t
         case t: TypeRef =>
           t.info match {
             case TypeBounds(lo, hi) if lo.ne(hi) && !t.symbol.is(Opaque) => apply(hi)

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1047,10 +1047,13 @@ trait Implicits:
     // This is done to check whether such types might plausibly be comparable to each other.
     val lift = new TypeMap {
       def apply(t: Type): Type = t match {
-        case FlexibleType(_) =>
-          // Keep flexible types as-is: they admit null, and lifting their
-          // abstract tycon to its upper bound would lose that information.
-          t
+        case FlexibleType(hi) =>
+          // Keep the flexible wrapper (it admits null), but lift the underlying
+          // type to its upper bound like any other abstract type. Mapping the
+          // flexible type with `mapOver` instead would lift its tycon to the
+          // tycon's upper bound and collapse the flexible type entirely, losing
+          // the nullability information.
+          FlexibleType.derivedFlexibleType(t, apply(hi))
         case t: TypeRef =>
           t.info match {
             case TypeBounds(lo, hi) if lo.ne(hi) && !t.symbol.is(Opaque) => apply(hi)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -624,8 +624,8 @@ object Inferencing {
   }
 
   def hasCaptureConversionArg(tp: Type)(using Context): Boolean = tp match
-    case tp: AppliedType => tp.args.exists(_.typeSymbol == defn.TypeBox_CAP)
     case FlexibleType(hi) => hasCaptureConversionArg(hi)
+    case tp: AppliedType => tp.args.exists(_.typeSymbol == defn.TypeBox_CAP)
     case _ => false
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -619,13 +619,13 @@ object Inferencing {
     case tp: RecType => tp.derivedRecType(captureWildcards(tp.parent))
     case tp: LazyRef => captureWildcards(tp.ref)
     case tp: AnnotatedType => tp.derivedAnnotatedType(captureWildcards(tp.parent), tp.annot)
-    case tp: FlexibleType => tp.derivedFlexibleType(captureWildcards(tp.hi))
+    case tp @ FlexibleType(hi) => FlexibleType.derivedFlexibleType(tp, captureWildcards(hi))
     case _ => tp
   }
 
   def hasCaptureConversionArg(tp: Type)(using Context): Boolean = tp match
     case tp: AppliedType => tp.args.exists(_.typeSymbol == defn.TypeBox_CAP)
-    case tp: FlexibleType => hasCaptureConversionArg(tp.hi)
+    case FlexibleType(hi) => hasCaptureConversionArg(hi)
     case _ => false
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1240,7 +1240,7 @@ object RefChecks {
         && !sym.owner.isAnonymousClass
         && !sym.isOneOf(JavaOrPrivateOrSynthetic | InlineProxy | Param | Exported) then
       val resTp = sym.info.finalResultType
-      if resTp.existsPart(_.isInstanceOf[FlexibleType], StopAt.Static) then
+      if resTp.existsPart(FlexibleType.isInstance(_), StopAt.Static) then
         report.warning(
           em"${sym.show} exposes a flexible type in its inferred result type ${resTp}. Consider annotating the type explicitly",
           sym.srcPos

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1684,8 +1684,21 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
     val result =
       if tree.elsep.isEmpty then
-        val thenp1 = typed(tree.thenp, branchPt)(using cond1.nullableContextIf(true))
+        val thenp0 = typed(tree.thenp, branchPt)(using cond1.nullableContextIf(true))
         val elsep1 = tpd.unitLiteral.withSpan(tree.span.endPos)
+        // Discard a `then` value that only *conforms* to `Unit` (e.g. a Java
+        // `FlexibleType[Unit]`, as returned by `Map[K, Unit].put`) so the branch is
+        // actually `Unit`. Otherwise `assignType(If)`'s lub (used when the tree is
+        // unpickled or rebuilt) recomputes the `if` to `lub(FlexibleType[Unit], Unit) =
+        // FlexibleType[Unit]` and disagrees with the `Unit` hardcoded here, breaking TASTY
+        // pickling round-trips. (The previous `FlexibleType` representation hid this: being
+        // a freshly-allocated proxy rather than a hash-consed `AppliedType`, it failed the
+        // `eq` check in `TypedTreeCopier.If`, forcing that copier to recompute the `if` to
+        // the same lub the unpickler uses.)
+        val thenp1 =
+          if FlexibleType.isInstance(thenp0.tpe.widenExpr)
+          then tpd.Block(thenp0 :: Nil, tpd.unitLiteral.withSpan(tree.span.endPos))
+          else thenp0
         cpy.If(tree)(cond1, thenp1, elsep1).withType(defn.UnitType)
       else
         val thenp1 :: elsep1 :: Nil = harmonic(harmonize, pt) {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2028,8 +2028,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case SAMType(_, _) => true
         case tp: AndOrType =>
           containsFunctionType(tp.tp1) || containsFunctionType(tp.tp2)
-        case FlexibleType(hi) =>
-          containsFunctionType(hi)
         case _ => false
       containsFunctionType(bounds.lo) || containsFunctionType(bounds.hi)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1358,8 +1358,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if (untpd.isWildcardStarArg(tree)) {
 
       def fromRepeated(pt: Type): Type = pt match
-        case pt: FlexibleType =>
-          pt.derivedFlexibleType(fromRepeated(pt.hi))
+        case pt @ FlexibleType(hi) =>
+          FlexibleType.derivedFlexibleType(pt, fromRepeated(hi))
         case _ =>
           if ctx.mode.isQuotedPattern then
             // FIXME(#8680): Quoted patterns do not support Array repeated arguments
@@ -1999,8 +1999,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         val t1 = instantiatableTypeVar(tp.tp1)
         if t1.exists then t1
         else instantiatableTypeVar(tp.tp2)
-      case tp: FlexibleType =>
-        instantiatableTypeVar(tp.hi)
+      case FlexibleType(hi) =>
+        instantiatableTypeVar(hi)
       case tp: TypeVar if isConstrainedByFunctionType(tp) =>
         // Only instantiate if the type variable is constrained by function types
         tp
@@ -2015,8 +2015,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case SAMType(_, _) => true
         case tp: AndOrType =>
           containsFunctionType(tp.tp1) || containsFunctionType(tp.tp2)
-        case tp: FlexibleType =>
-          containsFunctionType(tp.hi)
+        case FlexibleType(hi) =>
+          containsFunctionType(hi)
         case _ => false
       containsFunctionType(bounds.lo) || containsFunctionType(bounds.hi)
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1981,7 +1981,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           self.subst(from, to)
 
         def typeArgs: List[TypeRepr] = self match
-          case FlexibleType(underlying) => underlying.typeArgs
+          // `FlexibleType` is an `AppliedType` here (opaque alias is transparent in this
+          // scope), so check it via the dotc-level extractor to avoid `case AppliedType`.
+          case _ if Types.FlexibleType.isInstance(self) => Types.FlexibleType.unapply(self).get.typeArgs
           case AppliedType(_, args) => args
           case AnnotatedType(parent, _) => parent.typeArgs
           case _ => List.empty
@@ -2108,7 +2110,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object AppliedTypeTypeTest extends TypeTest[TypeRepr, AppliedType]:
       def unapply(x: TypeRepr): Option[AppliedType & x.type] = x match
-        case tpe: (Types.AppliedType & x.type) if !tpe.tycon.isRef(dotc.core.Symbols.defn.MatchCaseClass) => Some(tpe)
+        case tpe: (Types.AppliedType & x.type)
+        if !tpe.tycon.isRef(dotc.core.Symbols.defn.MatchCaseClass) && !Types.FlexibleType.isInstance(tpe) => Some(tpe)
         case _ => None
     end AppliedTypeTypeTest
 
@@ -2473,7 +2476,11 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def unapply(x: NoPrefix): true = true
     end NoPrefix
 
-    type FlexibleType = dotc.core.Types.AppliedType
+    // A flexible type is represented as an `AppliedType` over the synthetic
+    // `<FlexibleType>` symbol. We use an opaque type so that `FlexibleType` is
+    // nominally distinct from `AppliedType`, otherwise the two `TypeTest`s would
+    // be indistinguishable and `case FlexibleType(_)` could match plain applied types.
+    opaque type FlexibleType <: TypeRepr = dotc.core.Types.AppliedType
 
     object FlexibleTypeTypeTest extends TypeTest[TypeRepr, FlexibleType]:
       def unapply(x: TypeRepr): Option[FlexibleType & x.type] = x match

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2110,8 +2110,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object AppliedTypeTypeTest extends TypeTest[TypeRepr, AppliedType]:
       def unapply(x: TypeRepr): Option[AppliedType & x.type] = x match
-        case tpe: (Types.AppliedType & x.type)
-        if !tpe.tycon.isRef(dotc.core.Symbols.defn.MatchCaseClass) && !Types.FlexibleType.isInstance(tpe) => Some(tpe)
+        case tpe: (Types.AppliedType & x.type) if !tpe.tycon.isRef(dotc.core.Symbols.defn.MatchCaseClass) => Some(tpe)
         case _ => None
     end AppliedTypeTypeTest
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1981,9 +1981,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           self.subst(from, to)
 
         def typeArgs: List[TypeRepr] = self match
+          case FlexibleType(underlying) => underlying.typeArgs
           case AppliedType(_, args) => args
           case AnnotatedType(parent, _) => parent.typeArgs
-          case FlexibleType(underlying) => underlying.typeArgs
           case _ => List.empty
       end extension
     end TypeReprMethods
@@ -2473,24 +2473,24 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def unapply(x: NoPrefix): true = true
     end NoPrefix
 
-    type FlexibleType = dotc.core.Types.FlexibleType
+    type FlexibleType = dotc.core.Types.AppliedType
 
     object FlexibleTypeTypeTest extends TypeTest[TypeRepr, FlexibleType]:
       def unapply(x: TypeRepr): Option[FlexibleType & x.type] = x match
-        case x: (Types.FlexibleType & x.type) => Some(x)
+        case x: (Types.AppliedType & x.type) if Types.FlexibleType.isInstance(x) => Some(x)
         case _ => None
     end FlexibleTypeTypeTest
 
     object FlexibleType extends FlexibleTypeModule:
-      def apply(tp: TypeRepr): FlexibleType = Types.FlexibleType(tp)
-      def unapply(x: FlexibleType): Some[TypeRepr] = Some(x.hi)
+      def apply(tp: TypeRepr): FlexibleType = Types.FlexibleType(tp).asInstanceOf[FlexibleType]
+      def unapply(x: FlexibleType): Some[TypeRepr] = Some(Types.FlexibleType.unapply(x).get)
     end FlexibleType
 
     given FlexibleTypeMethods: FlexibleTypeMethods with
       extension (self: FlexibleType)
-        def underlying: TypeRepr = self.hi
-        def lo: TypeRepr = self.lo
-        def hi: TypeRepr = self.hi
+        def underlying: TypeRepr = Types.FlexibleType.unapply(self).get
+        def lo: TypeRepr = Types.OrNull(Types.FlexibleType.unapply(self).get)
+        def hi: TypeRepr = Types.FlexibleType.unapply(self).get
       end extension
     end FlexibleTypeMethods
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1931,7 +1931,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
               member.info.substThis(self.classSymbol.asClass, self)
             else
               member.info
-          
+
           // We treat the constructor type parameters as if they were the same as corresponding type members.
           // That's how Scala 2 symbols are unpickled to begin with.
           val memberInfoSubstituted =
@@ -1981,9 +1981,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           self.subst(from, to)
 
         def typeArgs: List[TypeRepr] = self match
-          // `FlexibleType` is an `AppliedType` here (opaque alias is transparent in this
-          // scope), so check it via the dotc-level extractor to avoid `case AppliedType`.
-          case _ if Types.FlexibleType.isInstance(self) => Types.FlexibleType.unapply(self).get.typeArgs
+          case FlexibleType(tp) => tp.typeArgs
           case AppliedType(_, args) => args
           case AnnotatedType(parent, _) => parent.typeArgs
           case _ => List.empty

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2487,7 +2487,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object FlexibleType extends FlexibleTypeModule:
       def apply(tp: TypeRepr): FlexibleType = Types.FlexibleType(tp).asInstanceOf[FlexibleType]
-      def unapply(x: FlexibleType): Some[TypeRepr] = Some(Types.FlexibleType.unapply(x).get)
+      def unapply(x: FlexibleType): Option[TypeRepr] = Types.FlexibleType.unapply(x)
     end FlexibleType
 
     given FlexibleTypeMethods: FlexibleTypeMethods with

--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -214,6 +214,8 @@ object Extractors {
         this += "TypeRef(" += qual += ", \"" += name += "\")"
       case Refinement(parent, name, info) =>
         this += "Refinement(" += parent += ", \"" += name += "\", " += info += ")"
+      case FlexibleType(tp) =>
+        this += "FlexibleType(" += tp += ")"
       case AppliedType(tycon, args) =>
         this += "AppliedType(" += tycon += ", " ++= args += ")"
       case AnnotatedType(underlying, annot) =>
@@ -253,8 +255,6 @@ object Extractors {
         this += "NoPrefix()"
       case MatchCase(pat, rhs) =>
         this += "MatchCase(" += pat += ", " += rhs += ")"
-      case FlexibleType(tp) =>
-        this += "FlexibleType(" += tp += ")"
       case tp =>
         this += s"<Internal compiler type $tp does not have a corresponding reflect extractor>"
     }

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1142,6 +1142,11 @@ object SourceCode {
       case tpe @ Refinement(_, _, _) =>
         printRefinement(tpe)
 
+      case FlexibleType(tp) =>
+        this += "("
+        printType(tp)
+        this += ")?"
+
       case AppliedType(tp, args) =>
         tp match {
           case tp: TypeLambda =>
@@ -1259,11 +1264,6 @@ object SourceCode {
         printType(pat)
         this += " => "
         printType(rhs)
-
-      case FlexibleType(tp) =>
-        this += "("
-        printType(tp)
-        this += ")?"
 
       case _ =>
         cannotBeShownAsSource(tpe.show(using Printer.TypeReprStructure))

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.InsertTextFormat
-import org.eclipse.lsp4j.InsertTextMode
 import org.eclipse.lsp4j.Range as LspRange
 import org.eclipse.lsp4j.TextEdit
 

--- a/tests/explicit-nulls/pos/flexible-cbn-capture/J.java
+++ b/tests/explicit-nulls/pos/flexible-cbn-capture/J.java
@@ -1,0 +1,10 @@
+// A generic Java class (`Schema`) and an `ObjectMapper`-like helper whose
+// `readValue` mirrors Jackson's `<T> T readValue(Class<T>)`.
+public class J {
+    public static class Schema<T> {}
+
+    public static class Mapper {
+        public Schema<?> createProperty() { return null; }
+        public <T> T readValue(Class<T> cls) { return null; }
+    }
+}

--- a/tests/explicit-nulls/pos/flexible-cbn-capture/S.scala
+++ b/tests/explicit-nulls/pos/flexible-cbn-capture/S.scala
@@ -1,0 +1,22 @@
+import scala.util.Try
+
+// Minimization of a swagger-akka-http regression. Passing the Java
+// `mapper.createProperty().getClass` inline to the generic `readValue` triggers
+// capture conversion using a `TypeBox#CAP` skolem. Because the Java `readValue`
+// return type is flexible, the by-name argument to `Try.apply` has type
+// `FlexibleType(TypeBox[Nothing, (Schema[?])?]#CAP)`.
+//
+// A `FlexibleType` is now represented as `AppliedType(FlexibleType, hi :: Nil)`,
+// so `hasCaptureConversionArg` must look through the flexible wrapper before its
+// `AppliedType` case, otherwise it mistakes the wrapped `CAP` for a genuine
+// wildcard type argument and rejects the by-name argument with
+// "argument for by-name parameter is not a value".
+object Test:
+  val mapper: J.Mapper = new J.Mapper()
+
+  def tryCorrect(itemSchema: J.Schema[?]): Any =
+    Try {
+      val primitiveProperty = mapper.createProperty()
+      val corrected = mapper.readValue(primitiveProperty.getClass)
+      corrected
+    }.toOption.getOrElse(itemSchema)

--- a/tests/explicit-nulls/pos/flexible-hk-extension.scala
+++ b/tests/explicit-nulls/pos/flexible-hk-extension.scala
@@ -1,0 +1,25 @@
+// A higher-kinded extension method `map` (as provided e.g. by cats' `Functor`
+// syntax together with a `Functor[Id]` instance) must not be applicable to a
+// flexible-typed receiver such as the Java array `Throwable.getStackTrace`
+// (`(Array[(StackTraceElement)?])?`). A flexible type `T?` is `=:=` to `T` and
+// its type constructor is `=:=` to the identity, so without special handling the
+// `F[A]`-shaped extension would match via the `Id` instance and shadow the
+// intended `ArrayOps.map`, binding the lambda parameter to the whole array
+// instead of its element. See the gcp4s community-build regression.
+object catslike:
+  trait Functor[F[_]]:
+    extension [A](fa: F[A]) def fmap[B](f: A => B): F[B]
+  type Id[A] = A
+  given Functor[Id] with
+    extension [A](fa: A) def fmap[B](f: A => B): B = f(fa)
+  extension [F[_], A](fa: F[A])(using F: Functor[F]) def map[B](f: A => B): F[B] = F.fmap(fa)(f)
+
+object Test:
+  import catslike.*
+
+  def stackFrames(t: Throwable): Option[List[String]] =
+    Option(t.getStackTrace).map { st =>
+      // `st.map` must resolve to `ArrayOps.map` (via the `refArrayOps` conversion),
+      // so `ste` is a `StackTraceElement`, not the whole array.
+      st.map { ste => ste.getMethodName }.toList
+    }

--- a/tests/explicit-nulls/warn/expose-flexible-types.check
+++ b/tests/explicit-nulls/warn/expose-flexible-types.check
@@ -1,56 +1,56 @@
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:4:6 --------------------------------------------------
 4 |  def f = s.trim // warn
   |      ^
-  |   method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+  |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:8:6 --------------------------------------------------
 8 |  def h = (s.trim, s.length) // warn
   |      ^
-  |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
+  |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:9:16 -------------------------------------------------
 9 |  protected def i = s.trim // warn
   |                ^
-  |   method i exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+  |method i exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:11:19 ------------------------------------------------
 11 |  private[foo] def k = s.trim // warn
    |                   ^
-   | method k exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |method k exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:12:6 -------------------------------------------------
 12 |  val ss = s.replace("a", "A") // warn
    |      ^
-   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:13:6 -------------------------------------------------
 13 |  val ss2 = Seq(s.trim) // warn
    |      ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:21:6 -------------------------------------------------
 21 |  def f = s2.trim // warn
    |      ^
-   | method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:25:6 -------------------------------------------------
 25 |  def h = (s2.trim, s2.length) // warn
    |      ^
-   |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
+   |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:26:6 -------------------------------------------------
 26 |  val ss = s2.replace("a", "A") // warn
    |      ^
-   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:27:6 -------------------------------------------------
 27 |  val ss2 = Seq(s2.trim) // warn
    |      ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:32:4 -------------------------------------------------
 32 |def f = s2.trim // warn
    |    ^
-   | method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:36:4 -------------------------------------------------
 36 |def h = (s2.trim, s2.length) // warn
    |    ^
-   |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
+   |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:37:4 -------------------------------------------------
 37 |val ss = s2.replace("a", "A") // warn
    |    ^
-   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
+   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:38:4 -------------------------------------------------
 38 |val ss2 = Seq(s2.trim) // warn
    |    ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly

--- a/tests/explicit-nulls/warn/expose-flexible-types.check
+++ b/tests/explicit-nulls/warn/expose-flexible-types.check
@@ -1,56 +1,56 @@
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:4:6 --------------------------------------------------
 4 |  def f = s.trim // warn
   |      ^
-  |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+  |   method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:8:6 --------------------------------------------------
 8 |  def h = (s.trim, s.length) // warn
   |      ^
-  |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
+  |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:9:16 -------------------------------------------------
 9 |  protected def i = s.trim // warn
   |                ^
-  |method i exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+  |   method i exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:11:19 ------------------------------------------------
 11 |  private[foo] def k = s.trim // warn
    |                   ^
-   |method k exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | method k exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:12:6 -------------------------------------------------
 12 |  val ss = s.replace("a", "A") // warn
    |      ^
-   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:13:6 -------------------------------------------------
 13 |  val ss2 = Seq(s.trim) // warn
    |      ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:21:6 -------------------------------------------------
 21 |  def f = s2.trim // warn
    |      ^
-   |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:25:6 -------------------------------------------------
 25 |  def h = (s2.trim, s2.length) // warn
    |      ^
-   |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
+   |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:26:6 -------------------------------------------------
 26 |  val ss = s2.replace("a", "A") // warn
    |      ^
-   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:27:6 -------------------------------------------------
 27 |  val ss2 = Seq(s2.trim) // warn
    |      ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:32:4 -------------------------------------------------
 32 |def f = s2.trim // warn
    |    ^
-   |method f exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | method f exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:36:4 -------------------------------------------------
 36 |def h = (s2.trim, s2.length) // warn
    |    ^
-   |method h exposes a flexible type in its inferred result type (<FlexibleType>[String], Int). Consider annotating the type explicitly
+   |method h exposes a flexible type in its inferred result type ((String)?, Int). Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:37:4 -------------------------------------------------
 37 |val ss = s2.replace("a", "A") // warn
    |    ^
-   |value ss exposes a flexible type in its inferred result type <FlexibleType>[String]. Consider annotating the type explicitly
+   | value ss exposes a flexible type in its inferred result type (String)?. Consider annotating the type explicitly
 -- Warning: tests/explicit-nulls/warn/expose-flexible-types.scala:38:4 -------------------------------------------------
 38 |val ss2 = Seq(s2.trim) // warn
    |    ^
-   |value ss2 exposes a flexible type in its inferred result type Seq[<FlexibleType>[String]]. Consider annotating the type explicitly
+   |value ss2 exposes a flexible type in its inferred result type Seq[(String)?]. Consider annotating the type explicitly


### PR DESCRIPTION
This is a rebased version of #26245. It also removes the unrelated and now-outdated changes that enable explicit nulls by default, to make the changes for the representation of FlexibleType more clearly visible.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Covered by existing tests (this is a refactoring)
