### PR TITLE
Avoid Unit =:= on class refs to fix cyclic TASTy load

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -374,7 +374,9 @@ trait BCodeSkelBuilder extends BCodeHelpers {
 
       }
 
-      cnode.visitAttribute(bTypeLoader.classBTypeFromSymbol(claszSymbol).inlineInfoAttribute)
+      val classBType = bTypeLoader.classBTypeFromSymbol(claszSymbol)
+      if classBType.info.inlineInfo.methodInfos.nonEmpty then
+        cnode.visitAttribute(classBType.inlineInfoAttribute)
 
       // the invoker is responsible for adding a class-static constructor.
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/BTypesFromClassfile.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/BTypesFromClassfile.scala
@@ -166,8 +166,9 @@ class BTypesFromClassfile(byteCodeRepository: BCodeRepository, bTypeLoader: BTyp
   
   /**
    * Build the InlineInfo for a class. For Scala classes, the information is stored in the
-   * inline info attribute. If the attribute is missing, the InlineInfo is built using the
-   * metadata available in the classfile (ACC_FINAL flags, etc.).
+   * inline info attribute. If the attribute is missing or is an empty stub (libraries compiled
+   * without `-opt:inline`), the InlineInfo is built using the metadata available in the classfile
+   * (ACC_FINAL flags, etc.).
    */
   private def inlineInfoFromClassfile(classNode: ClassNode, moduleNode: Option[ModuleNode]): InlineInfo = {
     def fromClassfileAttribute: Option[InlineInfo] = {
@@ -206,6 +207,11 @@ class BTypesFromClassfile(byteCodeRepository: BCodeRepository, bTypeLoader: BTyp
       InlineInfo(isFinalClass, sam, methodInfos, warning, isAccessible)
     }
 
-    fromClassfileAttribute.getOrElse(fromClassfileWithoutAttribute)
+    // Libraries compiled without -opt:inline still get a Scala3InlineInfo stub
+    // (version + flags 0 + zero methods, isAccessible=false). Trusting that
+    // attribute hides real methods and blocks inlining (#27010 / OptimizationBytecodeTests).
+    fromClassfileAttribute
+      .filter(_.methodInfos.nonEmpty)
+      .getOrElse(fromClassfileWithoutAttribute)
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -1018,7 +1018,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
     // constructor method should not be semi-erased.
     if semiEraseVCs && isConstructor && !tp.isInstanceOf[MethodOrPoly] then
       erasureFn(sourceLanguage, semiEraseVCs = false, isConstructor, isSymbol, inSigName).eraseResult(tp)
-    else if tp =:= defn.UnitType then
+    else if isErasedToVoid(tp) then
       // This should always be UnitType. However, there is one exception: if we
       // are computing the erasure of a Scala 2 symbol whose result type is a
       // Scala.js pseudo-union type, we must preserve the pseudo-union.
@@ -1034,6 +1034,15 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         defn.UnitType
     else
       apply(tp)
+
+  /** True if a result type should erase to JVM void. */
+  private def isErasedToVoid(tp: Type)(using Context): Boolean =
+    tp.isRef(defn.UnitClass) || nonClassEqUnit(tp)
+
+  private def nonClassEqUnit(tp: Type)(using Context): Boolean = tp.stripTypeVar match
+    case tref: TypeRef if tref.symbol.isClass => false
+    case AnnotatedType(tp1, _) => nonClassEqUnit(tp1)
+    case _ => tp =:= defn.UnitType
 
   /** The name of the type as it is used in `Signature`s.
    *

--- a/tests/pos/i26959-alias/Lib_1.scala
+++ b/tests/pos/i26959-alias/Lib_1.scala
@@ -1,0 +1,13 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  type U = Unit
+  type ID[T] = T
+  trait InnerSupport { this: Companion.type =>
+    def foo: U = ()
+    def bar: ID[Unit] = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}

--- a/tests/pos/i26959-alias/User_2.scala
+++ b/tests/pos/i26959-alias/User_2.scala
@@ -1,0 +1,2 @@
+package repro
+class User(c: Outer)

--- a/tests/pos/i26959-joint.scala
+++ b/tests/pos/i26959-joint.scala
@@ -1,0 +1,12 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  trait InnerSupport { this: Companion.type =>
+    def foo: Unit = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}
+
+class User(c: Outer)

--- a/tests/pos/i26959/Lib_1.scala
+++ b/tests/pos/i26959/Lib_1.scala
@@ -1,0 +1,10 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  trait InnerSupport { this: Companion.type =>
+    def foo: Unit = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}

--- a/tests/pos/i26959/User_2.scala
+++ b/tests/pos/i26959/User_2.scala
@@ -1,0 +1,2 @@
+package repro
+class User(c: Outer)


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26959

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running automated tests against the case from the issue (and some adjacent ones)

## How was the solution tested?
New automated tests (including the issue's reproducer, if applicable)
