### PR TITLE
Backport "Macro interpreter: rethrow RecursionOverflow" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
@@ -240,6 +240,8 @@ class Interpreter(pos: SrcPos, classLoader0: ClassLoader)(using Context):
         ex.getTargetException match {
           case ex: scala.quoted.runtime.StopMacroExpansion =>
             throw ex
+          case ex: dotty.tools.dotc.core.RecursionOverflow =>
+            throw ex
           case MissingClassValidInCurrentRun(sym, origin) =>
             suspendOnMissing(sym, origin, pos)
           case targetException =>

--- a/tests/neg-macros/recursionoverflow-in-macro.check
+++ b/tests/neg-macros/recursionoverflow-in-macro.check
@@ -1,0 +1,254 @@
+-- Error: tests/neg-macros/recursionoverflow-in-macro/Use_2.scala:6:42 -------------------------------------------------
+ 6 |val proof: Int = LemmaMacros.applyTactics { // error
+   |                 ^
+   |Recursion limit exceeded.
+   |Maybe there is an illegal cyclic reference?
+   |If that's not the case, you could try to increase the fuel and stack size: https://docs.scala-lang.org/overviews/compiler-options/compiling-deeply-nested-code.html
+   |For the unprocessed stack overflow trace, compile with -Xno-enrich-error-messages.
+   |A recurring operation is (inner to outer):
+   |
+   |  folding over LemmaMacros.use(0, step)
+   |  folding over LemmaMacros.use(0, step)
+   |  folding over LemmaMacros.use(0, step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(0, step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(0, step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(0, step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step)
+   |  folding over LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step)
+   |  ...
+   |
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step), step),
+   |                step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step), step),
+   |                step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step), step)
+   |                    ,
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step), step)
+   |                    ,
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step), step)
+   |                    ,
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(
+   |                      LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step),
+   |                      step),
+   |                  step),
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(
+   |                      LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step),
+   |                      step),
+   |                  step),
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(
+   |                      LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step),
+   |                      step),
+   |                  step),
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(
+   |                      LemmaMacros.use(
+   |                        LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step),
+   |                        step),
+   |                    step),
+   |                  step),
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |  folding over LemmaMacros.use(
+   |  LemmaMacros.use(
+   |    LemmaMacros.use(
+   |      LemmaMacros.use(
+   |        LemmaMacros.use(
+   |          LemmaMacros.use(
+   |            LemmaMacros.use(
+   |              LemmaMacros.use(
+   |                LemmaMacros.use(
+   |                  LemmaMacros.use(
+   |                    LemmaMacros.use(
+   |                      LemmaMacros.use(
+   |                        LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(LemmaMacros.use(0, step), step), step), step),
+   |                        step),
+   |                    step),
+   |                  step),
+   |                step),
+   |              step),
+   |            step),
+   |          step),
+   |        step),
+   |      step),
+   |    step),
+   |  step),
+   |step)
+   |
+ 7 |  step; step; step; step; step; step; step; step; step; step; step; step; step; step; step
+ 8 |...
+10 |}
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from Macro_1.scala:23
+23 |      '{ LemmaMacros.use($acc, ${ tactic.asExprOf[Tactic[Any]] }) }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from Macro_1.scala:23
+23 |      '{ LemmaMacros.use($acc, ${ tactic.asExprOf[Tactic[Any]] }) }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/recursionoverflow-in-macro/Macro_1.scala
+++ b/tests/neg-macros/recursionoverflow-in-macro/Macro_1.scala
@@ -1,0 +1,24 @@
+import scala.quoted.*
+
+trait Tactic[+T]
+
+object LemmaMacros:
+  def use(state: Int, tactical: Tactic[Any]): Int = state + 1
+
+  inline def applyTactics[U](inline tacticsProof: => Tactic[U]): Int =
+    ${ helperImpl('tacticsProof) }
+
+  def helperImpl[U: Type](tacticsProof: Expr[Tactic[U]])(using Quotes): Expr[Int] =
+    constructProofState('{ 0 }, tacticsProof)
+
+  private def constructProofState[U: Type](proofState: Expr[Int], tacticsProof: Expr[Tactic[U]])(using Quotes): Expr[Int] =
+    import quotes.reflect.*
+    def unwrapInlined(term: Term): Term = term match
+      case Inlined(_, _, t) => unwrapInlined(t)
+      case t => t
+    val tacticTerms: List[Term] = unwrapInlined(tacticsProof.asTerm) match
+      case Block(stmts, term) => stmts.collect { case t: Term => t } :+ term
+      case term => List(term)
+    tacticTerms.foldLeft(proofState) { (acc, tactic) =>
+      '{ LemmaMacros.use($acc, ${ tactic.asExprOf[Tactic[Any]] }) }
+    }

--- a/tests/neg-macros/recursionoverflow-in-macro/Use_2.scala
+++ b/tests/neg-macros/recursionoverflow-in-macro/Use_2.scala
@@ -1,0 +1,10 @@
+//> using options -Xmax-fuel:50
+// (deliberately low, we want this to fail so we can check the error message)
+
+def step: Tactic[Unit] = new Tactic[Unit] {}
+
+val proof: Int = LemmaMacros.applyTactics { // error
+  step; step; step; step; step; step; step; step; step; step; step; step; step; step; step
+  step; step; step; step; step; step; step; step; step; step; step; step; step; step; step
+  step; step; step; step; step; step; step; step; step; step; step; step; step; step; step
+}


### PR DESCRIPTION
Backports #26896 to the 3.10.0-RC2.

PR submitted by the release tooling.
[skip ci]