### PR TITLE
Backport "Increase phase ID width, stealing a bit from run ID" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -32,10 +32,9 @@ object Periods {
   /** A period is a contiguous sequence of phase ids in some run.
    *  It is coded as follows:
    *
-   *     sign, always 0:  1 bit
-   *     run id:          17 bits
-   *     last phase id:   7 bits
-   *     duration:        7 bits (a.k.a. #phases before last)
+   *     run id:          16 bits
+   *     last phase id:   8 bits
+   *     duration:        8 bits (a.k.a. #phases before last)
    *
    *  This encoding ensures the < and > operators can be delegated as-is to `code`, making them cheap.
    */
@@ -45,26 +44,26 @@ object Periods {
      * To avoid introducing incorrect "optimizations", use your favorite SMT solver to check them.
      * You can model two Periods using the current encoding with the following:
        ; (r, l, d) components
-       (declare-fun r1 () (_ BitVec 17))
-       (declare-fun l1 () (_ BitVec 7))
-       (declare-fun d1 () (_ BitVec 7))
-       (declare-fun r2 () (_ BitVec 17))
-       (declare-fun l2 () (_ BitVec 7))
-       (declare-fun d2 () (_ BitVec 7))
+       (declare-fun r1 () (_ BitVec 16))
+       (declare-fun l1 () (_ BitVec 8))
+       (declare-fun d1 () (_ BitVec 8))
+       (declare-fun r2 () (_ BitVec 16))
+       (declare-fun l2 () (_ BitVec 8))
+       (declare-fun d2 () (_ BitVec 8))
        ; assume d <= l
        (assert (bvule d1 l1))
        (assert (bvule d2 l2))
        ; assume l < 64
-       (assert (bvult l1 #b1000000))
-       (assert (bvult l2 #b1000000))
+       (assert (bvult l1 #b10000000))
+       (assert (bvult l2 #b10000000))
        ; assume r > 0
-       (assert (bvult #b00000000000000000 r1))
-       (assert (bvult #b00000000000000000 r2))
-       ; full code, including 0 as sign bit
+       (assert (bvult #b0000000000000000 r1))
+       (assert (bvult #b0000000000000000 r2))
+       ; full code
        (declare-fun code1 () (_ BitVec 32))
-       (assert (= code1 (concat #b0 r1 l1 d1)))
+       (assert (= code1 (concat r1 l1 d1)))
        (declare-fun code2 () (_ BitVec 32))
-       (assert (= code2 (concat #b0 r2 l2 d2)))
+       (assert (= code2 (concat r2 l2 d2)))
      */
 
     /** The run identifier of this period. */
@@ -78,13 +77,14 @@ object Periods {
       /* More obvious version with one more bitmask: (lastPhaseId - (code & PhaseMask))
          SMT proof, given the definitions above:
            (declare-fun lastPhaseId () (_ BitVec 32))
-           (assert (= lastPhaseId (bvand (bvlshr code1 #x00000007) #x0000007F)))
+           (assert (= lastPhaseId (bvand (bvlshr code1 #x00000008) #x000000FF)))
            (declare-fun simple () (_ BitVec 32))
-           (assert (= simple (bvsub lastPhaseId (bvand code1 #x0000007F))))
+           (assert (= simple (bvsub lastPhaseId (bvand code1 #x000000FF))))
            (declare-fun opt () (_ BitVec 32))
-           (assert (= opt (bvand (bvsub (bvashr code1 #x00000007) code1) #x0000007F)))
+           (assert (= opt (bvand (bvsub (bvashr code1 #x00000008) code1) #x000000FF)))
            (assert (not (= opt simple)))
-         This returns false for (check-sat), thus `opt` is always equal to `simple`.
+           (check-sat)
+         This returns UNSAT, thus `opt` is always equal to `simple`.
        */
       ((code >>> PhaseWidth) - code) & PhaseMask
 
@@ -92,16 +92,17 @@ object Periods {
       /* More obvious version: firstPhaseId <= id && id <= lastPhaseId
          SMT proof, given the definitions above:
            (declare-fun lastPhaseId () (_ BitVec 32))
-           (assert (= lastPhaseId (bvand (bvlshr code1 #x00000007) #x0000007F)))
+           (assert (= lastPhaseId (bvand (bvlshr code1 #x00000008) #x000000FF)))
            (declare-fun firstPhaseId () (_ BitVec 32))
-           (assert (= firstPhaseId (bvsub lastPhaseId (bvand code1 #x0000007F))))
+           (assert (= firstPhaseId (bvsub lastPhaseId (bvand code1 #x000000FF))))
            (declare-fun diff () (_ BitVec 32))
-           (assert (= diff (bvand code1 #x0000007F)))
+           (assert (= diff (bvand code1 #x000000FF)))
            (declare-fun id () (_ BitVec 32))
-           (assert (bvule id #x0000007F))
+           (assert (bvule id #x000000FF))
            (assert (not (= (and (bvsle firstPhaseId id) (bvsle id lastPhaseId))
                            (bvsle (bvxor (bvsub (bvadd id diff) lastPhaseId) #x80000000) (bvxor diff #x80000000)))))
-         This returns false for (check-sat), thus the simple and complex versions are equivalent.
+           (check-sat)
+         This returns UNSAT, thus the simple and complex versions are equivalent.
          Reasoning:
           if a <= b, then a <= x && x <= b is equivalent to (x - a) unsigned_<= (b - a). Here a == firstPhaseId == lastP - diff and b == lastP.
           So (x - a) == x - (lastP - diff) == x + diff - lastP
@@ -122,17 +123,18 @@ object Periods {
            (declare-fun simple () (_ Bool))
            (assert (= simple (and (= r1 r2) (bvuge l1 l2) (bvule (bvsub l1 d1) (bvsub l2 d2)))))
            (declare-fun firstPhaseId1 () (_ BitVec 32))
-           (assert (= firstPhaseId1 ((_ zero_extend 25) (bvsub l1 d1))))
+           (assert (= firstPhaseId1 ((_ zero_extend 24) (bvsub l1 d1))))
            (declare-fun firstPhaseId2 () (_ BitVec 32))
-           (assert (= firstPhaseId2 ((_ zero_extend 25) (bvsub l2 d2))))
+           (assert (= firstPhaseId2 ((_ zero_extend 24) (bvsub l2 d2))))
            (declare-fun lastPhaseId1 () (_ BitVec 32))
-           (assert (= lastPhaseId1 ((_ zero_extend 25) l1)))
+           (assert (= lastPhaseId1 ((_ zero_extend 24) l1)))
            (declare-fun lastPhaseId2 () (_ BitVec 32))
-           (assert (= lastPhaseId2 ((_ zero_extend 25) l2)))
+           (assert (= lastPhaseId2 ((_ zero_extend 24) l2)))
            (declare-fun opt () (_ Bool))
-           (assert (= opt (= #x00000000 (bvor (bvand (bvxor code1 code2) #xFFFFC000) (bvand (bvor (bvsub firstPhaseId2 firstPhaseId1) (bvsub lastPhaseId1 lastPhaseId2)) #x80000000)))))
+           (assert (= opt (= #x00000000 (bvor (bvand (bvxor code1 code2) #xFFFF0000) (bvand (bvor (bvsub firstPhaseId2 firstPhaseId1) (bvsub lastPhaseId1 lastPhaseId2)) #x80000000)))))
            (assert (not (= simple opt)))
-         This returns false for (check-sat), thus the simple and complex versions are equivalent.
+           (check-sat)
+         This returns UNSAT, thus the simple and complex versions are equivalent.
        */
       (((this.code ^ that.code) & (-1 << (PhaseWidth * 2))) | (((that.firstPhaseId - this.firstPhaseId) | (this.lastPhaseId - that.lastPhaseId)) & Int.MinValue)) == 0
 
@@ -159,10 +161,10 @@ object Periods {
           this.lastPhaseId max that.lastPhaseId)
 
     inline def <(that: Period): Boolean =
-      this.code < that.code
+      Integer.compareUnsigned(this.code, that.code) < 0
 
     inline def >(that: Period): Boolean =
-      this.code > that.code
+      Integer.compareUnsigned(this.code, that.code) > 0
 
     def toText(p: Printer): Text =
       inContext(p.printerContext):
@@ -216,7 +218,7 @@ object Periods {
   type RunId = Int
   inline val NoRunId = 0
   inline val InitialRunId = 1
-  inline val RunWidth = java.lang.Integer.SIZE - PhaseWidth * 2 - 1/* sign */
+  inline val RunWidth = java.lang.Integer.SIZE - PhaseWidth * 2
   inline val MaxPossibleRunId = (1 << RunWidth) - 1
 
   /** An ordinal number for phases. First phase has number 1. */
@@ -225,7 +227,7 @@ object Periods {
   inline val FirstPhaseId = 1
 
   /** The number of bits needed to encode a phase identifier. */
-  inline val PhaseWidth = 7
+  inline val PhaseWidth = 8
   private inline val PhaseMask = (1 << PhaseWidth) - 1
   inline val MaxPossiblePhaseId = PhaseMask
 


### PR DESCRIPTION
Backports #27006 to the 3.10.0-RC2.

PR submitted by the release tooling.
[skip ci]