### PR TITLE
Backport "Minimize `Tree.symbol` calls" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/backend/ScalaPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/ScalaPrimitives.scala
@@ -397,8 +397,9 @@ class ScalaPrimitives(using @constructorOnly initCtx: Context) {
     primitives.contains(sym)
 
   def isPrimitive(fun: Tree)(using Context): Boolean =
-    primitives.contains(fun.symbol)
-    || (fun.symbol == NoSymbol // the only trees that do not have a symbol assigned are array.{update,select,length,clone}
+    val sym = fun.symbol
+    primitives.contains(sym)
+    || (sym == NoSymbol // the only trees that do not have a symbol assigned are array.{update,select,length,clone}
         && {
           fun match
             case Select(_, nme.clone_) => false // but array.clone is NOT a primitive op.

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -397,10 +397,11 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
           generatedType = genApply(app, expectedType)
 
         case This(qual) =>
-          val symIsModuleClass = tree.symbol.is(ModuleClass)
-          assert(tree.symbol == claszSymbol || symIsModuleClass,
-                 s"Trying to access the this of another class: tree.symbol = ${tree.symbol}, class symbol = $claszSymbol compilation unit: ${ctx.compilationUnit}")
-          if (symIsModuleClass && tree.symbol != claszSymbol) {
+          val sym = tree.symbol
+          val symIsModuleClass = sym.is(ModuleClass)
+          assert(sym == claszSymbol || symIsModuleClass,
+                 s"Trying to access the this of another class: tree.symbol = $sym, class symbol = $claszSymbol compilation unit: ${ctx.compilationUnit}")
+          if (symIsModuleClass && sym != claszSymbol) {
             generatedType = genLoadModule(tree)
           }
           else {
@@ -409,7 +410,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
             // is `[Object` (computed by typeToBType, the type of This(Array) is `Array[T]`). If we would set
             // the generatedType to `Array` below, the call to adapt at the end would fail. The situation is
             // similar for primitives (`I` vs `Int`).
-            if (tree.symbol != defn.ArrayClass && !tree.symbol.isPrimitiveValueClass) {
+            if (sym != defn.ArrayClass && !sym.isPrimitiveValueClass) {
               generatedType = bTypeLoader.classBTypeFromSymbol(claszSymbol)
             }
           }
@@ -1278,13 +1279,13 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
     end genLoadArguments
 
     def genLoadModule(tree: Tree)(using Context): BType = {
-      val module = (
-        if (!tree.symbol.is(PackageClass)) tree.symbol
-        else tree.symbol.info.member(nme.PACKAGE).symbol match {
+      val sym = tree.symbol
+      val module =
+        if !sym.is(PackageClass) then sym
+        else sym.info.member(nme.PACKAGE).symbol match {
           case NoSymbol => throw new AssertionError(s"SI-5604: Cannot use package as value: $tree")
           case s        => throw new AssertionError(s"SI-5604: found package class where package object expected: $tree")
         }
-      )
       lineNumber(tree)
       genLoadModule(module)
       symInfoTK(module)

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -646,8 +646,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     }
 
     // on entering a method
-    def resetMethodBookkeeping(dd: DefDef)(using Context) = {
-      val rhs = dd.rhs
+    def resetMethodBookkeeping()(using Context) = {
       locals.reset(isStaticMethod = methSymbol.isStaticMember)
       jumpDest = immutable.Map.empty
 
@@ -813,14 +812,15 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     private def genDefDef(dd: DefDef)(using Context): Unit = {
       val rhs = dd.rhs
       val vparamss = dd.termParamss
-      // the only method whose implementation is not emitted: getClass()
-      if (dd.symbol eq defn.Any_getClass) { return }
       assert(mnode == null, "GenBCode detected nested method.")
 
       methSymbol  = dd.symbol
+      // the only method whose implementation is not emitted: getClass()
+      if (methSymbol eq defn.Any_getClass) { return }
+
       returnType  = bTypeLoader.methodBTypeFromSymbol(methSymbol).returnType
 
-      resetMethodBookkeeping(dd)
+      resetMethodBookkeeping()
 
       // add method-local vars for params
 
@@ -903,7 +903,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
             )
           else
             // The JVM doesn't support `synchronized` methods on interfaces so we must implement that ourselves
-            if dd.symbol.is(Synchronized) && dd.symbol.owner.is(Trait) then
+            if methSymbol.is(Synchronized) && methSymbol.owner.is(Trait) then
               bc.aloadThis()
               val generatedType = genSynchronized(trimmedRhs, trimmedRhs :: Nil, returnType)
               genAdaptAndSendToDest(generatedType, returnType, LoadDestination.Return)

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -1039,7 +1039,9 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     else
       val locals = new mutable.ListBuffer[Symbol]
       for stat <- stats do
-        if stat.isDef && stat.symbol.exists then locals += stat.symbol
+        if stat.isDef then
+          val sym = stat.symbol
+          if sym.exists then locals += sym
       locals.toList
 
   /** If `tree` is a DefTree, the symbol defined by it, otherwise NoSymbol */

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -370,8 +370,10 @@ object Trees {
 
     protected def srcName(using Context): Name =
       if name == nme.CONSTRUCTOR then nme.this_
-      else if symbol.isPackageObject then symbol.owner.name
-      else name
+      else
+        val sym = this.symbol
+        if sym.isPackageObject then sym.owner.name
+        else name
 
     /** The position of the name defined by this definition.
      *  This is a point position if the definition is synthetic, or a range position

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1200,6 +1200,12 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       tree
     }
 
+    /** Same as above, but when you already have `tree.symbol` */
+    def setDefTree(sym: Symbol)(using Context): ThisTree = {
+      if (sym.exists) sym.defTree = tree
+      tree
+    }
+
     /** Make sure tree has given symbol. This is called when typing or unpickling
      *  a ValDef or DefDef. It turns out that under very rare circumstances the symbol
      *  computed for a tree is not correct. The only known test case is i21755.scala.
@@ -1209,11 +1215,14 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
      *  corresponding symbol in the superclass. It is not known what are the precise
      *  conditions where this happens, but my guess would be that it's connected to the
      *  recursion in the self type.
+     *  As an optimization, returns the symbol.
      */
-    def ensureHasSym(sym: Symbol)(using Context): Unit =
-      if sym.exists && sym != tree.symbol then
-        typr.println(i"correcting definition symbol from ${tree.symbol.showLocated} to ${sym.showLocated}")
+    def ensureHasSym(sym: Symbol)(using Context): Symbol =
+      val treeSym = tree.symbol
+      if sym.exists && sym != treeSym then
+        typr.println(i"correcting definition symbol from ${treeSym.showLocated} to ${sym.showLocated}")
         tree.overwriteType(NamedType(sym.owner.thisType, sym.name, sym.denot))
+      treeSym
 
     def etaExpandCFT(using Context): Tree =
       def expand(target: Tree, tp: Type)(using Context): Tree = tp match

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -16,7 +16,8 @@ import scala.annotation.internal.sharable
 object Annotations {
 
   def annotClass(tree: Tree)(using Context) =
-    if (tree.symbol.isConstructor) tree.symbol.owner
+    val sym = tree.symbol
+    if (sym.isConstructor) sym.owner
     else tree.tpe.typeSymbol
 
   abstract class Annotation extends Showable {

--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -55,7 +55,7 @@ object TypeEval:
         case ConstantType(_) => Some(true)
         // constant if the term is constant
         case t: TermRef =>
-          if t.denot.symbol.flagsUNSAFE.is(Flags.Param) then
+          if t.symbol.flagsUNSAFE.is(Flags.Param) then
             // might be substituted later
             None
           else

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -80,11 +80,9 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
   def addrOfSym(sym: Symbol): Option[Addr] =
     symRefs.get(sym)
 
-  def preRegister(tree: Tree)(using Context): Unit = tree match {
-    case tree: MemberDef =>
-      if (!symRefs.contains(tree.symbol)) symRefs(tree.symbol) = NoAddr
-    case _ =>
-  }
+  def preRegister(tree: Tree)(using Context): Unit = tree match
+    case tree: MemberDef => symRefs.getOrElseUpdate(tree.symbol, NoAddr)
+    case _ => ()
 
   def registerDef(sym: Symbol): Unit =
     symRefs(sym) = currentAddr
@@ -474,17 +472,18 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
                 pickleType(tp)
               }
             case _ =>
+              val sym = tree.symbol
+              val ename = sym.targetName
               if passesConditionForErroringBestEffortCode(tree.hasType) then
                 // #19951 The signature of a constructor of a Java annotation is irrelevant
                 val sig =
-                  if name == nme.CONSTRUCTOR && tree.symbol.exists && tree.symbol.owner.is(JavaAnnotation) then Signature.NotAMethod
+                  if name == nme.CONSTRUCTOR && sym.exists && sym.owner.is(JavaAnnotation) then Signature.NotAMethod
                   else tree.tpe.signature
-                var ename = tree.symbol.targetName
                 val selectFromQualifier =
                   name.isTypeName
                   || qual.isInstanceOf[Hole] // holes have no symbol
                   || sig == Signature.NotAMethod // no overload resolution necessary
-                  || !tree.denot.symbol.exists // polymorphic function type
+                  || !sym.exists // polymorphic function type
                   || tree.denot.asSingleDenotation.isRefinedMethod // refined methods have no defining class symbol
                 if selectFromQualifier then
                   writeByte(if name.isTypeName then SELECTtpt else SELECT)
@@ -493,22 +492,22 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
                 else // select from owner
                   writeByte(SELECTin)
                   withLength {
-                    pickleNameAndSig(name, tree.symbol.signature, ename)
+                    pickleNameAndSig(name, sym.signature, ename)
                     pickleTree(qual)
-                    pickleType(tree.symbol.owner.typeRef)
+                    pickleType(sym.owner.typeRef)
                   }
               else
                 writeByte(if name.isTypeName then SELECTtpt else SELECT)
-                val ename = tree.symbol.targetName
                 pickleNameAndSig(name, Signature.NotAMethod, ename)
                 pickleTree(qual)
           }
         case Apply(fun, args) =>
-          if (fun.symbol eq defn.throwMethod) {
+          val funSym = fun.symbol
+          if (funSym eq defn.throwMethod) {
             writeByte(THROW)
             pickleTree(args.head)
           }
-          else if fun.symbol.originalSignaturePolymorphic.exists then
+          else if funSym.originalSignaturePolymorphic.exists then
             writeByte(APPLYsigpoly)
             withLength {
               pickleTree(fun)
@@ -520,7 +519,7 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
             withLength {
               pickleTree(fun)
               // #19951 Do not pickle default arguments to Java annotation constructors
-              if fun.symbol.isClassConstructor && fun.symbol.owner.is(JavaAnnotation) then
+              if funSym.isClassConstructor && funSym.owner.is(JavaAnnotation) then
                 for arg <- args do
                   arg match
                     case NamedArg(_, Ident(nme.WILDCARD)) => ()

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -927,8 +927,8 @@ class TreeUnpickler(reader: TastyReader,
       def ValDef(tpt: Tree) =
         ta.assignType(untpd.ValDef(sym.name.asTermName, tpt, readRhs(using localCtx)), sym)
 
-      def DefDef(paramss: List[ParamClause], tpt: Tree) =
-        sym.setParamssFromDefs(paramss)
+      def DefDef(paramss: List[ParamClause], paramsSyms: List[List[Symbol]], tpt: Tree) =
+        sym.setParamss(paramsSyms)
         ta.assignType(
           untpd.DefDef(sym.name.asTermName, paramss, tpt, readRhs(using localCtx)),
           sym)
@@ -950,18 +950,18 @@ class TreeUnpickler(reader: TastyReader,
         case DEFDEF =>
           val paramDefss = readParamss()(using localCtx)
           val tpt = readTpt()(using localCtx)
-          val paramss = normalizeIfConstructor(
-              paramDefss.nestedMap(_.symbol), name == nme.CONSTRUCTOR)
+          val paramss = paramDefss.nestedMap(_.symbol)
+          val normalizedParamss = normalizeIfConstructor(paramss, name == nme.CONSTRUCTOR)
           val resType =
             if name == nme.CONSTRUCTOR then
-              effectiveResultType(sym, paramss)
+              effectiveResultType(sym, normalizedParamss)
             else if sym.isAllOf(Given | Method) && Feature.enabled(Feature.modularity) then
-              addParamRefinements(tpt.tpe, paramss)
+              addParamRefinements(tpt.tpe, normalizedParamss)
             else
               tpt.tpe
-          sym.info = methodType(paramss, resType)
+          sym.info = methodType(normalizedParamss, resType)
           nullify(sym)
-          DefDef(paramDefss, tpt)
+          DefDef(paramDefss, paramss, tpt)
         case VALDEF =>
           val tpt = readTpt()(using localCtx)
           sym.info = tpt.tpe.suppressIntoIfParam(sym)
@@ -1036,8 +1036,8 @@ class TreeUnpickler(reader: TastyReader,
         }
       }
 
-      tree.ensureHasSym(sym)
-      tree.setDefTree
+      val sym1 = tree.ensureHasSym(sym)
+      tree.setDefTree(sym1)
     }
 
     /** Read enough of parent to determine its type, without reading arguments
@@ -1530,11 +1530,12 @@ class TreeUnpickler(reader: TastyReader,
               tpd.Super(qual, mixId, mixTpe.typeSymbol)
             case APPLY =>
               val fn = readTree()
+              val sym = fn.symbol
               val args = until(end)(readTree())
-              if fn.symbol.isConstructor then constructorApply(fn, args)
-              else if fn.symbol == defn.QuotedRuntime_exprQuote then quotedExpr(fn, args) // decode pre 3.5.0 encoding
-              else if fn.symbol == defn.QuotedRuntime_exprSplice then splicedExpr(fn, args) // decode pre 3.5.0 encoding
-              else if fn.symbol == defn.QuotedRuntime_exprNestedSplice then nestedSpliceExpr(fn, args) // decode pre 3.5.0 encoding
+              if sym.isConstructor then constructorApply(fn, args)
+              else if sym == defn.QuotedRuntime_exprQuote then quotedExpr(fn, args) // decode pre 3.5.0 encoding
+              else if sym == defn.QuotedRuntime_exprSplice then splicedExpr(fn, args) // decode pre 3.5.0 encoding
+              else if sym == defn.QuotedRuntime_exprNestedSplice then nestedSpliceExpr(fn, args) // decode pre 3.5.0 encoding
               else if isSpuriousApply(fn, args) then fn
               else tpd.Apply(fn, args)
             case TYPEAPPLY =>

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -63,7 +63,8 @@ object Inliner:
       case New(_) | Closure(_, _, _) =>
         true
       case TypeApply(fn, _) =>
-        if fn.symbol.isErased || fn.symbol == defn.QuotedTypeModule_of then true else apply(fn)
+        val sym = fn.symbol
+        if sym.isErased || sym == defn.QuotedTypeModule_of then true else apply(fn)
       case Apply(fn, args) =>
         val isCaseClassApply = {
           val cls = tree.tpe.classSymbol
@@ -711,8 +712,10 @@ class Inliner(val call: tpd.Tree)(using Context):
         /* Span of the argument. Used when the argument is inlined directly without a binding */
         def argSpan =
           if (tree.name == nme.WILDCARD) tree.span // From type match
-          else if (tree.symbol.isTypeParam && tree.symbol.owner.isClass) tree.span // TODO is this the correct span
-          else paramSpan(tree.name)
+          else
+            val sym = tree.symbol
+            if sym.isTypeParam && sym.owner.isClass then tree.span // TODO is this the correct span
+            else paramSpan(tree.name)
         val inlinedCtx = ctx.withSource(inlinedMethod.topLevelClass.source)
         paramProxy.get(tree.tpe) match {
           case Some(t) if tree.isTerm && t.isSingleton =>

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -191,19 +191,20 @@ object Inlines:
     )
 
     val tree0 = stripper.transform(tree)
+    val symbol0 = tree0.symbol
 
-    if tree0.symbol.denot.exists
-      && tree0.symbol.effectiveOwner == defn.CompiletimeTestingPackage.moduleClass
+    if symbol0.denot.exists
+      && symbol0.effectiveOwner == defn.CompiletimeTestingPackage.moduleClass
     then
-      if (tree0.symbol == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree0)
-      if (tree0.symbol == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree0)
+      if (symbol0 == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree0)
+      if (symbol0 == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree0)
 
     if ctx.isAfterTyper then
       // During typer we wait with cross version checks until PostTyper, in order
       // not to provoke cyclic references. See i16116 for a test case.
-      CrossVersionChecks.checkRef(tree0.symbol, tree0.srcPos)
+      CrossVersionChecks.checkRef(symbol0, tree0.srcPos)
 
-    if tree0.symbol.isConstructor then return tree // error already reported for the inline constructor definition
+    if symbol0.isConstructor then return tree // error already reported for the inline constructor definition
 
     /** Set the position of all trees logically contained in the expansion of
      *  inlined call `call` to the position of `call`. This transform is necessary
@@ -258,7 +259,7 @@ object Inlines:
         cpy.Block(tree0)(bindings.toList, inlineCall(tree1))
       else if enclosingInlineds.length < ctx.settings.XmaxInlines.value && !reachedInlinedTreesLimit then
         val body =
-          try bodyToInline(tree0.symbol) // can typecheck the tree and thereby produce errors
+          try bodyToInline(symbol0) // can typecheck the tree and thereby produce errors
           catch case _: MissingInlineInfo =>
             throw CyclicReference(ctx.owner)
         new InlineCall(tree0).expand(body)
@@ -277,7 +278,7 @@ object Inlines:
     // if tree0 (inline call tree before expansion) is transparent
     // attach the method name to the tree2 (expanded tree)
     val tree3 =
-      if tree0.symbol.is(Transparent) then tree2.withAttachment(TransparentInlinedCall, tree0.symbol.show) else tree2
+      if symbol0.is(Transparent) then tree2.withAttachment(TransparentInlinedCall, symbol0.show) else tree2
     if ctx.base.stopInlining && enclosingInlineds.isEmpty then
       ctx.base.stopInlining = false
         // we have completely backed out of the call that overflowed;

--- a/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
@@ -55,7 +55,7 @@ class BeanProperties(thisPhase: DenotTransformer):
     def prefixedName(prefix: String, valName: Name) =
       (prefix + valName.lastPart.toString.capitalize).toTermName
 
-    val symbol = valDef.denot.symbol
+    val symbol = valDef.symbol
     symbol.getAnnotation(defn.BeanPropertyAnnot)
       .orElse(symbol.getAnnotation(defn.BooleanBeanPropertyAnnot))
       .toList.flatMap { annot =>

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -497,7 +497,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
         else Nil
       implicitRefs.find(ref => ref.underlyingRef.widen <:< tp) match
       case Some(found: TermRef) =>
-        refUsage(found.denot.symbol, pos)
+        refUsage(found.symbol, pos)
         if importInfo `ne` null then
           importInfo.selectors.find(sel => sel.isGiven || sel.rename == found.name) match
           case Some(sel) =>
@@ -505,7 +505,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
           case _ =>
         return
       case Some(found: RenamedImplicitRef) if importInfo `ne` null =>
-        refUsage(found.underlyingRef.denot.symbol, pos)
+        refUsage(found.underlyingRef.symbol, pos)
         importInfo.selectors.find(sel => sel.rename == found.implicitName) match
         case Some(sel) =>
           refInfos.sels.put(sel, ())

--- a/compiler/src/dotty/tools/dotc/transform/DesugarSpecializedTraits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DesugarSpecializedTraits.scala
@@ -364,10 +364,14 @@ class DesugarSpecializedTraits extends MiniPhase, IdentityDenotTransformer:
     // TODO: Depending on how we ultimately organize the phasing
     // If we settle on using miniphases, this could be moved into transformDefDef and transformBlock.
     tree.foreachSubTree { 
-      case ddef: DefDef if ddef.symbol.isConstructor && !ddef.symbol.owner.is(Flags.Inline) => 
-        ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
-      case ddef: DefDef if !ddef.symbol.isConstructor && !ddef.symbol.is(Flags.Inline) => 
-        ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
+      case ddef: DefDef =>
+        val sym = ddef.symbol
+        if sym.isConstructor then
+          if !sym.owner.is(Flags.Inline) then
+            ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
+        else
+          if !sym.is(Flags.Inline) then
+            ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
       case AnonymousClassInstance(anon) =>
         def deandify(tp: Type): Iterator[Type] = tp match {
           case AndType(l, r) => deandify(l) ++ deandify(r)
@@ -897,7 +901,7 @@ object Specialization:
 
   def unapply(tpt: Tree)(using Context): Option[Specialization] = tpt match {
     case AppliedTypeTree(specializedTrait: Ident, concreteTypeTrees: List[Tree]) => 
-      Some(Specialization(specializedTrait.denot.symbol, concreteTypeTrees.map(_.tpe), tpt.span))
+      Some(Specialization(specializedTrait.symbol, concreteTypeTrees.map(_.tpe), tpt.span))
     case t: TypeTree => Specialization.unapply(t.tpe, t.span)
     case _ => None
   }

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -512,11 +512,11 @@ object Erasure {
   class Typer(erasurePhase: DenotTransformer) extends typer.ReTyper with NoChecking {
     import Boxing.*
 
-    def isErased(tree: Tree)(using Context): Boolean = tree match {
-      case TypeApply(Select(qual, _), _) if tree.symbol == defn.Any_typeCast =>
-        isErased(qual)
-      case _ => tree.symbol.isEffectivelyErased
-    }
+    def isErased(tree: Tree)(using Context): Boolean =
+      val sym = tree.symbol
+      tree match
+        case TypeApply(Select(qual, _), _) if sym == defn.Any_typeCast => isErased(qual)
+        case _ => sym.isEffectivelyErased
 
     /** Check that
      *    - erased values are not referred to from normal code

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -43,7 +43,7 @@ class InterceptedMethods extends MiniPhase {
     transformRefTree(tree)
 
   private def transformRefTree(tree: RefTree)(using Context): Tree =
-    if (tree.symbol.isTerm && (defn.Any_## eq tree.symbol)) {
+    if (tree.isTerm && (defn.Any_## eq tree.symbol)) {
       val qual = tree match {
         case id: Ident => tpd.desugarIdentPrefix(id)
         case sel: Select => sel.qualifier

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -306,7 +306,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisPhase =>
 
   override def transformSelect(tree: Select)(using Context): Tree =
     val denot = tree.denot
-    val sym = tree.symbol
+    val sym = denot.symbol
     // The Lifter updates the type of symbols using `installAfter` to give them a
     // new `SymDenotation`, but that doesn't affect non-sym denotations, so we
     // reload them manually here.

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -265,7 +265,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
       tree match
         case tree: ValOrDefDef if !sym.is(Synthetic) =>
           checkInferredWellFormed(tree.tpt)
-          if tree.symbol.owner.isInlineTrait then checkInlTraitPrivateMemberIsLocal(tree)
+          if sym.owner.isInlineTrait then checkInlTraitPrivateMemberIsLocal(tree)
           if sym.is(Method) then
             if sym.isSetter then
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.SetterMetaAnnot))
@@ -383,12 +383,13 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
     def checkUsableAsValue(tree: Tree)(using Context): Tree =
       def unusable(msg: Symbol => Message) =
         errorTree(tree, msg(tree.symbol))
-      if tree.symbol.is(PhantomSymbol) then
-        if tree.symbol.isDummyCaptureParam then
+      val sym = tree.symbol
+      if sym.is(PhantomSymbol) then
+        if sym.isDummyCaptureParam then
           unusable(DummyCaptureParamNotValue(_))
         else
           unusable(ConstructorProxyNotValue(_))
-      else if tree.symbol.isContextBoundCompanion then
+      else if sym.isContextBoundCompanion then
         unusable(ContextBoundCompanionNotValue(_))
       else
         tree
@@ -682,12 +683,12 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           val tree1 = cpy.DefDef(tree)(tpt = explicifyTpt(tree))
           processValOrDefDef(superAcc.wrapDefDef(tree1)(super.transform(tree1).asInstanceOf[DefDef]))
         case tree: TypeDef =>
-          if tree.symbol.isInlineTrait then
+          val sym = tree.symbol
+          if sym.isInlineTrait then
             ctx.compilationUnit.needsInlining = true  // Check and transform inline traits
-          if tree.rhs.tpe.existsPart(t => t.typeSymbol == defn.SpecializedClass.asType) && (tree.symbol ne defn.SpecializedClass) then
+          if tree.rhs.tpe.existsPart(t => t.typeSymbol == defn.SpecializedClass.asType) && (sym ne defn.SpecializedClass) then
             report.error(IllegalUseOfSpecialized(), tree.srcPos)
           registerIfHasMacroAnnotations(tree)
-          val sym = tree.symbol
           if (sym.isClass)
             VarianceChecker.check(tree)
             annotateExperimentalCompanion(sym)
@@ -744,14 +745,15 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         case tree @ Annotated(annotated, annot) =>
           cpy.Annotated(tree)(transform(annotated), transformAnnotTree(annot))
         case tree: AppliedTypeTree =>
-          if (tree.tpt.symbol == defn.andType)
+          val sym = tree.tpt.symbol
+          if (sym == defn.andType)
             Checking.checkNonCyclicInherited(tree.tpe, tree.args.tpes, EmptyScope, tree.srcPos)
               // Ideally, this should be done by Typer, but we run into cyclic references
               // when trying to typecheck self types which are intersections.
-          else if (tree.tpt.symbol == defn.orType)
+          else if (sym == defn.orType)
             () // nothing to do
           else
-            if tree.tpt.symbol == defn.SpecializedClass && !(ctx.owner.name.is(ContextBoundParamName) || ctx.owner.ownersIterator.contains(defn.SpecializedModule_apply)) then
+            if sym == defn.SpecializedClass && !(ctx.owner.name.is(ContextBoundParamName) || ctx.owner.ownersIterator.contains(defn.SpecializedModule_apply)) then
               report.error(IllegalUseOfSpecialized(), tree.srcPos)
             Checking.checkAppliedType(tree)
           super.transform(tree)

--- a/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
@@ -21,13 +21,14 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
   override def description: String = TupleOptimizations.description
 
   override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree =
-    if (!tree.symbol.exists || tree.symbol.owner != defn.RuntimeTuplesModuleClass) tree
-    else if (tree.symbol == defn.RuntimeTuples_cons) transformTupleCons(tree)
-    else if (tree.symbol == defn.RuntimeTuples_tail) transformTupleTail(tree)
-    else if (tree.symbol == defn.RuntimeTuples_size) transformTupleSize(tree)
-    else if (tree.symbol == defn.RuntimeTuples_concat) transformTupleConcat(tree)
-    else if (tree.symbol == defn.RuntimeTuples_apply) transformTupleApply(tree)
-    else if (tree.symbol == defn.RuntimeTuples_toArray) transformTupleToArray(tree)
+    val sym = tree.symbol
+    if (!sym.exists || sym.owner != defn.RuntimeTuplesModuleClass) tree
+    else if (sym == defn.RuntimeTuples_cons) transformTupleCons(tree)
+    else if (sym == defn.RuntimeTuples_tail) transformTupleTail(tree)
+    else if (sym == defn.RuntimeTuples_size) transformTupleSize(tree)
+    else if (sym == defn.RuntimeTuples_concat) transformTupleConcat(tree)
+    else if (sym == defn.RuntimeTuples_apply) transformTupleApply(tree)
+    else if (sym == defn.RuntimeTuples_toArray) transformTupleToArray(tree)
     else tree
 
   private def transformTupleCons(tree: tpd.Apply)(using Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -32,15 +32,13 @@ class CrossVersionChecks extends MiniPhase:
       checkMigration(sym, pos, xMigrationValue)
   end checkUndesiredProperties
 
-  private def checkExperimentalAnnots(sym: Symbol)(using Context): Unit =
-    if sym.exists && !sym.isInExperimentalScope then
-      for annot <- sym.annotations if annot.symbol.isExperimental do
-        Feature.checkExperimentalDef(annot.symbol, annot.tree)
-
-  private def checkDeprecatedAnnots(sym: Symbol)(using Context): Unit =
+  private def checkExperimentalAndDeprecatedAnnots(sym: Symbol)(using Context): Unit =
     if sym.exists then
       for annot <- sym.annotations if annot.symbol.isDeprecated do
         checkDeprecatedRef(annot.symbol, annot.tree.srcPos)
+      if !sym.isInExperimentalScope then
+        for annot <- sym.annotations if annot.symbol.isExperimental do
+          Feature.checkExperimentalDef(annot.symbol, annot.tree)
 
   /** If @migration is present (indicating that the symbol has changed semantics between versions),
    *  emit a warning.
@@ -106,22 +104,19 @@ class CrossVersionChecks extends MiniPhase:
   override def transformValDef(tree: ValDef)(using Context): ValDef =
     checkUnrollMemberDef(tree)
     checkDeprecatedOvers(tree)
-    checkExperimentalAnnots(tree.symbol)
-    checkDeprecatedAnnots(tree.symbol)
+    checkExperimentalAndDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformDefDef(tree: DefDef)(using Context): DefDef =
     checkUnrollMemberDef(tree)
     checkDeprecatedOvers(tree)
-    checkExperimentalAnnots(tree.symbol)
-    checkDeprecatedAnnots(tree.symbol)
+    checkExperimentalAndDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformTypeDef(tree: TypeDef)(using Context): TypeDef =
     // TODO do we need to check checkDeprecatedOvers(tree)?
     checkUnrollMemberDef(tree)
-    checkExperimentalAnnots(tree.symbol)
-    checkDeprecatedAnnots(tree.symbol)
+    checkExperimentalAndDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformTemplate(tree: tpd.Template)(using Context): tpd.Tree =

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1330,10 +1330,11 @@ object RefChecks {
   def checkAnyRefMethodCall(tree: Tree)(using Context): Unit =
     extension (c: Context) def enclosingClass: Symbol =
       c.outersIterator.find(_.isClassDefContext).map(_.owner).getOrElse(NoSymbol)
-    if tree.symbol.exists && defn.topClasses.contains(tree.symbol.owner) then
+    val sym = tree.symbol
+    if sym.exists && defn.topClasses.contains(sym.owner) then
       tree.tpe match
         case tp: NamedType if tp.prefix.typeSymbol != ctx.enclosingClass =>
-          report.warning(UnqualifiedCallToAnyRefMethod(tree, tree.symbol), tree)
+          report.warning(UnqualifiedCallToAnyRefMethod(tree, sym), tree)
         case _ => ()
 
   private def createAddMissingMethodsAction(clazz: ClassSymbol, methods: List[String])(using Context): List[CodeAction] =
@@ -1484,8 +1485,8 @@ class RefChecks extends MiniPhase { thisPhase =>
     // Needs to run after ElimRepeated for override checks involving varargs methods
 
   override def transformValDef(tree: ValDef)(using Context): ValDef = {
-    if tree.symbol.exists then
-      val sym = tree.symbol
+    val sym = tree.symbol
+    if sym.exists then
       checkNoPrivateOverrides(sym)
       checkVolatile(sym)
       checkPublicFlexibleTypes(sym)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -982,7 +982,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case Some((_, fieldType)) =>
             val dynSelected = dynamicSelect(fieldType)
             dynSelected match
-              case Apply(sel: Select, _) if !sel.denot.symbol.exists =>
+              case Apply(sel: Select, _) if !sel.symbol.exists =>
                 // Reject corner case where selectDynamic needs annother selectDynamic to be called. E.g. as in neg/unselectable-fields.scala.
                 report.error(i"Cannot use selectDynamic here since it needs another selectDynamic to be invoked", tree.srcPos)
               case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -208,32 +208,36 @@ class VarianceChecker(using Context) {
       case None =>
     }
 
-    override def traverse(tree: Tree)(using Context) = {
-      def sym = tree.symbol
-      // No variance check for private/protected[this] methods/values.
-      def skip = !sym.exists
-        || sym.name.is(InlineAccessorName) // TODO: should we exclude all synthetic members?
-        || sym.isAllOf(LocalParamAccessor) // local class parameters are construction only
-        || sym.is(TypeParam) && sym.owner.isClass // already taken care of in primary constructor of class
-      try tree match {
-        case defn: MemberDef if skip =>
+    override def traverse(tree: Tree)(using Context): Unit = tree match {
+      case defn: MemberDef =>
+        val sym = tree.symbol
+        // No variance check for private/protected[this] methods/values.
+        def skip = !sym.exists
+          || sym.name.is(InlineAccessorName) // TODO: should we exclude all synthetic members?
+          || sym.isAllOf(LocalParamAccessor) // local class parameters are construction only
+          || sym.is(TypeParam) && sym.owner.isClass // already taken care of in primary constructor of class
+        if skip then
           report.debuglog(s"Skipping variance check of ${sym.showDcl}")
-        case tree: TypeDef =>
-          checkVariance(sym, tree.srcPos)
-          tree.rhs match {
-            case rhs: Template => traverseChildren(rhs)
-            case _ =>
-          }
-        case tree: ValDef =>
-          checkVariance(sym, tree.srcPos)
-        case DefDef(_, paramss, _, _) =>
-          checkVariance(sym, tree.srcPos)
-          paramss.foreach(_.foreach(traverse))
-        case _ =>
-      }
-      catch {
-        case ex: TypeError => report.error(ex, tree.srcPos.focus)
-      }
+          return
+
+        try tree match {
+          case tree: TypeDef =>
+            checkVariance(sym, tree.srcPos)
+            tree.rhs match {
+              case rhs: Template => traverseChildren(rhs)
+              case _ =>
+            }
+          case tree: ValDef =>
+            checkVariance(sym, tree.srcPos)
+          case DefDef(_, paramss, _, _) =>
+            checkVariance(sym, tree.srcPos)
+            paramss.foreach(_.foreach(traverse))
+          case _ =>
+        }
+        catch {
+          case ex: TypeError => report.error(ex, tree.srcPos.focus)
+        }
+      case _ => ()
     }
   }
 }


### PR DESCRIPTION
Backports #26914 to the 3.10.0-RC2.

PR submitted by the release tooling.
[skip ci]