### PR TITLE
Backport "Only run trait specialization passes when compilation units contain inline traits" to 3.10.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -57,6 +57,12 @@ class CompilationUnit protected (val source: SourceFile, val info: CompilationUn
    */
   var needsInlining: Boolean = false
 
+  /** Set to `true` if there are inline traits (with or without Specialized context bounds)
+   *  This is used by:
+   *  DesugarSpecializedTraits, SpecializeInlineTraits, PruneInlinedMethods, PruneInlineTraits
+   */
+  var hasSpecializations: Boolean = false
+
   var hasMacroAnnotations: Boolean = false
 
   def hasUnrollDefs: Boolean = unrolledClasses.nonEmpty

--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -43,7 +43,8 @@ class Compiler {
     List(new UnrollDefinitions) ::  // Unroll annotated methods if detected in PostTyper
     List(new sjs.PrepJSInterop) ::  // Additional checks and transformations for Scala.js (Scala.js only)
     List(new SetRootTree) ::        // Set the `rootTreeOrProvider` on class symbols
-    List(new DesugarSpecializedTraits,  // Process Specialized traits
+    List(new CheckInlineTraits,         // Check for inline traits
+         new DesugarSpecializedTraits,  // Process Specialized traits
          new SpecializeInlineTraits) :: // Inline the code of inline traits into their children
     Nil
 

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -789,16 +789,17 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         else if semiEraseVCs && sym.isDerivedValueClass then eraseDerivedValueClass(tp)
         else if defn.isSyntheticFunctionClass(sym) then defn.functionTypeErasure(sym)
         else eraseNormalClassRef(tp)
-      case Specialization(spec) if ((ctx.phase == erasurePhase || ctx.erasedTypes) // At the beginning the $sp$ trait symbols are not present so up until 
-                                                                                   // erasure need to consider the signature of def foo(x: Foo[Int]): Int as
-                                                                                   // foo(Foo):Int. Only at erasure do the symbols swap. This ensures
-                                                                                   // the signatures don't change before erasure which is required (meta-ordering
-                                                                                   // constraint in Compiler.scala)
-                                    && spec.isSpecialized && ctx.property(DisallowSpecialized).isEmpty) => 
-        val specName = spec.newSpecializedTraitName
-        val interfaceSymbol = spec.symbol.owner.enclosingPackageClass.info.decls.lookup(specName)
-        assert(interfaceSymbol.exists && interfaceSymbol.isClass)
-        this(interfaceSymbol.typeRef.appliedTo(spec.unspecializedTypeArgs))
+      // At the beginning the $sp$ trait symbols are not present so up until 
+      // erasure need to consider the signature of def foo(x: Foo[Int]): Int as
+      // foo(Foo):Int. Only at erasure do the symbols swap. This ensures
+      // the signatures don't change before erasure which is required (meta-ordering
+      // constraint in Compiler.scala)
+      case Specialization(spec) if ((ctx.phase == erasurePhase || ctx.erasedTypes) && 
+        spec.isSpecialized && ctx.property(DisallowSpecialized).isEmpty) => 
+          val specName = spec.newSpecializedTraitName
+          val interfaceSymbol = spec.symbol.owner.enclosingPackageClass.info.decls.lookup(specName)
+          assert(interfaceSymbol.exists && interfaceSymbol.isClass)
+          this(interfaceSymbol.typeRef.appliedTo(spec.unspecializedTypeArgs))
       case tp: AppliedType =>
         val tycon = tp.tycon
         if (tycon.isRef(defn.ArrayClass)) eraseArray(tp)

--- a/compiler/src/dotty/tools/dotc/transform/CheckInlineTraits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckInlineTraits.scala
@@ -1,0 +1,179 @@
+package dotty.tools.dotc.transform
+
+import dotty.tools.dotc.transform.MegaPhase.MiniPhase
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.report
+import dotty.tools.dotc.reporting.IllegalUseOfSpecialized
+import dotty.tools.dotc.core.Symbols.defn
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.core.NameKinds.ContextBoundParamName
+import dotty.tools.dotc.core.Contexts.ctx
+import dotty.tools.dotc.core.Decorators.em
+import dotty.tools.dotc.inlines.Inlines
+import dotty.tools.dotc.transform.Specialization.isSpecializationCandidate
+import dotty.tools.dotc.transform.Specialization.isSpecializedTrait
+import dotty.tools.dotc.core.Flags
+
+object CheckInlineTraits:
+  val name: String = "checkInlineTraits"
+  val description: String = "check if inline & specialized traits are present and are correctly used"
+
+class CheckInlineTraits extends MiniPhase:
+    override def phaseName: String = CheckInlineTraits.name 
+
+    override def description: String = CheckInlineTraits.description
+
+    override def changesMembers: Boolean = false
+    
+    override def changesParents: Boolean = false
+
+    override def runsAfter: Set[String] = Set("typer")
+
+    override def transformIdent(tree: Ident)(using Context): Tree = {
+      val sym = tree.symbol
+      if !sym.isType then 
+        if sym == defn.SpecializedModule && (ctx.owner ne defn.SpecializedModule.moduleClass) then
+          report.error(IllegalUseOfSpecialized(), tree.srcPos)
+        
+        if sym == defn.SpecializedModule_apply then 
+          registerSpecializationsInUnit
+
+      tree
+    }
+
+    private def checkInlTraitPrivateMemberIsLocal(tree: ValOrDefDef)(using Context): Unit =
+      val sym = tree.symbol
+      if sym.exists && !sym.is(Synthetic) && sym.owner.isInlineTrait && sym.isAllOf(Private, butNot = Local) then
+        report.error(
+          em"""
+            implementation restriction: inline traits cannot have non-local private members. 
+            This also means no retained inline methods.
+          """, 
+          tree.srcPos
+        )
+  
+          
+    override def transformValDef(tree: ValDef)(using Context): Tree = {
+      checkInlTraitPrivateMemberIsLocal(tree)
+
+      tree
+    }
+
+    override def transformDefDef(tree: DefDef)(using Context): Tree = {
+      checkInlTraitPrivateMemberIsLocal(tree)
+
+      val sym = tree.symbol 
+      val isConstructorOfNonInlineType = sym.isConstructor && !sym.owner.is(Inline)
+      val isRegularDefDef = !sym.isConstructor && !sym.is(Inline) 
+      if isConstructorOfNonInlineType || isRegularDefDef then
+        tree.paramss.flatten.foreach {
+          param => if SpecializedEvidence.unapply(param.tpe.widen.dealias).nonEmpty then 
+            report.error(s"Only inline traits and inline functions may take Specialized type parameters", param.srcPos)
+        }
+
+      tree
+    }
+
+    override def prepareForOther(tree: Tree)(using Context): Context = tree match {
+      case tree: AppliedTypeTree =>
+        val sym = tree.tpt.symbol
+        if sym != defn.orType && sym != defn.andType && sym == defn.SpecializedClass && 
+            !(ctx.owner.name.is(ContextBoundParamName) || ctx.owner.ownersIterator.contains(defn.SpecializedModule_apply)) then
+          report.error(IllegalUseOfSpecialized(), tree.srcPos)
+        ctx
+
+      case _ => ctx
+    }
+
+    override def transformTypeDef(tree: TypeDef)(using Context): Tree = {
+      val containUseOfSpecialized = 
+        tree.rhs.tpe.existsPart(t => t.typeSymbol == defn.SpecializedClass.asType) 
+      if containUseOfSpecialized && (tree.symbol ne defn.SpecializedClass) then
+        report.error(IllegalUseOfSpecialized(), tree.srcPos)
+        
+      if tree.symbol.isInlineTrait then 
+        registerSpecializationsInUnit
+
+      tree
+    }
+
+    override def transformBlock(tree: Block)(using Context): Tree = tree match {
+      case AnonymousClassInstance(anon) =>
+        def deandify(tp: Type): Iterator[Type] = tp match {
+          case AndType(l, r) => deandify(l) ++ deandify(r)
+          case _ => Iterator.single(tp)
+        }
+
+        def checkSpecializedMixins(tpe: AndType) = deandify(tpe) foreach {
+          Specialization.unapply(_, anon.typeTree.span) foreach {
+            spec => if spec.hasSpecializedParams then
+              report.error(
+                """
+                Anonymous classes acting as instances of Specialized traits may not mix in other traits; 
+                You can make a named object instead if you like.
+                """, 
+                anon.srcPos
+              )
+          }
+        }
+        anon.typeTree.tpe match {
+          case tpe: AndType => /* Multiple mixed in traits will be typed as an AndType */ 
+            checkSpecializedMixins(tpe)
+
+            tree 
+          
+          case tpe =>
+            Specialization
+              .unapply(tpe, anon.typeTree.span)
+              .foreach(spec => 
+                if spec.hasSpecializedParams then
+                  // Only allowed to contain evidence parameters
+                  if anon.body.filterNot(x => x.symbol.name.is(ContextBoundParamName)).nonEmpty then 
+                    report.error(
+                      """
+                      Anonymous classes acting as instances of Specialized traits may not have additional members; 
+                      you can make a named object instead if you like.
+                      """,
+                      anon.srcPos
+                    )                    
+
+                  def hasOnlyValidParents: Boolean = anon.parentCalls match { 
+                    case (obj :: parentsOfSpecTrait) :+ (app@Apply(_, _)) =>
+                      val isFirstParentObject = obj.symbol.owner == ctx.definitions.ObjectClass
+                      val validOtherParents =
+                        parentsOfSpecTrait.forall(x => spec.symbol.asClass.baseClasses.exists(p => p == x.symbol.owner))
+                      
+                      isFirstParentObject && validOtherParents
+                    case _ => false
+                  }
+                      
+                  if !hasOnlyValidParents then
+                    report.error(
+                      """
+                      Anonymous classes acting as instances of Specialized traits may not mix in other traits; 
+                      you can make a named object instead if you like.""", 
+                      anon.srcPos
+                    )
+
+                  registerSpecializationsInUnit
+                )
+              
+            tree
+        }
+      case _ => tree
+    }
+
+    override def transformTemplate(tree: Template)(using Context): Tree = {
+      if tree.parents.exists(parent => Inlines.symbolFromParent(parent).isInlineTrait) then 
+        registerSpecializationsInUnit
+
+      tree
+    }
+
+    private inline def registerSpecializationsInUnit(using Context): Unit = { 
+      ctx.compilationUnit.needsInlining = true
+      ctx.compilationUnit.hasSpecializations = true
+    }

--- a/compiler/src/dotty/tools/dotc/transform/DesugarSpecializedTraits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DesugarSpecializedTraits.scala
@@ -60,6 +60,8 @@ class DesugarSpecializedTraits extends MiniPhase, IdentityDenotTransformer:
   override def changesMembers: Boolean = false
   override def changesParents: Boolean = true 
 
+  override def runsAfter: Set[String] = Set("checkInlineTraits")
+
   override def allowsImplicitSearch: Boolean = true
 
   private def newInterfaceTrait(specialization: Specialization, cache: SpecializationCache)(using Context): (ClassSymbol, SpecializationCache) = {
@@ -353,78 +355,6 @@ class DesugarSpecializedTraits extends MiniPhase, IdentityDenotTransformer:
     // but not sure if that's worth doing (it would be throwing away work).
     (generatedTraitStatsFinal ++ generatedClassStatsFinal ++ stats, specializationsFinal) 
   }
-  
-  private def checkSpecializedTraitRules(tree: Tree)(using Context) =
-    def checkType(t: Type, pos: SrcPos) = t.widen.dealias match {
-      case SpecializedEvidence(_) => 
-        report.error(s"Only inline traits and inline functions may take Specialized type parameters", pos)
-      case _ =>
-    }
-    
-    // TODO: Depending on how we ultimately organize the phasing
-    // If we settle on using miniphases, this could be moved into transformDefDef and transformBlock.
-    tree.foreachSubTree { 
-      case ddef: DefDef =>
-        val sym = ddef.symbol
-        if sym.isConstructor then
-          if !sym.owner.is(Flags.Inline) then
-            ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
-        else
-          if !sym.is(Flags.Inline) then
-            ddef.paramss.flatten.foreach(p => checkType(p.tpe, ddef.srcPos))
-      case AnonymousClassInstance(anon) =>
-        def deandify(tp: Type): Iterator[Type] = tp match {
-          case AndType(l, r) => deandify(l) ++ deandify(r)
-          case _ => Iterator.single(tp)
-        }
-        anon.typeTree.tpe match {
-          case a: AndType => /* Multiple mixed in traits will be typed as an AndType */ 
-            deandify(a) foreach {trt =>
-              Specialization.unapply(trt, anon.typeTree.span) foreach { spec => 
-                if spec.hasSpecializedParams then
-                  report.error(
-                    """
-                    Anonymous classes acting as instances of Specialized traits may not mix in other traits; 
-                    You can make a named object instead if you like.
-                    """, 
-                    anon.srcPos
-                  )
-              }
-            }
-      
-          case tpe =>
-            Specialization.unapply(tpe, anon.typeTree.span).map(spec => 
-                {
-                if spec.hasSpecializedParams then
-                  // Only allowed to contain evidence parameters
-                  if anon.body.filterNot(x => x.symbol.name.is(ContextBoundParamName)).nonEmpty then 
-                    report.error(
-                      """
-                      Anonymous classes acting as instances of Specialized traits may not have additional members; 
-                      you can make a named object instead if you like.
-                      """,
-                      anon.srcPos
-                    )                    
-
-                  anon.parentCalls match { 
-                    case (obj :: parentsOfSpecTrait) :+ (app@Apply(_, _)) 
-                      if (obj.symbol.owner == ctx.definitions.ObjectClass) && 
-                        (parentsOfSpecTrait.forall(x => spec.symbol.asClass.baseClasses.exists(p => p == x.symbol.owner))) => 
-                    case _ => 
-                      report.error(
-                        """
-                        Anonymous classes acting as instances of Specialized traits may not mix in other traits; 
-                        you can make a named object instead if you like.""", 
-                        anon.srcPos
-                      )
-                  }
-                else
-                  tree
-              }).getOrElse(tree)
-        }
-
-      case _ =>
-    }
 
   private def specializedTraitCtx(using Context): Context = 
     ctx.fresh.setInlineTraitState(ctx.inlineTraitState.copyInPhase(InlineTraitState.InlineContext.SpecializedTraits))
@@ -443,10 +373,9 @@ class DesugarSpecializedTraits extends MiniPhase, IdentityDenotTransformer:
   // As long as we remember to call transformFollowing on the synthetic classes (which we do) then 
   // we should be composable in the way that we want to be.
   override def transformUnit(tree: Tree)(using Context): Tree = 
-    tree match {
+    if !ctx.compilationUnit.hasSpecializations then tree 
+    else tree match {
       case pkg@PackageDef(pid, stats) =>
-        checkSpecializedTraitRules(tree)
-
         val (stats1, specializedTraitCache2) = transformStatements(stats, specializedTraitCache)
         
         specializedTraitCache = specializedTraitCache2 
@@ -898,23 +827,21 @@ object SpecializedEvidence {
 }
 
 object Specialization:
+  def unapply(typeSpan: (Type, Span))(using Context): Option[Specialization] = typeSpan match {
+    case (AppliedType(tycon: Type, args: List[Type]), span) if isSpecializationCandidate(tycon.typeSymbol) => 
+      Some(Specialization(tycon.typeSymbol, args, span))
+    case _ => 
+      None
+  }
 
   def unapply(tpt: Tree)(using Context): Option[Specialization] = tpt match {
-    case AppliedTypeTree(specializedTrait: Ident, concreteTypeTrees: List[Tree]) => 
-      Some(Specialization(specializedTrait.symbol, concreteTypeTrees.map(_.tpe), tpt.span))
+    case tpt: AppliedTypeTree=> 
+      Specialization.unapply(tpt.tpe, tpt.span)
     case t: TypeTree => Specialization.unapply(t.tpe, t.span)
     case _ => None
   }
-  
-  def unapply(typeSpan: (Type, Span))(using Context): Option[Specialization] = typeSpan match {
-    case (AppliedType(tycon: Type, args: List[Type]), span) => Some(Specialization(tycon.typeSymbol, args, span))
-    case _ => None
-  }
 
-  def unapply(tpe: Type)(using Context): Option[Specialization] = tpe match {
-    case AppliedType(tycon: Type, args: List[Type]) => Some(Specialization(tycon.typeSymbol, args, NoSpan))
-    case _ => None
-  }
+  def unapply(tpe: Type)(using Context): Option[Specialization] = unapply(tpe, NoSpan)
 
   def classSpecializedTypeParams(classSym: Symbol)(using Context): List[Type] = 
     if !classSym.isClass || classSym.is(Flags.JavaDefined) then
@@ -936,12 +863,17 @@ object Specialization:
       case TypeDef(anon, Template(_, parentCalls: List[Tree], _, _)) =>
         parentCalls match {
           case _ :+ Apply(Apply(t, ctorArgs), ev) => // extends Object, parents of spec trait, spec trait
-            val spec = Specialization.unapply(t.tpe.resultType.resultType, t.span)
-            spec.get.hasSpecializedParams
+            Specialization
+              .unapply(t.tpe.resultType.resultType, t.span)
+              .map(_.hasSpecializedParams)
+              .nonEmpty
           case _ => false
         }
       case _ => false
     } 
+
+  def isSpecializationCandidate(sym: Symbol)(using Context) = 
+    isSpecializedTrait(sym) || isSpecializedTrait(sym.info.firstParent.typeSymbol)
 
   def isSpecializedTrait(sym: Symbol)(using Context) = 
     sym.isClass && 

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -1109,7 +1109,8 @@ object Erasure {
     }
 
     override def typedClassDef(cdef: untpd.TypeDef, cls: ClassSymbol)(using Context): Tree =
-      val cdef1 = typedSpecializedClassDef(cdef, cls)
+      val cdef1 = if ctx.compilationUnit.hasSpecializations then typedSpecializedClassDef(cdef, cls) else cdef
+
       val typedTree@TypeDef(name, impl @ Template(constr, _, self, _)) = super.typedClassDef(cdef1, cls): @unchecked
       // In the case where a trait extends a class, we need to strip any non trait class from the signature
       // and accept the first one (see tests/run/mixins.scala)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -265,7 +265,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
       tree match
         case tree: ValOrDefDef if !sym.is(Synthetic) =>
           checkInferredWellFormed(tree.tpt)
-          if sym.owner.isInlineTrait then checkInlTraitPrivateMemberIsLocal(tree)
           if sym.is(Method) then
             if sym.isSetter then
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.SetterMetaAnnot))
@@ -311,10 +310,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           // for inferred types if explicit types are already ill-formed
         => Checking.checkAppliedTypesIn(tree)
       case _ =>
-
-    private def checkInlTraitPrivateMemberIsLocal(tree: Tree)(using Context): Unit =
-      if tree.symbol.owner.isInlineTrait && tree.symbol.isAllOf(Private, butNot = Local) then
-        report.error(em"implementation restriction: inline traits cannot have non-local private members. This also means no retained inline methods.", tree.srcPos)
 
     private def transformSelect(tree: Select, targs: List[Tree])(using Context): Tree = {
       val qual = tree.qualifier
@@ -579,8 +574,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           if tree.isType then
             checkNotPackage(tree)
           else
-            if tree.symbol == defn.SpecializedModule && (ctx.owner ne defn.SpecializedModule.moduleClass) then
-              report.error(IllegalUseOfSpecialized(), tree.srcPos)
             registerNeedsInlining(tree)
             val tree1 = checkUsableAsValue(tree)
             tree1.tpe match {
@@ -684,10 +677,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           processValOrDefDef(superAcc.wrapDefDef(tree1)(super.transform(tree1).asInstanceOf[DefDef]))
         case tree: TypeDef =>
           val sym = tree.symbol
-          if sym.isInlineTrait then
-            ctx.compilationUnit.needsInlining = true  // Check and transform inline traits
-          if tree.rhs.tpe.existsPart(t => t.typeSymbol == defn.SpecializedClass.asType) && (sym ne defn.SpecializedClass) then
-            report.error(IllegalUseOfSpecialized(), tree.srcPos)
           registerIfHasMacroAnnotations(tree)
           if (sym.isClass)
             VarianceChecker.check(tree)
@@ -698,8 +687,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             tree.rhs match
               case impl: Template =>
                 for parent <- impl.parents do
-                  if Inlines.symbolFromParent(parent).isInlineTrait then
-                    ctx.compilationUnit.needsInlining = true
                   Checking.checkTraitInheritance(parent.tpe.classSymbol, sym.asClass, parent.srcPos)
                   // Constructor parameters are in scope when typing a parent.
                   // While they can safely appear in a parent tree, to preserve
@@ -753,8 +740,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           else if (sym == defn.orType)
             () // nothing to do
           else
-            if sym == defn.SpecializedClass && !(ctx.owner.name.is(ContextBoundParamName) || ctx.owner.ownersIterator.contains(defn.SpecializedModule_apply)) then
-              report.error(IllegalUseOfSpecialized(), tree.srcPos)
             Checking.checkAppliedType(tree)
           super.transform(tree)
         case SingletonTypeTree(ref) =>

--- a/compiler/src/dotty/tools/dotc/transform/PruneInlineTraits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneInlineTraits.scala
@@ -21,18 +21,23 @@ class PruneInlineTraits extends MiniPhase with SymTransformer { thisTransform =>
   
   override def runsAfter: Set[String] = Set(PruneInlinedMethods.name)
   
-  override def transformSym(sym: SymDenotation)(using Context): SymDenotation =
-    if isEraseable(sym) then sym.copySymDenotation(initFlags = sym.flags | Deferred)
-    else if sym.isInlineTrait then
+  override def transformSym(sym: SymDenotation)(using Context): SymDenotation = {
+    val hasSpecializations = ctx.compilationUnit.hasSpecializations
+
+    if hasSpecializations && isEraseable(sym) then 
+      sym.copySymDenotation(initFlags = sym.flags | Deferred)
+    else if hasSpecializations && sym.isInlineTrait then
       val clsInfo = sym.asClass.classInfo
       val clsInfo2 = clsInfo.derivedClassInfo(decls = 
           clsInfo.decls.filteredScope(!isDeletable(_))
       )
       sym.copySymDenotation(initFlags = sym.flags | PureInterface | NoInits, info = clsInfo2)
     else sym
+  }
 
   override def transformTemplate(tree: Template)(using Context): Tree = 
-    cpy.Template(tree)(body = tree.body.flatMap({
+    if !ctx.compilationUnit.hasSpecializations then tree 
+    else cpy.Template(tree)(body = tree.body.flatMap({
       case stmt: ValDef if isEraseable(stmt.symbol) => Some(cpy.ValDef(stmt)(rhs = EmptyTree))
       case stmt: DefDef if isEraseable(stmt.symbol) => Some(cpy.DefDef(stmt)(rhs = EmptyTree))
       case stmt: (ValDef | DefDef) if isDeletable(stmt.symbol) => None
@@ -40,14 +45,14 @@ class PruneInlineTraits extends MiniPhase with SymTransformer { thisTransform =>
     }))
 
   private def isEraseable(sym: SymDenotation)(using Context): Boolean =
-    !sym.isType
+    sym.exists
+    && !sym.isType
+    && sym.owner.isInlineTrait
     && !sym.isConstructor
     && !sym.is(Param)
     && !sym.is(ParamAccessor)
     && !sym.is(Local)
     && !sym.isLocalDummy
-    && sym.exists
-    && sym.owner.isInlineTrait
 
   private def isDeletable(sym: SymDenotation)(using Context): Boolean = 
     !sym.isType

--- a/compiler/src/dotty/tools/dotc/transform/PruneInlinedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneInlinedMethods.scala
@@ -20,19 +20,26 @@ class PruneInlinedMethods extends MiniPhase with InfoTransformer { thisTransform
 
   override def description: String = PruneInlinedMethods.description
 
-  override def transformInfo(tp: Type, sym: Symbol)(using Context) = tp match {
-    case clsInfo: ClassInfo if sym.isClass && !sym.is(Package) && !sym.is(JavaDefined) => 
-      clsInfo.derivedClassInfo(decls =
-          clsInfo.decls.filteredScope(!isDeletable(_))
-      )
-    case _ => tp
-  }
+  override protected def infoMayChange(sym: Symbol)(using Context): Boolean = 
+    ctx.compilationUnit.hasSpecializations || ctx.compilationUnit.needsInlining
+
+  override def transformInfo(tp: Type, sym: Symbol)(using Context) = 
+    tp match {
+      case clsInfo: ClassInfo if sym.isClass && !sym.is(Package) && !sym.is(JavaDefined) => 
+        clsInfo.derivedClassInfo(decls =
+            clsInfo.decls.filteredScope(!isDeletable(_))
+        )
+      case _ => tp
+    }
 
   override def transformTemplate(tree: Template)(using Context): Tree = 
-    cpy.Template(tree)(body = tree.body.flatMap({
-      case stmt: DefDef if isDeletable(stmt.symbol) => None
-      case stmt => Some(stmt)
-    }))
+    if !ctx.compilationUnit.hasSpecializations then tree 
+    else cpy.Template(tree)(
+      body = tree.body.flatMap {
+        case stmt: DefDef if isDeletable(stmt.symbol) => None
+        case stmt => Some(stmt)
+      }
+    )
 
   private def isDeletable(sym: Symbol)(using Context): Boolean = 
     Specialization.isSpecializedMethod(sym)

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeInlineTraits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeInlineTraits.scala
@@ -37,6 +37,8 @@ class SpecializeInlineTraits extends MiniPhase {
 
   override def changesParents: Boolean = true
 
+  override def runsAfter: Set[String] = Set("desugarSpecializedTraits")
+
   private def inlineTraitCtx(using Context): Context = ctx.fresh.setInlineTraitState(ctx.inlineTraitState.copyInPhase(InlineTraitState.InlineContext.InlineTraits))    
 
   private val seen = mutable.HashSet[Symbol]() // Ensure we don't inline into the same child class multiple times even though we repeatedly check for nested inlines.
@@ -53,7 +55,8 @@ class SpecializeInlineTraits extends MiniPhase {
   override def transformTypeDef(tree: TypeDef)(using Context): Tree =
     // We need to inline recursively because inlining may create further opportunities for inlining. 
     // Notably this does limit the composition potential of this miniphase.
-    new TreeMapWithPreciseStatContexts { 
+    if !ctx.compilationUnit.hasSpecializations then tree 
+    else new TreeMapWithPreciseStatContexts { 
       override def transform(tree: Tree)(using Context): Tree = 
         tree match {
         case tree: TypeDef if tree.symbol.isInlineTrait =>

--- a/tests/run/i3000b.check
+++ b/tests/run/i3000b.check
@@ -1,2 +1,2 @@
-Foo$$anon$2
-bar.Bar$$anon$1
+Foo$$anon$1
+bar.Bar$$anon$2


### PR DESCRIPTION
Backports #26842 to the 3.10.0-RC2.

PR submitted by the release tooling.