### PR TITLE
Doc: into type constructor: Make implicit import into explicit one

### DIFF
--- a/docs/_docs/reference/other-new-features/into.md
+++ b/docs/_docs/reference/other-new-features/into.md
@@ -18,9 +18,14 @@ class without requiring a language import.
 The first scheme is
 to have a special type `into[T]` which serves as a marker that conversions into that type are allowed. These types are typically used in parameters of methods that are designed to work with implicit conversions of their arguments. This allows fine-grained control over where implicit conversions should be allowed. We call this scheme "_into as a type constructor_".
 
+Following codes assumes this import to use `into` as a type constructor:
+
+```
+import scala.Conversion.into
+```
+
 The second scheme allows `into` as a soft modifier on traits, classes, and opaque type aliases. If a type definition is declared with this modifier, conversions to that type are allowed. The second scheme requires that one has control over the conversion target types so that an `into` can be added to their declaration. It is appropriate where there are a few designated types that are meant to be conversion targets. If that's the case, migration from Scala 2 to Scala 3
 becomes easier since no function signatures need to be rewritten. We call this scheme "_into as a modifier_".
-
 
 ## Motivation
 


### PR DESCRIPTION
The code examples in the documentation demonstrate the use of an `into` type constructor without explicit `import` statements. While the documentation's description of `into`'s location implies the need for an import, I believe this documentation is incomplete. Therefore, I've added explicit documentation about the need for an import. The phrasing may still be improved.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No


