### PR TITLE
Fix MainGenericCompiler -D property parsing

### DIFF
--- a/compiler/src/dotty/tools/MainGenericCompiler.scala
+++ b/compiler/src/dotty/tools/MainGenericCompiler.scala
@@ -54,7 +54,7 @@ case class CompileSettings(
 object MainGenericCompiler {
 
   private val classpathSeparator: String = File.pathSeparator
-  private val javaPropOption = raw"""-D(.+?)=(.?)""".r
+  private val javaPropOption = raw"""-D([^=]+)=(.*)""".r
 
   private def processClasspath(cp: String, tail: List[String]): (List[String], List[String]) =
     val cpEntries = cp.split(classpathSeparator).toList

--- a/compiler/test/dotty/tools/MainGenericCompilerTest.scala
+++ b/compiler/test/dotty/tools/MainGenericCompilerTest.scala
@@ -1,0 +1,19 @@
+package dotty.tools
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MainGenericCompilerTest:
+  @Test def javaPropertyValuesAreParsedInFull(): Unit =
+    val cases: List[(String, (String, String))] = List(
+      "-Dkey=" -> ("key" -> ""),
+      "-Dkey=x" -> ("key" -> "x"),
+      "-Dkey=World3" -> ("key" -> "World3"),
+      "-Dkey=a=b" -> ("key" -> "a=b"),
+    )
+
+    cases.foreach { (arg, expected) =>
+      val settings = MainGenericCompiler.process(List(arg), CompileSettings())
+      assertEquals(List(expected), settings.javaProps)
+      assertEquals(Nil, settings.residualArgs)
+    }


### PR DESCRIPTION
Fixes  https://github.com/scala/scala3/issues/27024

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by reviewing the existing argument parser, validating the regular-expression behavior, and adding focused JUnit regression tests.


## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->


New automated tests (including the issue's reproducer)

The regression test covers empty values, one-character values, multi-character values, and values containing additional `=` characters. It also verifies that parsed `-D` options are absent from `residualArgs`.