### PR TITLE
Fix Windows-only stack overflow

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3724,7 +3724,7 @@ class MatchReducer(initctx: Context) extends TypeComparer(initctx) {
 
   override def matchReducer = this
 
-  def matchCases(scrut: Type, cases: List[MatchTypeCaseSpec])(using Context): Type = {
+  def matchCases(scrut: Type, cases: List[MatchTypeCaseSpec])(using Context): Type = ctx.handleRecursive("match cases for", scrut) {
     // a reference for the type parameters poisoned during matching
     // for use during the reduction step
     var poisoned: Set[TypeParamRef] = Set.empty

--- a/tests/neg/i17132.min.check
+++ b/tests/neg/i17132.min.check
@@ -7,25 +7,25 @@
   |For the unprocessed stack overflow trace, compile with -Xno-enrich-error-messages.
   |A recurring operation is (inner to outer):
   |
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
   |  ...
   |
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee t
-  |  reduce match type for scrutinee T
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for t
+  |  match cases for T


### PR DESCRIPTION
Failing on main. I guess somewhere in Windows-only JVM code we use more stack at just the worst time.

[test_windows_full]

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
