### PR TITLE
Use the right context when loading symbols during gensig

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -498,54 +498,51 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
      * @see    https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.4
      */
     def getGenericSignature(sym: Symbol, descriptor: String | Null)(using Context): String | Null = {
-      val ogPhase = ctx.phase
-      atPhase(erasurePhase) {
-        // Finding the member's type is nontrivial because of erasure and how it interacts with other phases.
-        def computeMemberType(): Type = {
-          // Mixins are resolved _after_ erasure, so we cannot simply ask for "the information before erasure" for these,
-          // since that information never existed.
-          // Thus, we first check if the symbol was specifically marked as having generic information,
-          mixinPhase.asInstanceOf[Mixin].mixinGenericInfos.get(sym) match
-            // and if so, we use it.
-            case Some(genericInfo) => return genericInfo
-            case _ => ()
+      // Finding the member's type is nontrivial because of erasure and how it interacts with other phases.
+      def computeMemberType(): Type = atPhase(erasurePhase) {
+        // Mixins are resolved _after_ erasure, so we cannot simply ask for "the information before erasure" for these,
+        // since that information never existed.
+        // Thus, we first check if the symbol was specifically marked as having generic information,
+        mixinPhase.asInstanceOf[Mixin].mixinGenericInfos.get(sym) match
+          // and if so, we use it.
+          case Some(genericInfo) => return genericInfo
+          case _ => ()
 
-          // Methods are straightforward.
-          if sym.is(Method) then
-            return sym.denot.info
+        // Methods are straightforward.
+        if sym.is(Method) then
+          return sym.denot.info
 
-          // Fields have two special cases:
-          if sym.isField then
-            // we must use the getter if entered after erasure at memoize, see tests/generic-java-signatures/17069.scala for an example
-            if sym.denot.validFor.firstPhaseId > erasurePhase.id then
-              if sym.getter.exists then
-                return sym.getter.denot.info.resultType
+        // Fields have two special cases:
+        if sym.isField then
+          // we must use the getter if entered after erasure at memoize, see tests/generic-java-signatures/17069.scala for an example
+          if sym.denot.validFor.firstPhaseId > erasurePhase.id then
+            if sym.getter.exists then
+              return sym.getter.denot.info.resultType
 
-              // there might be a getter created after erasure by the mixin phase,
-              // and if so we must use the information that the mixin phase stored for it.
-              val mixinGetter = atPhase(mixinPhase.next) {
-                sym.getter
-              }
-              if mixinGetter.exists then mixinPhase.asInstanceOf[Mixin].mixinGenericInfos.get(mixinGetter) match
-                case Some(ExprType(genericInfo)) => return genericInfo // since we're looking for the getter, we get an ExprType
-                case _ => ()
+            // there might be a getter created after erasure by the mixin phase,
+            // and if so we must use the information that the mixin phase stored for it.
+            val mixinGetter = atPhase(mixinPhase.next) {
+              sym.getter
+            }
+            if mixinGetter.exists then mixinPhase.asInstanceOf[Mixin].mixinGenericInfos.get(mixinGetter) match
+              case Some(ExprType(genericInfo)) => return genericInfo // since we're looking for the getter, we get an ExprType
+              case _ => ()
 
-          sym.owner.denot.thisType.memberInfo(sym)
-        }
-
-        if ctx.base.settings.XnoGenericSig.value then null
-        else
-          val genSig = getGenericSignatureHelper(sym, computeMemberType(), ogPhase)
-          if genSig == null || (descriptor != null && descriptor.contentEquals(genSig)) then null
-          else genSig.toString
+        sym.owner.denot.thisType.memberInfo(sym)
       }
+
+      if ctx.base.settings.XnoGenericSig.value then null
+      else
+        val genSig = getGenericSignatureHelper(sym, computeMemberType())
+        if genSig == null || (descriptor != null && descriptor.contentEquals(genSig)) then null
+        else genSig.toString
     }
 
-    private def getGenericSignatureHelper(sym: Symbol, memberTpe: Type, ogPhase: Phase)(using Context): java.lang.StringBuilder | Null = {
+    private def getGenericSignatureHelper(sym: Symbol, memberTpe: Type)(using Context): java.lang.StringBuilder | Null = {
       // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
       // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
       // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
-      lazy val loadingCtx = ctx.withPhase(ogPhase)
+      val loadingCtx = ctx
       val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
         if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
       })
@@ -592,7 +589,7 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
         val memberTpe = atPhase(erasurePhase) { moduleClass.denot.thisType.memberInfo(sym) }
         val erasedMemberType = ElimErasedValueType.elimEVT(TypeErasure.transformInfo(sym, memberTpe))
         if (erasedMemberType =:= sym.denot.info)
-          val gensig = getGenericSignatureHelper(sym, memberTpe, ctx.phase)
+          val gensig = getGenericSignatureHelper(sym, memberTpe)
           if gensig == null || (descriptor != null && descriptor.contentEquals(gensig)) then null
           else gensig.toString
         else null

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -498,6 +498,7 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
      * @see    https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.4
      */
     def getGenericSignature(sym: Symbol, descriptor: String | Null)(using Context): String | Null = {
+      val ogPhase = ctx.phase
       atPhase(erasurePhase) {
         // Finding the member's type is nontrivial because of erasure and how it interacts with other phases.
         def computeMemberType(): Type = {
@@ -534,17 +535,17 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
 
         if ctx.base.settings.XnoGenericSig.value then null
         else
-          val genSig = getGenericSignatureHelper(sym, computeMemberType())
+          val genSig = getGenericSignatureHelper(sym, computeMemberType(), ogPhase)
           if genSig == null || (descriptor != null && descriptor.contentEquals(genSig)) then null
           else genSig.toString
       }
     }
 
-    private def getGenericSignatureHelper(sym: Symbol, memberTpe: Type)(using Context): java.lang.StringBuilder | Null = {
+    private def getGenericSignatureHelper(sym: Symbol, memberTpe: Type, ogPhase: Phase)(using Context): java.lang.StringBuilder | Null = {
       // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
       // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
       // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
-      lazy val loadingCtx = ctx.withPhase(flattenPhase.next)
+      lazy val loadingCtx = ctx.withPhase(ogPhase)
       val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
         if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
       })
@@ -591,7 +592,7 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
         val memberTpe = atPhase(erasurePhase) { moduleClass.denot.thisType.memberInfo(sym) }
         val erasedMemberType = ElimErasedValueType.elimEVT(TypeErasure.transformInfo(sym, memberTpe))
         if (erasedMemberType =:= sym.denot.info)
-          val gensig = getGenericSignatureHelper(sym, memberTpe)
+          val gensig = getGenericSignatureHelper(sym, memberTpe, ctx.phase)
           if gensig == null || (descriptor != null && descriptor.contentEquals(gensig)) then null
           else gensig.toString
         else null

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -35,11 +35,11 @@ object GenericSignatures {
    *  @return The signature if it could be generated, `null` otherwise.
    */
   def javaSig(sym0: Symbol, info: Type, onClassRef: ClassSymbol => Unit)(using Context): StringBuilder | Null =
-    if mayNeedSignature(sym0, info) then
-      ctx.handleRecursive("generating the generic signature of", sym0, sym0):
-        atPhase(erasurePhase):
+    ctx.handleRecursive("generating the generic signature of", sym0, sym0):
+      atPhase(erasurePhase):
+        if mayNeedSignature(sym0, info) then
           javaSig0(sym0, info, onClassRef)
-    else null
+        else null
 
   private def mayNeedSignature(sym0: Symbol, info: Type)(using Context) = {
     def mayNeedSignature(t: Type): Boolean = t match

--- a/tests/pos/26987/a_use.scala
+++ b/tests/pos/26987/a_use.scala
@@ -1,0 +1,4 @@
+//> using options -opt -opt-inline:**,!java.**
+
+package a.b
+class Holder(v: Option[VC])

--- a/tests/pos/26987/b_pkg.scala
+++ b/tests/pos/26987/b_pkg.scala
@@ -1,0 +1,2 @@
+package a
+package object b { class VC(val id: String) extends AnyVal }


### PR DESCRIPTION
Fixes #26987

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
