### PR TITLE
Force update liqp's transitive Jackson deps

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1744,6 +1744,7 @@ object Build {
         Dependencies.jacksonDataformatYaml,
         Dependencies.sbtJunitInterface % Test,
       ),
+      dependencyOverrides ++= Dependencies.liqpDependencyOverrides,
       Compile / scalacOptions += "-experimental",
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
   val liqp = "nl.big-o" % "liqp" % "0.9.2.3"
   // otherwise the jackson versions are ancient, with known vulnerabilities
   val liqpDependencyOverrides = Seq(
-    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.22.2",
+    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.22",
     "com.fasterxml.jackson.core" % "jackson-core" % "2.22.2",
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.22.2",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.22.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,6 +48,13 @@ object Dependencies {
   val jsoup = "org.jsoup" % "jsoup" % "1.23.2"
 
   val liqp = "nl.big-o" % "liqp" % "0.9.2.3"
+  // otherwise the jackson versions are ancient, with known vulnerabilities
+  val liqpDependencyOverrides = Seq(
+    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.22.2",
+    "com.fasterxml.jackson.core" % "jackson-core" % "2.22.2",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.22.2",
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.22.2"
+  )
 
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "1.0.0"
 


### PR DESCRIPTION
This is most of the GitHub security alerts now

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
