### PR TITLE
Fix version completion detection after a trailing colon

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
@@ -33,7 +33,7 @@ object AmmoniteIvyCompletions:
             pos.withStart(rangeStart).withEnd(rangeEnd).toLsp
         val completions = coursierComplete.complete(dependency.nn)
         val normalized = dependency.replace(":::", ":").replace("::", ":")
-        val isVersionCompletion = normalized.split(":").length >= 3
+        val isVersionCompletion = normalized.count(_ == ':') >= 2
         completions
           .map(insertText =>
             CompletionValue.Coursier(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
@@ -35,7 +35,7 @@ class ScalaCliCompletions(
     val (editStart, editEnd) = CoursierComplete.inferEditRange(pos.point, text)
     val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp
     val normalized = dependency.replace(":::", ":").replace("::", ":")
-    val isVersionCompletion = normalized.split(":").length >= 3
+    val isVersionCompletion = normalized.count(_ == ':') >= 2
     completions
       .map(insertText =>
         CompletionValue.Coursier(

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionAmmoniteSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionAmmoniteSuite.scala
@@ -1,0 +1,35 @@
+package dotty.tools.pc.tests.completion
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+class CompletionAmmoniteSuite extends BaseCompletionSuite:
+
+  @Test def `version-sort-empty` =
+    checkSubset(
+      """|import $ivy.`com.lihaoyi::pprint:@@`
+         |""".stripMargin,
+      """|0.7.3
+         |0.7.2
+         |0.7.1
+         |0.7.0
+         |""".stripMargin,
+      filename = "A.worksheet.sc",
+      enablePackageWrap = false
+    )
+
+  private def checkSubset(
+      original: String,
+      expected: String,
+      filename: String,
+      enablePackageWrap: Boolean
+  ) =
+    val expectedAtLeast = expected.linesIterator.toSet
+    check(
+      original,
+      expected,
+      filter = expectedAtLeast,
+      filename = filename,
+      enablePackageWrap = enablePackageWrap
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -67,6 +67,18 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `version-sort-empty` =
+    checkSubset(
+      """|//> using dep "com.lihaoyi::pprint:@@"
+         |package A
+         |""".stripMargin,
+      """|0.7.3
+         |0.7.2
+         |0.7.1
+         |0.7.0
+         |""".stripMargin
+    )
+
   @Ignore
   @Test def `single-colon` =
     checkSubset(


### PR DESCRIPTION

Fixes https://github.com/scala/scala3/issues/27034

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reviewing the implementation, adding regression tests for Scala CLI and Ammonite completions, and running both presentation-compiler test suites locally.

## How was the solution tested?

New automated tests (including the issue's reproducer)

The fix replaces the trailing-empty-sensitive `split(":").length` check with a separator count in both `ScalaCliCompletions` and `AmmoniteIvyCompletions`. 