### PR TITLE
Improve message for ambiguous negative literal

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3070,7 +3070,7 @@ object Parsers {
             case Number(n, _) if n(0) == '-' =>
               val start = t.span.start
               val span = Span(start, in.lastOffset)
-              warning(IllegalLiteral(), start)
+              warning(IllegalLiteral(ambiguous = true), start)
               unpatch(ctx.compilationUnit.source, span)
               patch(span, s"($n)")
             case Literal(const)
@@ -3080,7 +3080,7 @@ object Parsers {
                     || const.tag == DoubleTag) =>
               val start = t.span.start
               val span = Span(start, in.lastOffset)
-              warning(IllegalLiteral(), start)
+              warning(IllegalLiteral(ambiguous = true), start)
               unpatch(ctx.compilationUnit.source, span)
               val text = new String(source.content, start, span.end - start)
               patch(span, s"($text)")

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -879,15 +879,21 @@ extends SyntaxMsg(AuxConstructorNeedsNonImplicitParameterID) {
         |"""
 }
 
-class IllegalLiteral()(using Context)
+class IllegalLiteral(ambiguous: Boolean = false)(using Context)
 extends SyntaxMsg(IllegalLiteralID) {
-  def msg(using Context) = "Illegal literal"
+  def msg(using Context) = if ambiguous then "Ambiguous literal" else "Illegal literal"
   def explain(using Context) =
+    if ambiguous then
+    i"""|`${hl("-42.abs")}` does not parse the same as `${hl("-n.abs")}`.
+        |For clarity, write `${hl("(-42).abs")}` instead.
+        |The literal can be rewritten automatically under -rewrite.
+        |"""
+    else
     i"""|Available literals can be divided into several groups:
         | - Integer literals: 0, 21, 0xFFFFFFFF, -42L
         | - Floating Point Literals: 0.0, 1e30f, 3.14159f, 1.0e-100, .1
         | - Boolean Literals: true, false
-        | - Character Literals: 'a', '\u0041', '\n'
+        | - Character Literals: 'a', '\\u0041', '\\n'
         | - String Literals: "Hello, World!"
         | - null
         |"""


### PR DESCRIPTION
Fixes #26991 

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Since `-explain` messages are un(der)tested, and this commit only touches the message text, I checked the text manually in REPL. This is a lazy follow-up to a previous lazy tweak that addressed an edge case of syntax.
