### PR TITLE
Fix crash pickling a quote as an inline argument (in different source)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -95,7 +95,7 @@ class PickleQuotes extends MacroTransform {
           val (holeContents, quote1) = extractHolesContents(quote)
           val quote2 = encodeTypeArgs(quote1)
           val holeContents1 = holeContents.map(transform(_))
-          PickleQuotes.pickle(quote2, quotes, holeContents1)
+          PickleQuotes.pickle(quote2, quotes, holeContents1)(using ctx.withSource(quote.source))
         case tree: DefDef if !tree.rhs.isEmpty && tree.symbol.isInlineMethod =>
           tree
         case _ =>

--- a/tests/pos-macros/i26796-inline-quotes/Macro_1.scala
+++ b/tests/pos-macros/i26796-inline-quotes/Macro_1.scala
@@ -1,0 +1,1 @@
+inline def mkPair[A, B](inline a: A, inline b: B): (A, B) = (a, b)

--- a/tests/pos-macros/i26796-inline-quotes/Test_2.scala
+++ b/tests/pos-macros/i26796-inline-quotes/Test_2.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+object Macros:
+  def impl(using Quotes): Expr[Int] =
+    val inner: Expr[Int] = '{ 1 }
+    val pair: (Int, Expr[Int]) = mkPair(0, '{ $inner + 1 })
+    pair._2
+
+  inline def trigger: Int = ${ impl }

--- a/tests/pos-macros/i26796/Macro_1.scala
+++ b/tests/pos-macros/i26796/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+object Macros:
+  def impl(using Quotes): Expr[Int] =
+    val inner: Expr[Int] = '{ 1 }
+    val pair: (Int, Expr[Int]) = 0 -> '{ $inner + 1 }
+    pair._2
+
+  inline def trigger: Int = ${ impl }

--- a/tests/pos-macros/i26796/Test_2.scala
+++ b/tests/pos-macros/i26796/Test_2.scala
@@ -1,0 +1,2 @@
+@main def run(): Unit =
+  println(Macros.trigger)


### PR DESCRIPTION
Fix https://github.com/scala/scala3/issues/26796

While this comes to surface because of https://github.com/scala/scala3/pull/24728, it's not a root cause. pickling crash if an inline method + inline argument received quoted expression.

**Problem**
When a quote is inlined into another file's inline method, `pickleQuotes` used the callee's compilation context to build the TASTy encoding.

For example below, when pickling `mkPair(0, '{ 1 + 1 })`, the `ctx.source` points to file1, instead of file 2.

```scala
// file 1
inline def mkPair[A, B](inline a: A, inline b: B) = (a, b)
// file 2
mkPair(0, '{ 1 + 1 })
```

`pickleQuotes` calls `inlineCallTrace`, which asserts `ctx.source == pos.source` and fails, [^1]
because `ctx.source` is file 1, and `quote.sourcePos` is in file 2.

```scala
// PickleQuotes.scala
def pickleAsTasty() = {
  val body1 =
    if body.isType then body
    else Inlined(Inlines.inlineCallTrace(ctx.owner, quote.sourcePos), Nil, body)

// Inlines.scala
def inlineCallTrace(callSym: Symbol, pos: SourcePosition)(using Context): Tree = {
  assert(ctx.source == pos.source)
```

This commit fix the issue by pickling quotes under `ctx.withSource(quote.source)` so the synthesized trees are attributed to the quote's file, instead of inline method's. [^2]

---

[^1]: `pickleQuotes` replaces `'{ e }` with
`unpickleExprV2(<TASTy of e>, typeHoles, termHoles)` Before pickling `e`, `pickleQuotes` wraps the body in `Inlined(inlineCallTrace(owner, quote.pos), Nil, e)` so that unpickling can restore where the quote is from.

[^2]: The immediate fix is using `ctx.withSource(quote.source)` specifically for `inlineCallTrace`, then we can workaround the assert. `Inlines.inlineCallTrace(ctx.owner, quote.sourcePos)(using ctx.withSource(quote.source)`
However, it doesn't apply the `ctx.withSource(quote.source)` for synthesized `unpickleExprV2(<TASTy of e>, ...)` tree. And compiler would crash recheck's `YcheckPosition` fails.

```
crash when compiling: tests/pos-macros/i26796-inline-quotes:
assertion failed: wrong source set for x$1.asInstanceOf[scala.quoted.runtime.QuoteUnpickler].unpickleExprV2[Int](
    ..., null, null) # -1 of class dotty.tools.dotc.ast.Trees$Apply, set to tests/pos-macros/i26796-inline-quotes/Macro_1.scala but context had tests/pos-macros/i26796-inline-quotes/Test_2.scala
 <deferred> <method> <touched>
        at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:10)
        at dotty.tools.dotc.transform.YCheckPositions$$anon$1.traverse(YCheckPositions.scala:36)
        at dotty.tools.dotc.transform.YCheckPositions$$anon$1.traverse(YCheckPositions.scala:45)
```



<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Not for codegen.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
