### PR TITLE
Re-fix #26959 by avoiding Unit =:= on class refs to fix cyclic TASTy load

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -1065,7 +1065,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
     // constructor method should not be semi-erased.
     if semiEraseVCs && isConstructor && !tp.isInstanceOf[MethodOrPoly] then
       erasureFn(sourceLanguage, semiEraseVCs = false, isConstructor, isSymbol, inSigName).eraseResult(tp)
-    else if tp =:= defn.UnitType then
+    else if isErasedToVoid(tp) then
       // This should always be UnitType. However, there is one exception: if we
       // are computing the erasure of a Scala 2 symbol whose result type is a
       // Scala.js pseudo-union type, we must preserve the pseudo-union.
@@ -1081,6 +1081,21 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         defn.UnitType
     else
       apply(tp)
+
+  /** True if a result type should erase to JVM void.
+   *
+   *  `isRef(UnitClass)` covers `Unit` and aliases of `Unit` without full equality.
+   *  `=:=` is kept for remaining Unit-equivalent types, but must not be used on
+   *  class TypeRefs: comparing them to `Unit` forces base classes, which is cyclic
+   *  for nested self-typed traits loaded from TASTy (#26959, introduced by #26252).
+   */
+  private def isErasedToVoid(tp: Type)(using Context): Boolean =
+    tp.isRef(defn.UnitClass) || nonClassEqUnit(tp)
+
+  private def nonClassEqUnit(tp: Type)(using Context): Boolean = tp.stripTypeVar match
+    case tref: TypeRef if tref.symbol.isClass => false
+    case AnnotatedType(tp1, _) => nonClassEqUnit(tp1)
+    case _ => tp =:= defn.UnitType
 
   /** The name of the type as it is used in `Signature`s.
    *

--- a/tests/pos/i26959-alias/Lib_1.scala
+++ b/tests/pos/i26959-alias/Lib_1.scala
@@ -1,0 +1,13 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  type U = Unit
+  type ID[T] = T
+  trait InnerSupport { this: Companion.type =>
+    def foo: U = ()
+    def bar: ID[Unit] = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}

--- a/tests/pos/i26959-alias/User_2.scala
+++ b/tests/pos/i26959-alias/User_2.scala
@@ -1,0 +1,2 @@
+package repro
+class User(c: Outer)

--- a/tests/pos/i26959-joint.scala
+++ b/tests/pos/i26959-joint.scala
@@ -1,0 +1,12 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  trait InnerSupport { this: Companion.type =>
+    def foo: Unit = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}
+
+class User(c: Outer)

--- a/tests/pos/i26959/Lib_1.scala
+++ b/tests/pos/i26959/Lib_1.scala
@@ -1,0 +1,10 @@
+package repro
+
+// https://github.com/scala/scala3/issues/26959
+trait Outer {
+  trait InnerSupport { this: Companion.type =>
+    def foo: Unit = ()
+  }
+  val Companion: CompanionTrait
+  trait CompanionTrait extends InnerSupport { this: Companion.type => }
+}

--- a/tests/pos/i26959/User_2.scala
+++ b/tests/pos/i26959/User_2.scala
@@ -1,0 +1,2 @@
+package repro
+class User(c: Outer)


### PR DESCRIPTION
Fixes #26959

~This merely ports tests from https://github.com/scala/scala3/pull/27010 / https://github.com/scala/scala3-lts/pull/1112 to the `main` branch, to prevent https://github.com/scala/scala3/issues/26959 from haunting us again (as we fixed it by accident, mostly 🙃)~

As per https://github.com/scala/scala3/issues/26959#issuecomment-5619789186, it seems we need to re-fix this for Scala 3.10.
This is almost the same as https://github.com/scala/scala3-lts/pull/1112, just without the optimizer adjustments.

## Have you relied on LLM-based tools in this contribution?
No

## How was the solution tested?
New automated tests (including the issue's reproducer, if applicable)
