### PR TITLE
Doc: clarify behavior of line-related functions

### DIFF
--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -256,18 +256,18 @@ object Console extends AnsiColor {
   }
 
   /** Flushes the output stream. This function is required when partial
-   *  output (i.e. output not terminated by a newline character) has
+   *  output (i.e. not an entire line ending in a line separator) has
    *  to be made visible on the terminal.
    *  @group console-output
    */
   def flush(): Unit = { out.flush() }
 
-  /** Prints a newline character on the default output.
+  /** Prints a line separator on the default output.
    *  @group console-output
    */
   def println(): Unit = { out.println() }
 
-  /** Prints out an object to the default output, followed by a newline character.
+  /** Prints out an object to the default output, followed by a line separator.
    *
    *  @param x the object to print.
    *  @group console-output

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -256,8 +256,8 @@ object Console extends AnsiColor {
   }
 
   /** Flushes the output stream. This function is required when partial
-   *  output (i.e. not an entire line ending in a line separator) has
-   *  to be made visible on the terminal.
+   *  output (i.e. not ending in a line separator) has
+   *  to be made visible.
    *  @group console-output
    */
   def flush(): Unit = { out.flush() }

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -514,12 +514,12 @@ object Predef extends LowPriorityImplicits {
    */
   def print(x: Any): Unit = Console.print(x)
 
-  /** Prints a newline character on the default output.
+  /** Prints a line separator on the default output.
    *  @group console-output
    */
   def println(): Unit = Console.println()
 
-  /** Prints out an object to the default output, followed by a newline character.
+  /** Prints out an object to the default output, followed by a line separator.
    *
    *  @param x the object to print.
    *  @group console-output

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -302,9 +302,9 @@ abstract class Source extends Iterator[Char] with Closeable {
     }
   }
 
-  /** Returns an iterator who returns lines (NOT including newline character(s)).
-   *  It will treat any of \r\n, \r, or \n as a line separator (longest match) - if
-   *  you need more refined behavior you can subclass Source#LineIterator directly.
+  /** Returns an iterator who returns lines, NOT including line separators.
+   *  Treats any of \r\n, \r, or \n as a line separator (longest match).
+   *  If you need more specific behavior, subclass Source#LineIterator directly.
    */
   def getLines(): Iterator[String] = new LineIterator()
 


### PR DESCRIPTION
Fixes https://users.scala-lang.org/t/which-line-separator-in-println/12375

This is still not quite right, because how it actually works is:
- Windows, like typewriters, _separates_ lines with CR + LF
- Unix-likes instead _terminate_ lines with LF

But it's better than referring to individual characters when there may be more than one.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
