### PR TITLE
Support `Symbol` name in `@deprecatedName`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package core
 
-import Symbols.*, Types.*, Contexts.*, Constants.*, Phases.*
+import Symbols.*, Types.*, Contexts.*, Constants.*, Phases.*, NameKinds.*
 import ast.tpd, tpd.*
 import util.Spans.{Span, NoSpan}
 import printing.{Showable, Printer}
@@ -46,10 +46,16 @@ object Annotations {
     def argumentTypes(using Context): List[Type] =
       tpd.allArguments(tree).filterConserve(_.isType).tpes
 
-    def argument(i: Int)(using Context): Option[Tree] = {
+    def argument(i: Int)(using Context): Option[Tree] =
       val args = arguments
-      if (i < args.length) Some(args(i)) else None
-    }
+      if i < args.length then Some(args(i)) else None
+
+    def hasExplicitArgument(i: Int)(using Context): Boolean =
+      argument(i) match
+        case Some(Select(Ident(_), DefaultGetterName(nme.CONSTRUCTOR, _))) => false
+        case Some(xxx) => true
+        case None => false
+
     def argumentConstant(i: Int)(using Context): Option[Constant] =
       for case ConstantType(c) <- argument(i).map(stripCast(_).tpe.widenTermRefExpr.normalized) yield c
 

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -53,7 +53,7 @@ object Annotations {
     def hasExplicitArgument(i: Int)(using Context): Boolean =
       argument(i) match
         case Some(Select(Ident(_), DefaultGetterName(nme.CONSTRUCTOR, _))) => false
-        case Some(xxx) => true
+        case Some(_) => true
         case None => false
 
     def argumentConstant(i: Int)(using Context): Option[Constant] =

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -10,6 +10,7 @@ import printing.Texts.Text
 import cc.{isRetainsLike, RetainingAnnotation}
 import config.Feature.sourceVersion
 import Decorators.*
+import dotty.tools.dotc.core.StdNames.nme
 
 import scala.annotation.internal.sharable
 
@@ -54,6 +55,14 @@ object Annotations {
 
     def argumentConstantString(i: Int)(using Context): Option[String] =
       for (case Constant(s: String) <- argumentConstant(i)) yield s
+
+    def argumentConstantSymbol(i: Int)(using Context): Option[String] =
+      argument(i) match
+        case Some(Apply(Select(Ident(nme.Symbol), nme.apply), Literal(Constant(s: String)) :: Nil)) => Some(s)
+        case _ => None
+
+    def argumentConstantStringOrSymbol(i: Int)(using Context): Option[String] =
+      argumentConstantString(i).orElse(argumentConstantSymbol(i))
 
     /** The tree evaluation is in progress. */
     def isEvaluating: Boolean = false

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -711,7 +711,7 @@ trait Applications extends Compatibility {
 
       extension (dna: Annotation)
         def deprecatedName: Name =
-          dna.argumentConstantString(0).map(_.toTermName).getOrElse(nme.NO_NAME)
+          dna.argumentConstantStringOrSymbol(0).map(_.toTermName).getOrElse(nme.NO_NAME)
         def since: String =
           val version = dna.argumentConstantString(1).filter(!_.isEmpty)
           version.map(v => s" (since $v)").getOrElse("")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3156,7 +3156,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           if seen(p.name) then
             report.error(em"parameter name must be distinct from deprecated name", p.srcPos)
           for annot <- p.symbol.getAnnotation(defn.DeprecatedNameAnnot) do
-            val nm = annot.argumentConstantString(0).map(_.toTermName).getOrElse(nme.NO_NAME)
+            val nm = annot.argumentConstantStringOrSymbol(0).map(_.toTermName).getOrElse(nme.NO_NAME)
             if seen(nm) then
               report.error(em"deprecated parameter name must be distinct from other names", annot.tree.srcPos)
             seen.addOne(nm)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -52,7 +52,7 @@ import cc.{Setup, CheckCaptures, isRetainsLike, derivesFromCapSet}
 import config.MigrationVersion
 import dotty.tools.dotc.core.Mode.Interactive
 import transform.CheckUnused.withOriginalName
-import dotty.tools.dotc.printing.Formatting
+import dotty.tools.dotc.printing.Formatting.hl
 
 import scala.annotation.{unchecked as _, *}
 import dotty.tools.dotc.util.chaining.*
@@ -1183,7 +1183,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     record("typedThis")
     val res = assignType(tree)
     if res.tpe.typeSymbol.name.isTopLevelPackageObjectName then
-      report.error(em"Top-level definitions cannot refer to ${Formatting.hl("this")}", tree)
+      report.error(em"Top-level definitions cannot refer to ${hl("this")}", tree)
     res
   }
 
@@ -3156,10 +3156,15 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           if seen(p.name) then
             report.error(em"parameter name must be distinct from deprecated name", p.srcPos)
           for annot <- p.symbol.getAnnotation(defn.DeprecatedNameAnnot) do
-            val nm = annot.argumentConstantStringOrSymbol(0).map(_.toTermName).getOrElse(nme.NO_NAME)
-            if seen(nm) then
-              report.error(em"deprecated parameter name must be distinct from other names", annot.tree.srcPos)
-            seen.addOne(nm)
+            if annot.hasExplicitArgument(0) then
+              annot.argumentConstantStringOrSymbol(0) match
+                case Some(nm0) =>
+                  val nm = nm0.toTermName
+                  if seen(nm) then
+                    report.error(em"deprecated parameter name must be distinct from other names", annot.tree.srcPos)
+                  seen.addOne(nm)
+                case None =>
+                  report.error(em"the first argument of ${hl("@deprecatedName")} must be a constant", annot.tree.srcPos)
           seen.addOne(p.name)
       checkNoForwardDependencies(vparams)
     if (sym.isOneOf(GivenOrImplicit)) checkImplicitConversionDefOK(sym)

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -80,7 +80,7 @@ final class SummaryReport extends SummaryReporting {
   override def echoSummary(): Unit = {
     val rep = new StringBuilder
     if failed == 0 && failedTests.isEmpty then
-      rep.append(s"${Console.BOLD}${Console.GREEN}== Vulpix Test Report: $passed suites passed, no failures (${skippedTests.size} skipped) ==${Console.RESET}")
+      rep.append(s"${Console.BOLD}${Console.GREEN}== Vulpix Test Report: all $passed suites passed (${skippedTests.size} skipped) ==${Console.RESET}")
     else
       rep.append(
         s"""|${Console.BOLD}${Console.RED}

--- a/tests/neg/deprecatedName-nonconstant.check
+++ b/tests/neg/deprecatedName-nonconstant.check
@@ -1,0 +1,16 @@
+-- Error: tests/neg/deprecatedName-nonconstant.scala:2:3 ---------------------------------------------------------------
+2 |  @deprecatedName("x".toUpperCase) a: Int // error
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  the first argument of @deprecatedName must be a constant
+-- Error: tests/neg/deprecatedName-nonconstant.scala:6:3 ---------------------------------------------------------------
+6 |  @deprecatedName(Symbol("x".toUpperCase)) a: Int // error
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  the first argument of @deprecatedName must be a constant
+-- Error: tests/neg/deprecatedName-nonconstant.scala:10:3 --------------------------------------------------------------
+10 |  @deprecatedName("x" + 1) a: Int // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |  the first argument of @deprecatedName must be a constant
+-- Error: tests/neg/deprecatedName-nonconstant.scala:14:3 --------------------------------------------------------------
+14 |  @deprecatedName(Symbol("x" + 1)) a: Int // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |  the first argument of @deprecatedName must be a constant

--- a/tests/neg/deprecatedName-nonconstant.scala
+++ b/tests/neg/deprecatedName-nonconstant.scala
@@ -1,0 +1,16 @@
+def f(
+  @deprecatedName("x".toUpperCase) a: Int // error
+): Int = a
+
+def g(
+  @deprecatedName(Symbol("x".toUpperCase)) a: Int // error
+): Int = a
+
+def h(
+  @deprecatedName("x" + 1) a: Int // error
+): Int = a
+
+def i(
+  @deprecatedName(Symbol("x" + 1)) a: Int // error
+): Int = a
+

--- a/tests/neg/i19077.check
+++ b/tests/neg/i19077.check
@@ -16,20 +16,24 @@
    |              x is already defined as parameter x
    |
    |              Note that overloaded methods must all be defined in the same group of toplevel definitions
--- Error: tests/neg/i19077.scala:13:15 ---------------------------------------------------------------------------------
-13 |  f(1, 2, 3, x = 42) // error
+-- Error: tests/neg/i19077.scala:12:36 ---------------------------------------------------------------------------------
+12 |def k(@deprecatedName("a") x: Int, @deprecatedName(Symbol("a")) y: Int) = x+y // error
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   deprecated parameter name must be distinct from other names
+-- Error: tests/neg/i19077.scala:15:15 ---------------------------------------------------------------------------------
+15 |  f(1, 2, 3, x = 42) // error
    |             ^^^^^^
    |             parameter x of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:14:15 ---------------------------------------------------------------------------------
-14 |  f(1, 2, 3, w = 42) // error
+-- Error: tests/neg/i19077.scala:16:15 ---------------------------------------------------------------------------------
+16 |  f(1, 2, 3, w = 42) // error
    |             ^^^^^^
    |             parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:15:20 ---------------------------------------------------------------------------------
-15 |  f(1, 2, w = 42, z = 27) // error
+-- Error: tests/neg/i19077.scala:17:20 ---------------------------------------------------------------------------------
+17 |  f(1, 2, w = 42, z = 27) // error
    |                  ^^^^^^
    |                  parameter z of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:16:20 ---------------------------------------------------------------------------------
-16 |  f(1, 2, z = 42, w = 27) // error
+-- Error: tests/neg/i19077.scala:18:20 ---------------------------------------------------------------------------------
+18 |  f(1, 2, z = 42, w = 27) // error
    |                  ^^^^^^
    |                  parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
 there was 1 deprecation warning; re-run with -deprecation for details

--- a/tests/neg/i19077.scala
+++ b/tests/neg/i19077.scala
@@ -9,6 +9,8 @@ def i(x: Int, @deprecatedName("x") y: Int) = x+y // error
 
 def j(x: Int, @deprecatedName("x") x: Int) = x // error
 
+def k(@deprecatedName("a") x: Int, @deprecatedName(Symbol("a")) y: Int) = x+y // error
+
 @main def Test =
   f(1, 2, 3, x = 42) // error
   f(1, 2, 3, w = 42) // error

--- a/tests/pos/deprecatedName-symbol.scala
+++ b/tests/pos/deprecatedName-symbol.scala
@@ -1,0 +1,4 @@
+def f(
+  @deprecatedName(Symbol("x")) a: Int,
+  @deprecatedName(Symbol("y")) b: Int
+): Unit = ()

--- a/tests/warn/deprecatedName-symbol.check
+++ b/tests/warn/deprecatedName-symbol.check
@@ -1,0 +1,4 @@
+-- Deprecation Warning: tests/warn/deprecatedName-symbol.scala:7:13 ----------------------------------------------------
+7 |val a2 = f(x = 2) // warn
+  |           ^^^^^
+  |           the parameter name x is deprecated: use y instead

--- a/tests/warn/deprecatedName-symbol.check
+++ b/tests/warn/deprecatedName-symbol.check
@@ -2,3 +2,7 @@
 7 |val a2 = f(x = 2) // warn
   |           ^^^^^
   |           the parameter name x is deprecated: use y instead
+-- Deprecation Warning: tests/warn/deprecatedName-symbol.scala:3:7 -----------------------------------------------------
+3 |def f(@deprecatedName(Symbol("x")) y: Int): Int = y // warn
+  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |constructor deprecatedName in class deprecatedName is deprecated since 2.13.0: The parameter name should be a String, not a symbol.

--- a/tests/warn/deprecatedName-symbol.scala
+++ b/tests/warn/deprecatedName-symbol.scala
@@ -1,6 +1,6 @@
 //> using options -deprecation
 
-def f(@deprecatedName(Symbol("x")) y: Int): Int = y
+def f(@deprecatedName(Symbol("x")) y: Int): Int = y // warn
 
 val a1 = f(y = 1)
 

--- a/tests/warn/deprecatedName-symbol.scala
+++ b/tests/warn/deprecatedName-symbol.scala
@@ -1,0 +1,7 @@
+//> using options -deprecation
+
+def f(@deprecatedName(Symbol("x")) y: Int): Int = y
+
+val a1 = f(y = 1)
+
+val a2 = f(x = 2) // warn


### PR DESCRIPTION
Fixes #27042
Fixes #27038

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
