### PR TITLE
Fix `$` warning and rewrite on already-backticked names.

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -194,8 +194,23 @@ class Namer { typer: Typer =>
             simple.length == 2 && simple.endsWith(str.EXPAND_SEPARATOR)
           }
       }
+    // Desugaring of objects / enum cases can drop the Backquoted attachment, so also
+    // treat names that are already enclosed in backticks in the source as exempt.
+    // After atNameSpan, span.point is either on the opening backtick (e.g. comma enum
+    // cases) or just after it (most other defs).
+    def alreadyBackquotedInSource: Boolean =
+      val span = tree.span
+      if !span.exists || span.isSynthetic then false
+      else
+        val content = tree.source.content()
+        val point = span.point
+        content.length > point && (
+          content(point) == '`'
+          || point > 0 && content(point - 1) == '`'
+        )
     def exempt =
          isBackquoted(tree)
+      || alreadyBackquotedInSource
       || tree.span.isSynthetic
       || flags.isOneOf(Synthetic | Accessor | CaseAccessor) // check the case param not the accessor
       || flags.is(Param) && ctx.owner.is(Synthetic)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -90,6 +90,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i24103b.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i24213.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i18234.scala", defaultOptions.and("-rewrite", "-source:3.8-migration")),
+      compileFile("tests/rewrites/i27041.scala", defaultOptions.and("-rewrite", "-source:3.9-migration")),
       compileFile("tests/rewrites/unary-minus.scala", defaultOptions.and("-rewrite")),
     )).checkRewrites()
   }

--- a/tests/pos/i27041.scala
+++ b/tests/pos/i27041.scala
@@ -1,0 +1,29 @@
+//> using options -Werror -source:3.9
+
+// 1:1 reproduction from scala/scala3#27041
+object `$foo` {}
+enum Token { case `${` }
+
+// Adjacent: other backticked $ definitions that should also be exempt
+case object `$caseObj`
+object `foo$bar`
+
+enum CommaCases:
+  case `$a`, `$b`
+
+enum CaseClassEnum:
+  case `Class$Case`(x: Int)
+
+enum `$EnumName`:
+  case Ok
+
+given `$g`: Int = 1
+
+package `$pkg`:
+  val x = 1
+
+// Regression anchors: attachment-based exemption already works for these
+val `$val` = 1
+def `$def` = 2
+class `$class`
+type `$type` = Int

--- a/tests/rewrites/i27041.check
+++ b/tests/rewrites/i27041.check
@@ -1,0 +1,27 @@
+//> using options -source:3.9-migration
+
+// Already backticked: rewrite must not wrap again (scala/scala3#27041)
+object `$foo` {}
+enum Token { case `${` }
+
+case object `$caseObj`
+object `foo$bar`
+
+enum CommaCases:
+  case `$a`, `$b`
+
+enum CaseClassEnum:
+  case `Class$Case`(x: Int)
+
+enum `$EnumName`:
+  case Ok
+
+given `$g`: Int = 1
+
+package `$pkg`:
+  val x = 1
+
+val `$val` = 1
+def `$def` = 2
+class `$class`
+type `$type` = Int

--- a/tests/rewrites/i27041.scala
+++ b/tests/rewrites/i27041.scala
@@ -1,0 +1,27 @@
+//> using options -source:3.9-migration
+
+// Already backticked: rewrite must not wrap again (scala/scala3#27041)
+object `$foo` {}
+enum Token { case `${` }
+
+case object `$caseObj`
+object `foo$bar`
+
+enum CommaCases:
+  case `$a`, `$b`
+
+enum CaseClassEnum:
+  case `Class$Case`(x: Int)
+
+enum `$EnumName`:
+  case Ok
+
+given `$g`: Int = 1
+
+package `$pkg`:
+  val x = 1
+
+val `$val` = 1
+def `$def` = 2
+class `$class`
+type `$type` = Int


### PR DESCRIPTION
Fixes #27041 
This is likely the upstream fix for https://github.com/scalameta/metals/issues/8839
It seems there are cases when Scala CLI script wrappers get caught up in this as well.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running tests

## How was the solution tested?
New automated tests (including the issue's reproducer, if applicable)
