### PR TITLE
Fix LTS nightly release job names

### DIFF
--- a/.github/workflows/release-maven-artifacts.yml
+++ b/.github/workflows/release-maven-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
           MAVEN_REPOSITORY_USER : ${{ secrets.MAVEN_REPOSITORY_USER }}
           MAVEN_REPOSITORY_TOKEN: ${{ secrets.MAVEN_REPOSITORY_TOKEN }}
 
-  release-maven-lts-3.3-artifacts:
+  release-maven-lts-3-3-artifacts:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
@@ -101,7 +101,7 @@ jobs:
           PGP_PW        : ${{ secrets.PGP_PW }}
           PGP_SECRET    : ${{ secrets.PGP_SECRET }}
 
-  release-maven-lts-3.9-artifacts:
+  release-maven-lts-3-9-artifacts:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:


### PR DESCRIPTION
Well, that's awkward.
This is a follow-up fix to https://github.com/scala/scala3/pull/27043 

```
error parsing called workflow
".github/workflows/release-nightly.yml"
-> "./.github/workflows/release-maven-artifacts.yml" (source branch with sha:1fdff21b7cf7511564b420c277d3755a80288948)
: (Line: 53, Col: 3): The identifier 'release-maven-lts-3.3-artifacts' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and must be less than 100 characters., (Line: 104, Col: 3): The identifier 'release-maven-lts-3.9-artifacts' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and must be less than 100 characters.
```

## Have you relied on LLM-based tools in this contribution?
No

## How was the solution tested?
Non-code change, no tests needed
