### PR TITLE
cast pattern matcher throwaway plan to type check under explicit nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -284,7 +284,8 @@ object PatternMatcher {
                 report.error(UnapplyInvalidNumberOfArguments(tree, tree.tpe :: Nil), arg.srcPos)
                 // Generate a throwaway but type-correct plan.
                 // This plan will never execute because it'll be guarded by a `NonNullTest`.
-                ResultPlan(tpd.Throw(tpd.nullLiteral))
+                // The cast is needed because under explicit nulls `Null` is not a `Throwable`.
+                ResultPlan(tpd.Throw(tpd.nullLiteral.cast(defn.ThrowableType)))
               else
                 val sym :: syms1 = syms: @unchecked
                 patternPlan(sym, arg, matchArgsPatternPlan(args1, syms1))
@@ -490,7 +491,8 @@ object PatternMatcher {
           val unappPlan = if (scrutinee.info.isBottomType)
             // Generate a throwaway but type-correct plan.
             // This plan will never execute because it'll be guarded by a `NonNullTest`.
-            ResultPlan(tpd.Throw(tpd.nullLiteral))
+            // The cast is needed because under explicit nulls `Null` is not a `Throwable`.
+            ResultPlan(tpd.Throw(tpd.nullLiteral.cast(defn.ThrowableType)))
           else {
             def applyImplicits(acc: Tree, implicits: List[Tree], mt: Type): Tree = mt match {
               case mt: MethodType =>

--- a/tests/explicit-nulls/pos/bottom-scrutinee-unapply.scala
+++ b/tests/explicit-nulls/pos/bottom-scrutinee-unapply.scala
@@ -1,0 +1,13 @@
+type X
+val x: X = ???
+extension (x: X) def unapply(arg: Any): Boolean = true
+
+def testExtensionUnapply =
+  ??? match
+    case x() =>
+
+def testBottomScrutinee =
+  type Y = Nothing
+  (??? : Y) match
+    case Some(_) => 1
+    case (_, _) => 2


### PR DESCRIPTION
The pattern matcher builds a throwaway plan for bottom-typed scrutinees that is never executed. That plan is `throw null`, which does not type check under explicit nulls. Wrap the plan in a cast so that it type checks under -Ycheck.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Human encountered the bug running existing tests with explicit nulls and came up with the fix.
LLM minimized a test case.
Human reviewed the test case.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated test