### PR TITLE
add missing stripNulls to overload resolution of wildcard arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1013,9 +1013,9 @@ trait Applications extends Compatibility {
         // However, for overload resolution, we want to check applicability:
         // "could this work with some type instantiation?" (yes, if ? = String)
         def wildcardArgOK =
-          argtpe match
+          argtpe.stripNull() match
             case at @ AppliedType(tycon1, args1) if at.hasWildcardArg =>
-              formal match
+              formal.stripNull() match
                 case AppliedType(tycon2, args2)
                 if tycon1 =:= tycon2 && args1.length == args2.length =>
                   // We need to handle all 4 cases, in addition to

--- a/tests/explicit-nulls/run/overload-wildcard/A_1.java
+++ b/tests/explicit-nulls/run/overload-wildcard/A_1.java
@@ -1,0 +1,15 @@
+public class A_1 {
+  // Overloads whose formal parameter types become flexible under explicit nulls.
+  public static <T> int foo5(Class<? extends T> a) { return 1; }
+  public static <T> int foo5(Class<T> a, int... ints) { return 2; }
+
+  public static <V> int foo10(java.util.Map<String, ? extends V> a) { return 1; }
+  public static <V> int foo10(java.util.Map<String, V> a, int... ints) { return 2; }
+
+  // Returns a wildcard type, so the argument type is flexible at the call site.
+  public static Class<? extends Object> cls() { return Object.class; }
+
+  public static java.util.Map<String, ? extends Object> map() {
+    return new java.util.HashMap<String, Object>();
+  }
+}

--- a/tests/explicit-nulls/run/overload-wildcard/B_2.scala
+++ b/tests/explicit-nulls/run/overload-wildcard/B_2.scala
@@ -1,0 +1,17 @@
+object Test:
+
+  // The formal parameter types come from Java: (Class[? <: T])? and (Class[T])?
+  def formalFromJava(): Unit =
+    assert(A_1.foo5(classOf[Object]: Class[? <: Object]) == 1)
+    assert(A_1.foo10(new java.util.HashMap(): java.util.Map[String, ? <: Object]) == 1)
+
+  // The argument type comes from Java: (java.util.Map[String, ? <: Object])?
+  def bar[V](a: java.util.Map[String, ? <: V]): Int = 1
+  def bar[V](a: java.util.Map[String, V], ints: Int*): Int = 2
+
+  def argFromJava(): Unit =
+    assert(bar(A_1.map()) == 1)
+
+  def main(args: Array[String]): Unit =
+    formalFromJava()
+    argFromJava()


### PR DESCRIPTION
The `wildcardArgOK` method for overload resolution does not handle FlexibleTypes coming from Java under explicit nulls. Add calls to `stripNull` to eliminate those types before the method looks at them.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Human encountered the bug running existing tests under explicit nulls and came up with the fix.
LLM created a minimized test.
Human reviewed the test.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests