### PR TITLE
don't try to flexify type lambdas in `FlexibleType.make`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3493,6 +3493,7 @@ object Types extends TypeUtils {
       case wt: WildcardType => wt.optBounds match
         case tb: TypeBounds => WildcardType(FlexibleType.make(tb).asInstanceOf[TypeBounds])
         case _ => wt
+      case tl: TypeLambda => tl
       case other => FlexibleType(tp)
   end FlexibleType
 

--- a/repl/test/dotty/tools/repl/TabcompleteExplicitNullsTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteExplicitNullsTests.scala
@@ -1,0 +1,17 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import org.junit.Test
+
+/** Tab completion with `-Yexplicit-nulls` enabled. */
+class TabcompleteExplicitNullsTests
+extends ReplTest(ReplTest.defaultOptions ++ Array("-Yexplicit-nulls")) {
+
+  // Completing on a type whose type argument is a type lambda used to abort
+  // completion with `Should not flexify HKTypeLambda(...)` from `FlexibleType.apply`.
+  @Test def i9334 = initially {
+    assert(tabComplete("class Foo[T]; classOf[Foo].").contains("getName"))
+  }
+}


### PR DESCRIPTION
A type map such as `asSeenFrom` can substitute a type lambda for the underlying type of a flexible type. A flexible type over a type constructor is meaningless, so leave it alone rather than failing the assertion in `FlexibleType.apply`.

## Have you relied on LLM-based tools in this contribution?

Human encountered the bug running existing tests under explicit nulls, and came up with the fix.
LLM generated a minimized test case.
Human reviewed the test case.

## How was the solution tested?

New automated test