### PR TITLE
Don't warn about flexible types in REPL wrapper objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1238,6 +1238,7 @@ object RefChecks {
     if ctx.explicitNulls && !ctx.isJava
         && sym.exists && sym.owner.isClass
         && !sym.owner.isAnonymousClass
+        && !sym.owner.name.isReplWrapperName
         && !sym.isOneOf(JavaOrPrivateOrSynthetic | InlineProxy | Param | Exported) then
       val resTp = sym.info.finalResultType
       if resTp.existsPart(_.isInstanceOf[FlexibleType], StopAt.Static) then

--- a/repl/test/dotty/tools/repl/ExplicitNullsReplTests.scala
+++ b/repl/test/dotty/tools/repl/ExplicitNullsReplTests.scala
@@ -1,0 +1,20 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** REPL behaviour with `-Yexplicit-nulls` enabled. */
+class ExplicitNullsReplTests
+extends ReplTest(ReplTest.defaultOptions ++ Array("-Yexplicit-nulls")) {
+
+  // The "exposes a flexible type" warning is about a library leaking a flexible
+  // type into its inferred public API. The synthetic objects the REPL wraps each
+  // input in are not an API, so the warning is just noise there.
+  @Test def noFlexibleTypeWarningForReplWrapper: Unit = initially:
+    run("""val version = System.getProperty("java.version")""")
+    val output = storedOutput()
+    assertFalse(output, output.contains("flexible type"))
+}


### PR DESCRIPTION
The compiler warns when a class member's inferred result type leaks a flexible type: a library should specify the types of its public API explicitly. The REPL wraps every input in a synthetic object, which triggers the warning. Suppress the warning for the REPL's synthetic object.


## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Human encountered the warning running the existing test suite with explicit nulls, and came up with the fix.
LLM created a minimized test.
Human reviewed the test.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated test