### PR TITLE
Fix Javadoc anchors built from flexible types

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/JavadocAnchorCreator.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/JavadocAnchorCreator.scala
@@ -28,6 +28,7 @@ object JavadocAnchorCreator:
   private def transformType(using Quotes)(tpe: reflect.TypeRepr): String =
     import reflect.*
     tpe.simplified match
+      case FlexibleType(tpe) => transformType(tpe)
       case AppliedType(tpe, typeList) if tpe.classSymbol.fold(false)(_ == defn.ArrayClass) => transformType(typeList.head) + ":A"
       case AppliedType(tpe, typeList) if tpe.classSymbol.fold(false)(_ == defn.RepeatedParamClass) => transformType(typeList.head) + "..."
       case AppliedType(tpe, typeList) => transformPrimitiveType(tpe)

--- a/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
@@ -22,6 +22,21 @@ class JavadocExternalLocationProviderIntegrationTest extends ExternalLocationPro
   )
 )
 
+class JavadocExplicitNullsExternalLocationProviderIntegrationTest extends ExternalLocationProviderIntegrationTest(
+  "externalJavadoc",
+  List(".*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/"),
+  List(
+    "https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#forEach-java.util.function.Consumer-",
+    "https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#subList-int-int-",
+    "https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#printf-java.lang.String-java.lang.Object...-",
+    "https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#write-byte:A-int-int-"
+  )
+):
+  override protected def compilerContext =
+    val ctx = testContext
+    ctx.setSetting(ctx.settings.YexplicitNulls, true)
+    ctx
+
 class JavadocStaticFieldExternalLocationProviderReproTest extends ExternalLocationProviderIntegrationTest(
   "externalJavadoc",
   List(".*java.*::javadoc::https://docs.oracle.com/en/java/javase/17/docs/api/java.base/"),

--- a/scaladoc/test/dotty/tools/scaladoc/ScaladocTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ScaladocTest.scala
@@ -7,8 +7,11 @@ import java.io.File
 
 abstract class ScaladocTest(val name: String):
 
+  /** The compiler context the Scaladoc run uses; override to set compiler settings. */
+  protected def compilerContext: CompilerContext = testContext
+
   def afterRendering(op: DocContext ?=> Unit) =
-    val ctx = Scaladoc.run(args)(using testContext)
+    val ctx = Scaladoc.run(args)(using compilerContext)
     op(using ctx)
 
   def moduleDocContext = testDocContext(tastyFiles(name))


### PR DESCRIPTION
Add a missing pattern match case for `FlexibleType` to `JavadocAnchorCreator.transformType`. Without it, the anchor comes out wrong:

    #printf-(java.lang.String)?-(_*)?-       instead of  #printf-java.lang.String-java.lang.Object...-
    #write-(scala.Array[scala.Byte])?-       instead of  #write-byte:A-int-int-

The flexible type also hides the `AppliedType` underneath, so the array and repeated-parameter cases stop matching.

The test needs Scaladoc itself to run with `-Yexplicit-nulls`, since the parameter types come from the Java symbol as resolved in Scaladoc's compiler context. This requires a new overridable method added to `ScaladocTest` to adjust the compiler context.

A possible alternative to this testing infrastructure change would be to not test the fix in this case.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Human encountered the bug running existing tests under explicit nulls, and came up with the fix.
LLM came up with the testing infrastructure change and the minimized test.
Human reviewed the testing changes.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated test