### PR TITLE
Reject @throws on non-methods and constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1725,6 +1725,8 @@ trait Checking {
         if (!sym.owner.is(Module) || !sym.owner.isStatic)
           report.error(em"$sym cannot be a main method since it cannot be accessed statically", pos)
       }
+      else if (annotCls == defn.ThrowsAnnot && !sym.is(Method) && !sym.isConstructor)
+        report.error(em"`@throws` only allowed for methods and constructors", pos)
       // TODO: Add more checks here
     }
 

--- a/tests/neg/throws-annot.scala
+++ b/tests/neg/throws-annot.scala
@@ -1,0 +1,14 @@
+import java.io.IOException
+
+@throws(classOf[IOException]) // error
+class C
+
+object O:
+  @throws(classOf[IOException]) // error
+  val x: Int = 0
+
+class D:
+  @throws(classOf[IOException]) // error
+  type T = String
+
+  def foo(@throws(classOf[IOException]) x: Int): Unit = () // error

--- a/tests/run/throws-annot.check
+++ b/tests/run/throws-annot.check
@@ -8,6 +8,8 @@ readMixed2 throws: class java.lang.NullPointerException, class java.io.IOExcepti
 readMixed2 annotations: interface java.lang.Deprecated
 readNoEx throws: 
 readNoEx annotations: interface java.lang.Deprecated
+ThrowsCtor throws: class java.io.IOException
+ThrowsCtor annotations:
 Testing mirror class
 read throws: class java.io.IOException
 read annotations: 

--- a/tests/run/throws-annot.scala
+++ b/tests/run/throws-annot.scala
@@ -28,6 +28,19 @@ object TestThrows {
     def readNoEx(): Int
   }
 
+  class ThrowsCtor @throws(classOf[IOException]) () {
+    def value: Int = 0
+  }
+
+  def checkConstructor(cls: Class[_]): Unit = {
+    val name = cls.getSimpleName
+    val ctor = cls.getConstructor()
+    println(name + " throws: " + ctor.getExceptionTypes.mkString("", ", ", ""))
+    val annots = ctor.getDeclaredAnnotations.map(_.annotationType)
+    val annotStr = annots.mkString("", ", ", "")
+    println(name + " annotations:" + (if annotStr.isEmpty then "" else " " + annotStr))
+  }
+
   def checkMethod(cls: Class[_], name: String): Unit = {
     val method = cls.getMethod(name)
     println(name + " throws: " + method.getExceptionTypes.mkString("", ", ", ""))
@@ -68,18 +81,10 @@ object TL {
   def readNoEx(): Int = 0
 }
 
-// @throws on class/object/field must be ignored/compiler shouldn't crash.
-@throws(classOf[IOException])
-class ThrowsOnClass
-
-@throws(classOf[IOException])
-object ThrowsOnObject:
-  @throws(classOf[IOException])
-  val field: Int = 0
-
 object Test {
   def main(args: Array[String]): Unit = {
     TestThrows.run(classOf[TestThrows.Foo])
+    TestThrows.checkConstructor(classOf[TestThrows.ThrowsCtor])
     println("Testing mirror class")
     TestThrows.run(Class.forName("TL"))
   }


### PR DESCRIPTION
part of https://github.com/scala/scala3/issues/26804
fixes #11634

Currently, Scala 3 accepts `@throws` annotations on any places. However `@throws` is effective only on methods/constructors, and otherwise it's ignored.

Scala 2 already  rejects `@throws` on non-methods/constructors:
```scala
import java.io.IOException
@throws(classOf[IOException])
class C
// error: @throws only allowed for methods and constructors
```

Scala 2: https://github.com/scala/scala/pull/9465

---

While some other annotations also lacks applicability check, let's track/fix in another issue/PR.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
