### PR TITLE
fix(compiler): add reproducer for value-class boxing crash #27066

### DIFF
--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -17,6 +17,13 @@ class ScalaJSCompilationTests {
   import ScalaJSCompilationTests.{*, given}
   import CompilationTest.aggregateTests
 
+  @Test def posScalaJS: Unit = {
+    implicit val testGroup: TestGroup = TestGroup("posScalaJS")
+    aggregateTests(
+      compileFilesInDir("tests/pos-scalajs", scalaJSOptions),
+    ).checkCompile()
+  }
+
   // Negative tests ------------------------------------------------------------
 
   @Test def negScalaJS: Unit = {

--- a/tests/pos-scalajs/i27066.scala
+++ b/tests/pos-scalajs/i27066.scala
@@ -1,0 +1,15 @@
+import scala.scalajs.js
+
+object Test {
+  def box(ops: js.UndefOrOps[String]): Any = ops
+
+  def check(receiver: Any, result: Boolean): Boolean = result
+
+  def test(value: js.UndefOr[String]): Boolean = {
+    val ops = js.|.undefOr2ops(value)
+    check(ops, ops.nonEmpty)
+  }
+
+  val defined: Boolean = test("x")
+  val undefined: Boolean = test(js.undefined)
+}


### PR DESCRIPTION
Related to #27066.

Adds a minimal Scala.js reproducer for the value-class boxing crash, without depending on ScalaTest or macros.

This is a repro-only PR. The test currently fails.

## Have you relied on LLM-based tools in this contribution?

Yes. GPT 6 Astra assisted with investigating and minimizing the reproducer.

## How was the solution tested?

This PR does not contain a solution; it contributes a reproducer, following the approach in #26756.
