### PR TITLE
Type Fix in StreamExtensions

### DIFF
--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -554,7 +554,7 @@ object StreamExtensions {
     }
 
     implicit val jIntegerAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Integer, IntAccumulator] = intAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Integer, IntAccumulator]]
-    implicit val jLongAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Long, IntAccumulator] = longAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Long, IntAccumulator]]
-    implicit val jDoubleAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Double, IntAccumulator] = doubleAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Double, IntAccumulator]]
+    implicit val jLongAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Long, LongAccumulator] = longAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Long, LongAccumulator]]
+    implicit val jDoubleAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Double, DoubleAccumulator] = doubleAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Double, DoubleAccumulator]]
   }
 }

--- a/tests/run/stream-boxed-accumulator-info.scala
+++ b/tests/run/stream-boxed-accumulator-info.scala
@@ -1,0 +1,23 @@
+import java.{lang => jl}
+import java.{util => ju}
+
+import scala.collection.convert.StreamExtensions.*
+import scala.jdk.StreamConverters.*
+import scala.jdk.{Accumulator, DoubleAccumulator, IntAccumulator, LongAccumulator}
+
+object Test extends App:
+  def assertCompanion[A, C](expected: AnyRef | Null)(info: AccumulatorFactoryInfo[A, C]): Unit =
+    assert(info.companion == expected, s"expected companion $expected, got ${info.companion}")
+
+  assertCompanion[Int, IntAccumulator](IntAccumulator)(implicitly[AccumulatorFactoryInfo[Int, IntAccumulator]])
+  assertCompanion[Long, LongAccumulator](LongAccumulator)(implicitly[AccumulatorFactoryInfo[Long, LongAccumulator]])
+  assertCompanion[Double, DoubleAccumulator](DoubleAccumulator)(implicitly[AccumulatorFactoryInfo[Double, DoubleAccumulator]])
+  assertCompanion[jl.Integer, IntAccumulator](IntAccumulator)(implicitly[AccumulatorFactoryInfo[jl.Integer, IntAccumulator]])
+  assertCompanion[jl.Long, LongAccumulator](LongAccumulator)(implicitly[AccumulatorFactoryInfo[jl.Long, LongAccumulator]])
+  assertCompanion[jl.Double, DoubleAccumulator](DoubleAccumulator)(implicitly[AccumulatorFactoryInfo[jl.Double, DoubleAccumulator]])
+
+  val longs: LongAccumulator = ju.stream.Stream.of(jl.Long.valueOf(1L), jl.Long.valueOf(2L), jl.Long.valueOf(3L)).toScala(Accumulator)
+  assert(longs.sum == 6L, s"boxed Long stream sum was ${longs.sum}")
+
+  val doubles: DoubleAccumulator = ju.stream.Stream.of(jl.Double.valueOf(1.5), jl.Double.valueOf(2.5)).toScala(Accumulator)
+  assert(doubles.sum == 4.0, s"boxed Double stream sum was ${doubles.sum}")


### PR DESCRIPTION
Fixed incorrect type for implicit val jLongAccumulatorFactoryInfo and jDoubleAccumulatorFactoryInfo in StreamExtensions.scala.
